### PR TITLE
Make Organization a Valid SBOM Author Entity

### DIFF
--- a/ntia_conformance_checker/cli_tools/check_anything.py
+++ b/ntia_conformance_checker/cli_tools/check_anything.py
@@ -109,7 +109,10 @@ def check_sbom_author(doc, messages):
         messages (list) - set of messages related to minumum elements check
     """
     for i, _ in enumerate(doc.creation_info.creators):
-        if isinstance(doc.creation_info.creators[i], spdx.creationinfo.Person):
+        if isinstance(
+            doc.creation_info.creators[i],
+            (spdx.creationinfo.Person, spdx.creationinfo.Organization),
+        ):
             return messages
     return messages.append("Document has no author.")
 

--- a/tests/data/missing_author_name/SPDXRdfExample.rdf
+++ b/tests/data/missing_author_name/SPDXRdfExample.rdf
@@ -21,7 +21,6 @@
         <created>2010-02-03T00:00:00Z</created>
         <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
         <creator>Tool: SourceAuditor-V1.2</creator>
-        <creator>Organization: Source Auditor Inc.</creator>
       </CreationInfo>
     </creationInfo>
     <specVersion>SPDX-2.3</specVersion>

--- a/tests/data/missing_author_name/SPDXTagExample.tag
+++ b/tests/data/missing_author_name/SPDXTagExample.tag
@@ -6,7 +6,6 @@ DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0
 DocumentComment: <text>This is a sample spreadsheet</text>
 
 ## Creation Information
-Creator: Organization: Source Auditor Inc.
 Creator: Tool: SourceAuditor-V1.2
 Created: 2010-02-03T00:00:00Z
 CreatorComment: <text>This is an example of an SPDX spreadsheet format</text>


### PR DESCRIPTION
Fix #20 

From my reading of the NTIA minimum elements document, there is no language that organizations should not be a valid SBOM author entity. This PR therefore:

- Adds functionality that identifies an organization as a valid SBOM author
- Revises the test suite to make sure that all documents that are meant to lack a valid SBOM author lack both a person SBOM author and an organization SBOM author.