### PR TITLE
Add machine readable output

### DIFF
--- a/ntia_conformance_checker/cli_tools/checker.py
+++ b/ntia_conformance_checker/cli_tools/checker.py
@@ -19,7 +19,7 @@ from output import structure_messages
 )
 @click.option(
     "--output_path",
-    help="Filepath for output of JSON.",
+    help="Filepath for optionally storing output.",
 )
 def main(file, output, output_path):
     """
@@ -29,12 +29,15 @@ def main(file, output, output_path):
     For help: run `python3 checker.py --help`
     """
     if output == "print":
-        print(check_minimum_elements(file).messages)
+        result_list = check_minimum_elements(file).messages
+        if output_path:
+            with open(output_path, "w", encoding="utf-8") as outfile:
+                json.dump(result_list, outfile)
+        else:
+            print(result_list)
     if output == "json":
         msgs = check_minimum_elements(file).messages
         result_dict = structure_messages(file, msgs)
-        # only export JSON results to a file if output_path
-        # is provided
         if output_path:
             with open(output_path, "w", encoding="utf-8") as outfile:
                 json.dump(result_dict, outfile)

--- a/ntia_conformance_checker/cli_tools/checker.py
+++ b/ntia_conformance_checker/cli_tools/checker.py
@@ -33,12 +33,13 @@ def main(file, output, output_path):
     if output == "json":
         msgs = check_minimum_elements(file).messages
         result_dict = structure_messages(file, msgs)
-        print(json.dumps(result_dict, indent=2))
         # only export JSON results to a file if output_path
         # is provided
         if output_path:
             with open(output_path, "w", encoding="utf-8") as outfile:
                 json.dump(result_dict, outfile)
+        else:
+            print(json.dumps(result_dict, indent=2))
 
 
 if __name__ == "__main__":

--- a/ntia_conformance_checker/cli_tools/checker.py
+++ b/ntia_conformance_checker/cli_tools/checker.py
@@ -2,22 +2,43 @@
 
 # pylint: disable=import-error
 
+import json
+
 import click
 from check_anything import check_minimum_elements
+from output import structure_messages
 
 
-@click.command()
+@click.command(context_settings={"show_default": True})
 @click.option("--file", prompt="File name", help="The file to be parsed")
-def main(file):
+@click.option(
+    "--output",
+    default="print",
+    type=click.Choice(["print", "json"]),
+    help="Output format",
+)
+@click.option(
+    "--output_path",
+    help="Filepath for output of JSON.",
+)
+def main(file, output, output_path):
     """
     COMMAND-LINE TOOL that checks for NTIA's minimum elements within a
     file of RDF, XML, JSON, YAML or XML format.
 
-    To use : run `python3 checker.py` using terminal or run
-    `python3 checker.py --file <file name>`
-
+    For help: run `python3 checker.py --help`
     """
-    print(check_minimum_elements(file).messages)
+    if output == "print":
+        print(check_minimum_elements(file).messages)
+    if output == "json":
+        msgs = check_minimum_elements(file).messages
+        result_dict = structure_messages(file, msgs)
+        print(json.dumps(result_dict, indent=2))
+        # only export JSON results to a file if output_path
+        # is provided
+        if output_path:
+            with open(output_path, "w", encoding="utf-8") as outfile:
+                json.dump(result_dict, outfile)
 
 
 if __name__ == "__main__":

--- a/ntia_conformance_checker/cli_tools/output.py
+++ b/ntia_conformance_checker/cli_tools/output.py
@@ -1,6 +1,6 @@
 """Parse and format message output."""
 
-from spdx.parsers import parse_anything # pylint: disable=import-error
+from spdx.parsers import parse_anything  # pylint: disable=import-error
 
 
 def structure_messages(file, messages):

--- a/ntia_conformance_checker/cli_tools/output.py
+++ b/ntia_conformance_checker/cli_tools/output.py
@@ -1,6 +1,6 @@
 """Parse and format message output."""
 
-from spdx.parsers import parse_anything
+from spdx.parsers import parse_anything # pylint: disable=import-error
 
 
 def structure_messages(file, messages):

--- a/ntia_conformance_checker/cli_tools/output.py
+++ b/ntia_conformance_checker/cli_tools/output.py
@@ -1,0 +1,109 @@
+"""Parse and format message output."""
+
+from spdx.parsers import parse_anything
+
+
+def structure_messages(file, messages):
+    """Parse messages into well-structured dict.
+
+    Args:
+        file (str) - full filepath
+        messages (list) - set of messages related to minumum elements check
+
+    Returns:
+        result (dict) - structured data on minimum elements conformance
+    """
+
+    # instantiate dict and fields that have > 1 level
+    result = {}
+    result["componentVersions"] = {}
+    result["componentIdentifiers"] = {}
+    result["componentSuppliers"] = {}
+    result["componentNames"] = {}
+
+    result["authorNameProvided"] = is_document_level_element_present(
+        messages, "Document has no author."
+    )
+    result["timestampProvided"] = is_document_level_element_present(
+        messages, "Document has no timestamp."
+    )
+    result["dependencyRelationshipsProvided"] = is_document_level_element_present(
+        messages, "Document has no dependency relationships."
+    )
+
+    field_match_pairs = [
+        ("componentVersions", "has no version"),
+        ("componentIdentifiers", "has no identifier"),
+        ("componentSuppliers", "has no supplier"),
+    ]
+    for field, match in field_match_pairs:
+        result[field][
+            "nonconformantComponents"
+        ] = find_nonconformant_component_level_elements(messages, match)
+        result[field]["allProvided"] = not result[field]["nonconformantComponents"]
+
+    result["componentNames"]["numNonconformantComponents"] = len(
+        find_nonconformant_component_level_elements(messages, "has no version")
+    )
+    result["componentNames"]["allProvided"] = not result["componentNames"][
+        "numNonconformantComponents"
+    ]
+
+    result["isNtiaConformant"] = all(
+        [
+            result["authorNameProvided"],
+            result["timestampProvided"],
+            result["dependencyRelationshipsProvided"],
+            result["componentVersions"]["allProvided"],
+            result["componentIdentifiers"]["allProvided"],
+            result["componentSuppliers"]["allProvided"],
+            result["componentNames"]["allProvided"],
+        ]
+    )
+
+    doc, _ = parse_anything.parse_file(file)
+    result["sbomName"] = doc.name
+
+    return result
+
+
+def is_document_level_element_present(messages, match):
+    """Check for a particular document-level minimum element.
+
+    Checks for existence of an error message (match) and, if error
+    exists, then reports that that document-level element is not
+    present. A document-level minimum element is one where the
+    property is associated with the whole SBOM document, such as
+    whether there is an author name or timestamp provided.
+
+    Args:
+        messages (list) - set of messages related to minumum elements check
+        match (str) - matching string for a particular minimum element
+
+    Returns:
+        bool (True if present, false otherwise)
+    """
+    return not any(match in msg for msg in messages)
+
+
+def find_nonconformant_component_level_elements(messages, match):
+    """List components with nonconformant minimum elements.
+
+    Checks for existence of error messages (match) and, if error
+    exists, then collects a list of the names of all components.
+
+    Args:
+        messages (list) - set of messages related to minumum elements check
+        match (str) - matching string for a particular minimum element
+
+    Returns:
+        list - names of non-conformant elements
+    """
+    nonconformant_components = []
+    for msg in messages:
+        if match in msg:
+            # package-level messages all use the same construct:
+            # e.g. "pkgxyz has no identifier.", so grab the first word
+            pkg_name = msg.split(" ")[0]
+            nonconformant_components.append(pkg_name)
+    return nonconformant_components

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -8,6 +8,7 @@ import pytest
 from spdx.parsers import parse_anything
 
 import ntia_conformance_checker.cli_tools.check_anything as check_anything  # pylint: disable=consider-using-from-import
+import ntia_conformance_checker.cli_tools.output as output
 
 dirname = os.path.join(os.path.dirname(__file__), "data", "no_elements_missing")
 test_files = [os.path.join(dirname, fn) for fn in os.listdir(dirname)]
@@ -340,3 +341,50 @@ files = [os.path.join(dirname, fn) for fn in os.listdir(dirname)]
 def test_zephyrwest(test_file):
     if test_file not in file_dict:
         file_dict[test_file] = check_anything.check_minimum_elements(test_file).messages
+
+
+def test_is_document_level_element_present():
+    messages = ["Document has no author.", "Document has no timestamp."]
+    got = output.is_document_level_element_present(messages, "Document has no author.")
+    # because there is an error message that the "document has no author",
+    # then that SBOM minimum element is not present, so False
+    assert got == False
+
+
+def test_find_nonconformant_component_level_elements():
+    messages = [
+        "pkg1 has has no supplier.",
+        "Document has no author.",
+        "Document has no timestamp.",
+        "pkg2 has has no supplier.",
+    ]
+    got = output.find_nonconformant_component_level_elements(
+        messages, "has no supplier."
+    )
+    assert got == ["pkg1", "pkg2"]
+
+
+def test_structure_messages():
+    messages = [
+        "pkg1 has has no supplier.",
+        "Document has no author.",
+        "Document has no timestamp.",
+        "pkg2 has has no supplier.",
+    ]
+    dirname = os.path.join(os.path.dirname(__file__), "data", "other_tests")
+    file = os.path.join(dirname, "SPDXSBOMExample.spdx.yml")
+    got = output.structure_messages(file, messages)
+    assert got == {
+        "componentVersions": {"nonconformantComponents": [], "allProvided": True},
+        "componentIdentifiers": {"nonconformantComponents": [], "allProvided": True},
+        "componentSuppliers": {
+            "nonconformantComponents": ["pkg1", "pkg2"],
+            "allProvided": False,
+        },
+        "componentNames": {"numNonconformantComponents": 0, "allProvided": True},
+        "authorNameProvided": False,
+        "timestampProvided": False,
+        "dependencyRelationshipsProvided": True,
+        "isNtiaConformant": False,
+        "sbomName": "xyz-0.1.0",
+    }

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -371,7 +371,9 @@ def test_structure_messages():
         "Document has no timestamp.",
         "pkg2 has has no supplier.",
     ]
-    filepath = os.path.join(os.path.dirname(__file__), "data", "other_tests", "SPDXSBOMExample.spdx.yml")
+    filepath = os.path.join(
+        os.path.dirname(__file__), "data", "other_tests", "SPDXSBOMExample.spdx.yml"
+    )
     got = output.structure_messages(filepath, messages)
     assert got == {
         "componentVersions": {"nonconformantComponents": [], "allProvided": True},

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,6 +1,6 @@
 """Tests using pytest framework."""
 
-# pylint: disable=missing-function-docstring,import-error
+# pylint: disable=missing-function-docstring,import-error,consider-using-from-import
 
 import os
 
@@ -348,7 +348,7 @@ def test_is_document_level_element_present():
     got = output.is_document_level_element_present(messages, "Document has no author.")
     # because there is an error message that the "document has no author",
     # then that SBOM minimum element is not present, so False
-    assert got == False
+    assert got is False
 
 
 def test_find_nonconformant_component_level_elements():
@@ -371,9 +371,8 @@ def test_structure_messages():
         "Document has no timestamp.",
         "pkg2 has has no supplier.",
     ]
-    dirname = os.path.join(os.path.dirname(__file__), "data", "other_tests")
-    file = os.path.join(dirname, "SPDXSBOMExample.spdx.yml")
-    got = output.structure_messages(file, messages)
+    filepath = os.path.join(os.path.dirname(__file__), "data", "other_tests", "SPDXSBOMExample.spdx.yml")
+    got = output.structure_messages(filepath, messages)
     assert got == {
         "componentVersions": {"nonconformantComponents": [], "allProvided": True},
         "componentIdentifiers": {"nonconformantComponents": [], "allProvided": True},


### PR DESCRIPTION
Closes #10 

Example JSON output:

```json
{
  "componentVersions": {
    "nonconformantComponents": [],
    "allProvided": true
  },
  "componentIdentifiers": {
    "nonconformantComponents": [
      "xyz-0.1.0:",
      "xyz-0.1.0:",
      "xyz-0.1.0:"
    ],
    "allProvided": false
  },
  "componentSuppliers": {
    "nonconformantComponents": [
      "xyz-0.1.0:",
      "xyz-0.1.0:",
      "xyz-0.1.0:"
    ],
    "allProvided": false
  },
  "componentNames": {
    "numNonconformantComponents": 0,
    "allProvided": true
  },
  "authorNameProvided": true,
  "timestampProvided": false,
  "dependencyRelationshipsProvided": true,
  "isNtiaConformant": false,
  "sbomName": "xyz-0.1.0"
}
```

Feedback and suggestions welcome.

The `messages` data structure that is integral to this codebase meant that this PR introduces functions that parse through `messages`.

A superior approach perhaps, but one which would have required surgery to the codbase, would be to re-architect the whole codebase via a singleton, object-oriented approach in which data is stored in a class in an organized fashion. This would obviate the need for these "reconstruction" functions. But I think that was too much for this PR. I am glad to re-organize the codebase like I suggest in future PRs, making maintenance easier.