### PR TITLE
Add PyPI Version Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://github.com/spdx/ntia-conformance-checker/workflows/build/badge.svg)](https://github.com/spdx/ntia-conformance-checker/actions)
+[![PyPI version](https://badge.fury.io/py/ntia-conformance-checker.svg)](https://badge.fury.io/py/ntia-conformance-checker)
 
 # NTIA Conformance Checker
 


### PR DESCRIPTION
Fix #97

Help users know that there is a PyPI package associated with the repo and to know the version of the latest package.