### PR TITLE
Fix file argument

### DIFF
--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -28,7 +28,7 @@ def get_parsed_args():
         help="Specify whether output should be verbose",
     )
     parser.add_argument(
-        "--output_path", help="Specify whether output should be verbose"
+        "--output_path", help="Filepath for optionally storing output"
     )
     parser.add_argument(
         "--version",
@@ -39,10 +39,15 @@ def get_parsed_args():
         "--skip-validation",
         action="store_true",
         default=False,
-        help="Display version of ntia-conformance-checker",
+        help="Specify whether to skip validation",
     )
 
     args = parser.parse_args()
+
+    if not args.file:
+        parser.print_help()
+        sys.exit(1)
+
     return args
 
 

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -27,9 +27,7 @@ def get_parsed_args():
         action="store_true",
         help="Specify whether output should be verbose",
     )
-    parser.add_argument(
-        "--output_path", help="Filepath for optionally storing output"
-    )
+    parser.add_argument("--output_path", help="Filepath for optionally storing output")
     parser.add_argument(
         "--version",
         action="store_true",

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -45,6 +45,9 @@ def get_parsed_args():
     args = parser.parse_args()
 
     if not args.file:
+        if args.version:
+            print(version("ntia-conformance-checker"))
+            sys.exit(0)
         parser.print_help()
         sys.exit(1)
 
@@ -55,10 +58,6 @@ def main():
     """Entrypoint for CLI application."""
 
     args = get_parsed_args()
-
-    if args.version:
-        print(version("ntia-conformance-checker"))
-        sys.exit(0)
 
     sbom = SbomChecker(args.file, validate=not args.skip_validation)
     if args.output == "print":

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -49,7 +49,7 @@ def get_parsed_args():
             print(version("ntia-conformance-checker"))
             sys.exit(0)
         parser.print_help()
-        sys.exit(1)
+        sys.exit(0)
 
     return args
 


### PR DESCRIPTION
This fix should allow omitting --file argument (prints the help message if so), while still allowing to pass arguments like --verbose or --version without crashing.