### PR TITLE
Set allow prereleases to false

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ spdx-tools = '0.7.1'
 python_version = "3.8"
 
 [pipenv]
-allow_prereleases = true
+allow_prereleases = false


### PR DESCRIPTION
Fix #120 

The spdx-tools pre-releases was being used in the build. This explains the breakage. Oops. This fix changes the pipenv default behavior to NOT allow pre-releases.