### PR TITLE
implement --skip-validation flag

### DIFF
--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -35,6 +35,13 @@ def get_parsed_args():
         action="store_true",
         help="Display version of ntia-conformance-checker",
     )
+    parser.add_argument(
+        "--skip-validation",
+        action="store_true",
+        default=False,
+        help="Display version of ntia-conformance-checker",
+    )
+
     args = parser.parse_args()
     return args
 
@@ -48,7 +55,7 @@ def main():
         print(version("ntia-conformance-checker"))
         sys.exit(0)
 
-    sbom = SbomChecker(args.file)
+    sbom = SbomChecker(args.file, validate=not args.skip_validation)
     if args.output == "print":
         sbom.print_table_output()
         if args.verbose:

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -16,14 +16,16 @@ from spdx_tools.spdx.validation.document_validator import validate_full_spdx_doc
 class SbomChecker:
     """SBOM minimum elements check."""
 
-    def __init__(self, file):
+    def __init__(self, file, validate=True):
         self.file = file
         self.parsing_error = []
         self.doc = self.parse_file()
         if not self.doc:
             self.ntia_mininum_elements_compliant = False
         else:
-            self.validation_messages = validate_full_spdx_document(self.doc)
+            self.validation_messages = None
+            if validate:
+                self.validation_messages = validate_full_spdx_document(self.doc)
             self.sbom_name = self.doc.creation_info.name
             self.doc_version = self.check_doc_version()
             self.doc_author = True


### PR DESCRIPTION
The SPDX validation takes a long time today (due to https://github.com/spdx/tools-python/issues/742). This results in really long runtimes for larger SBOMs, around > 3MB.

This PR suggests an addition to `--skip-validation` flag which will skip the validation step, which is not part of the NTIA conformance. 