### PR TITLE
Update dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-spdx-tools = '>=0.7.0rc0'
+click =  '8.1.3'
+spdx-tools = '0.7.0'
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fe289aca4045e9119a31628daf90d0235184655bff4cf595eef251329b5271a6"
+            "sha256": "8a1e4c5fc301ed26a3ed7b1e5d35cc69f356045e6e556e0d18c02a84ad4c6eb4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,6 +21,7 @@
                 "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
                 "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
         },
@@ -102,11 +103,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
-                "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"
+                "sha256:16ccf598aab3b506593c17378473978908a2734d7336755a8769b480906bec1c",
+                "sha256:b440ee5f7e607bb8c9de15259dba2583dd41a38879a7abc1d43a71c59524da48"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.6.3"
+            "version": "==67.2.0"
         },
         "six": {
             "hashes": [
@@ -118,11 +119,11 @@
         },
         "spdx-tools": {
             "hashes": [
-                "sha256:650dd0786eb5012ec5fb267228f1cf226e9d53a31be59a4f2e2a840942c1402f",
-                "sha256:cf950dc92e916a0097f3cef3aaa6632462d2e0312561244a3f7640d018749a01"
+                "sha256:400080a00fb024327a05a3e637b83490764b82f0c6e22a2033267603b842b0ea",
+                "sha256:42a28c28179d58e1581756aff48810bb227a6f998d8613292195497440dc00af"
             ],
             "index": "pypi",
-            "version": "==0.7.0rc0"
+            "version": "==0.7.0"
         },
         "xmltodict": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 urls = {Homepage = "https://github.com/spdx/ntia-conformance-checker"}
 requires-python = ">=3.8"
 keywords = ["spdx", "sbom", "ntia"]
-dependencies = ["click", "spdx-tools>=0.7.0rc0"]
+dependencies = ["click", "spdx-tools>=0.7.0"]
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
Add `click`, which the CLI requires, and update the `spdx-tools` version in both the pipfile and pyproject.toml

(Dear internet: Does anyone know why the dependencies get listed twice, once in pyproject.toml and once in the pipfile? That's confusing to me.)

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>