### PR TITLE
Fix noassertion supplier cases and provide new test cases

### DIFF
--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -36,10 +36,9 @@ class SbomChecker:
         if not os.path.exists(self.file):
             logging.error("Filename %s not found.", self.file)
             sys.exit(1)
-        try:
-            doc, _ = parse_anything.parse_file(self.file)
-        except Exception as parsing_error:  # pylint: disable=broad-except
-            logging.error("Document cannot be parsed: %s", parsing_error)
+        doc, err = parse_anything.parse_file(self.file)
+        if err:
+            logging.error("Document cannot be parsed: %s", err)
 
         return doc
 
@@ -95,7 +94,7 @@ class SbomChecker:
         """Retrieve name of components without suppliers."""
         components_without_suppliers = []
         for package in self.doc.packages:
-            if package.supplier is None:
+            if package.supplier is None or package.supplier == "NOASSERTION":
                 components_without_suppliers.append(package.name)
         return components_without_suppliers
 

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -94,7 +94,7 @@ class SbomChecker:
         """Retrieve name of components without suppliers."""
         components_without_suppliers = []
         for package in self.doc.packages:
-            if package.supplier is None or package.supplier == "NOASSERTION":
+            if package.supplier is None or "NOASSERTION" in package.supplier.name:
                 components_without_suppliers.append(package.name)
         return components_without_suppliers
 

--- a/tests/data/missing_supplier_name/SPDXJsonExample.json
+++ b/tests/data/missing_supplier_name/SPDXJsonExample.json
@@ -136,7 +136,7 @@
       "filesAnalyzed" : false,
       "homepage" : "http://www.openjena.org/",
       "name" : "Jena",
-      "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+      "supplier" : "Person: Jane Doe",
       "versionInfo" : "3.12.0"
     }, {
       "SPDXID" : "SPDXRef-Saxon",
@@ -153,7 +153,7 @@
       "licenseConcluded" : "MPL-1.0",
       "licenseDeclared" : "MPL-1.0",
       "name" : "Saxon",
-      "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+      "supplier" : "Person: NOASSERTION",
       "packageFileName" : "saxonB-8.8.zip",
       "versionInfo" : "8.8"
     } ],

--- a/tests/data/missing_supplier_name/SPDXXmlExample.xml
+++ b/tests/data/missing_supplier_name/SPDXXmlExample.xml
@@ -273,7 +273,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
     </externalRefs>
     <filesAnalyzed>false</filesAnalyzed>
     <homepage>http://www.openjena.org/</homepage>
-	<supplier>Organization: idk</supplier>
+	<supplier>Organization: Apache (apache@hotmail.com)</supplier>
     <name>Jena</name>
     <versionInfo>3.12.0</versionInfo>
   </packages>
@@ -291,7 +291,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
     <licenseComments>Other versions available for a commercial license</licenseComments>
     <licenseConcluded>MPL-1.0</licenseConcluded>
     <licenseDeclared>MPL-1.0</licenseDeclared>
-	<supplier>Organization: idk</supplier>
+	  <supplier>Organization: test</supplier>
     <name>Saxon</name>
     <packageFileName>saxonB-8.8.zip</packageFileName>
     <versionInfo>8.8</versionInfo>

--- a/tests/data/missing_supplier_name/SPDXYamlExample.yaml
+++ b/tests/data/missing_supplier_name/SPDXYamlExample.yaml
@@ -226,7 +226,7 @@ packages:
   homepage: "http://commons.apache.org/proper/commons-lang/"
   licenseConcluded: "NOASSERTION"
   licenseDeclared: "NOASSERTION"
-  supplier: "Person: Jane Doe (jane.doe@example.com)"
+  supplier: "Person: NOASSERTION"
   versionInfo: "2.11.1"
   name: "Apache Commons Lang"
 - SPDXID: "SPDXRef-fromDoap-0"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -125,7 +125,15 @@ def test_sbomchecker_missing_supplier_name(test_file):
     assert sbom.dependency_relationships
     assert not sbom.components_without_names
     assert not sbom.components_without_versions
-    assert sbom.components_without_suppliers in [["glibc"], ["SPDX Translator"]]
+    # this list approach reflects that different formats
+    # (e.g. JSON, tag-value, etc) are not identical. this
+    # should probably be refactored in the future.
+    assert sbom.components_without_suppliers in [
+        ["glibc"],
+        ["SPDX Translator"],
+        ["glibc", "Apache Commons Lang"],
+        ["glibc", "Saxon"],
+    ]
     assert not sbom.components_without_identifiers
     assert not sbom.ntia_mininum_elements_compliant
 


### PR DESCRIPTION
Fix #65

Will open a separate issue to handle problem of test documents for same test case but different formats having different values. This is creating a future maintenance burden and source of confusion. But it's more important to fix this bug now.

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>