### PR TITLE
Add quiet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,12 @@ python3 main.py --file sbom.json
 To make the output machine-readable JSON, run:
 
 ```bash
-python3 main.py --output json
+python3 main.py --output json --file sbom.json
+```
+
+To optimize the output for a CI/CD pipeline and return 0 for
+conformant and 1 for non-conformant, run:
+
+```bash
+python3 main.py --output quiet --file sbom.json
 ```

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -47,11 +47,8 @@ def main(file, output, verbose, output_path):
         else:
             print(json.dumps(result_dict, indent=2))
     if output == "bool":
-        if sbom.check_ntia_minimum_elements_compliance():
-            # 0 indicates success
-            sys.exit(0)
-        else:
-            sys.exit(1)
+        # 0 indicates success
+        sys.exit(0 if sbom.check_ntia_minimum_elements_compliance() else -1)
 
 
 if __name__ == "__main__":

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -48,7 +48,7 @@ def main(file, output, verbose, output_path):
             print(json.dumps(result_dict, indent=2))
     if output == "bool":
         # 0 indicates success
-        sys.exit(0 if sbom.check_ntia_minimum_elements_compliance() else -1)
+        sys.exit(0 if sbom.check_ntia_minimum_elements_compliance() else 1)
 
 
 if __name__ == "__main__":

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -13,7 +13,7 @@ import sbom_checker
 @click.option(
     "--output",
     default="print",
-    type=click.Choice(["print", "json"]),
+    type=click.Choice(["print", "json", "bool"]),
     help="Output format",
 )
 @click.option(
@@ -45,6 +45,11 @@ def main(file, output, verbose, output_path):
                 json.dump(result_dict, outfile)
         else:
             print(json.dumps(result_dict, indent=2))
+    if output == "bool":
+        if sbom.check_ntia_minimum_elements_compliance():
+            print(0)
+        else:
+            print(-1)
 
 
 if __name__ == "__main__":

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -46,9 +46,8 @@ def main(file, output, verbose, output_path):
                 json.dump(result_dict, outfile)
         else:
             print(json.dumps(result_dict, indent=2))
-    if output == "bool":
-        # 0 indicates success
-        sys.exit(0 if sbom.check_ntia_minimum_elements_compliance() else 1)
+    # 0 indicates success
+    sys.exit(0 if sbom.check_ntia_minimum_elements_compliance() else 1)
 
 
 if __name__ == "__main__":

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=import-error
 import json
+import sys
 
 import click
 
@@ -13,7 +14,7 @@ import sbom_checker
 @click.option(
     "--output",
     default="print",
-    type=click.Choice(["print", "json", "bool"]),
+    type=click.Choice(["print", "json", "quiet"]),
     help="Output format",
 )
 @click.option(
@@ -47,9 +48,10 @@ def main(file, output, verbose, output_path):
             print(json.dumps(result_dict, indent=2))
     if output == "bool":
         if sbom.check_ntia_minimum_elements_compliance():
-            print(0)
+            # 0 indicates success
+            sys.exit(0)
         else:
-            print(-1)
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #57

Add an output option of `quiet` optimized for using this tool in CI. Return 0 if successful and 1 otherwise.

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>