### PR TITLE
Add extra exception info when document can't parse

### DIFF
--- a/ntia_conformance_checker/cli_tools/check_anything.py
+++ b/ntia_conformance_checker/cli_tools/check_anything.py
@@ -33,8 +33,8 @@ def check_minimum_elements(file, messages=None):
 
     try:
         doc, error = parse_anything.parse_file(file)
-    except:  # pylint: disable=bare-except
-        messages.append("Document cannot be parsed.")
+    except Exception as e:  # pylint: disable=bare-except
+        messages.append(f"Document cannot be parsed: {e}")
         return messages
 
     messages.push_context(doc.name)

--- a/ntia_conformance_checker/cli_tools/check_anything.py
+++ b/ntia_conformance_checker/cli_tools/check_anything.py
@@ -33,8 +33,8 @@ def check_minimum_elements(file, messages=None):
 
     try:
         doc, error = parse_anything.parse_file(file)
-    except Exception as e:  # pylint: disable=bare-except
-        messages.append(f"Document cannot be parsed: {e}")
+    except Exception as parsing_error:  # pylint: disable=broad-except
+        messages.append(f"Document cannot be parsed: {parsing_error}")
         return messages
 
     messages.push_context(doc.name)


### PR DESCRIPTION
Add extra exception info when document can't parse.

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>