### PR TITLE
Remove --pre flag from GitHub Action for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pipenv
-        pipenv install --pre
+        pipenv install
         pipenv install pytest coverage
     - name: Test with pytest
       env:


### PR DESCRIPTION
Fix #79 

This `--pre` is no longer needed.