### PR TITLE
Implement trusted publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,10 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+       # 'id-token: write' is mandatory for trusted publishing
+       # see: https://docs.pypi.org/trusted-publishers/
+       id-token: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -24,6 +28,3 @@ jobs:
       run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
See: https://docs.pypi.org/trusted-publishers/

For a summary of benefits, the link above mentions:

This confers significant usability and security advantages when compared to PyPI's traditional authentication methods:

>Usability: with trusted publishing, users no longer need to manually create API tokens on PyPI and copy-paste them into their CI provider. The only manual step is configuring the publisher on PyPI.

>Security: PyPI's normal API tokens are long-lived, meaning that an attacker who compromises a package's release can use it until its legitimate user notices and manually revokes it. Similarly, uploading with a password means that an attacker can upload to any project associated with the account. Trusted publishing avoids both of these problems: the tokens minted expire automatically, and are scoped down to only the packages that they're authorized to upload to.