### PR TITLE
Improve error message when file not found

### DIFF
--- a/ntia_conformance_checker/cli_tools/check_anything.py
+++ b/ntia_conformance_checker/cli_tools/check_anything.py
@@ -1,18 +1,38 @@
+import os
+
 from spdx.parsers.loggers import ErrorMessages
 import asyncio
 import spdx.creationinfo
 from spdx.parsers import parse_anything
 
 def check_minimum_elements(file, messages=None):
+    """Assess if a SPDX document contains minumum elements.
+
+    The function gathers all the individual minimum elements checks.
+
+    Args:
+        file (str) - full filepath
+        messages (list) - set of messages related to minumum elements check
+
+    Returns:
+        messages (list) - set of messages related to minumum elements check
+    """
     if isinstance(messages, list):
         raise TypeError("messages should be None or an instance of ErrorMessages")
     if messages is None:
         messages = ErrorMessages()
+
+    # check if file even exists
+    if not os.path.exists(file):
+        messages.append(f"Filename {file} not found.")
+        return messages
+
     try:
         doc, error = parse_anything.parse_file(file)
     except:
         messages.append("Document cannot be parsed.")
         return messages
+
     messages.push_context(doc.name)
     if error:
         messages.append("Errors while parsing: True")


### PR DESCRIPTION
Fixes #7 

The current logic could confuse a user who enters a filepath to a file that does not exist. The current logic states, including when the file does not exist, that the document can't be parsed. This could imply to the user that they typed the filename correctly and the file does exist. The new logic alerts a user to the fact that the file does not exist.

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>