### PR TITLE
Fix check_components_identifiers function

### DIFF
--- a/ntia_conformance_checker/cli_tools/check_anything.py
+++ b/ntia_conformance_checker/cli_tools/check_anything.py
@@ -62,7 +62,7 @@ def check_components_suppliers(doc, messages):
 
 def check_components_identifiers(doc, messages):
     for package in doc.packages:
-        if has_supplier(package) == False:
+        if has_identifier(package) == False:
             messages.append(str(package.name) + " has no identifier.")
 
 def has_supplier(package):


### PR DESCRIPTION
Fixes #3 

This function was using the wrong business logic, relying on the has_supplier function rather than the has_identifier function. This commit fixes that.

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>