### PR TITLE
Add org as acceptable SBOM author

### DIFF
--- a/ntia_conformance_checker/cli_tools/check_anything.py
+++ b/ntia_conformance_checker/cli_tools/check_anything.py
@@ -108,7 +108,10 @@ def check_sbom_author(doc, messages):
         messages (list) - set of messages related to minumum elements check
     """
     for i, _ in enumerate(doc.creation_info.creators):
-        if isinstance(doc.creation_info.creators[i], spdx.creationinfo.Person):
+        if isinstance(
+            doc.creation_info.creators[i],
+            [spdx.creationinfo.Person, spdx.creationinfo.Organization],
+        ):
             return
     messages.append("Document has no author.")
 

--- a/ntia_conformance_checker/cli_tools/check_anything.py
+++ b/ntia_conformance_checker/cli_tools/check_anything.py
@@ -110,7 +110,7 @@ def check_sbom_author(doc, messages):
     for i, _ in enumerate(doc.creation_info.creators):
         if isinstance(
             doc.creation_info.creators[i],
-            [spdx.creationinfo.Person, spdx.creationinfo.Organization],
+            (spdx.creationinfo.Person, spdx.creationinfo.Organization),
         ):
             return
     messages.append("Document has no author.")


### PR DESCRIPTION
Closes #20
 
Add organization as an acceptable SBOM author. If this turns out to be wrong, we can always remove it.

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>