### PR TITLE
Make --file argument optional

### DIFF
--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -15,7 +15,7 @@ def get_parsed_args():
         prog="ntia-checker",
         description="Check if SPDX SBOM complies with NTIA minimum elements",
     )
-    parser.add_argument("--file", required=True, help="Filepath for SPDX SBOM")
+    parser.add_argument("--file", help="Filepath for SPDX SBOM")
     parser.add_argument(
         "--output",
         choices=["print", "json", "html", "quiet"],


### PR DESCRIPTION
Fix #150
 
This allows an argument like `--version` to be used without using a dummy `--file` argument, like `--file foobar.txt`.