### PR TITLE
support for -v shorthand for --verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Options:
   --output [print|json]  Output format  [default: print]
   -v, --verbose          Use verbose printing
   --output_path TEXT     Filepath for optionally storing output.
-  --help                 Show this message and exit.
+  -h, --help             Show this message and exit.
 ```
 
 The user can then analyze a particular file:

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -23,7 +23,8 @@ def get_parsed_args():
         help="Specify type of output",
     )
     parser.add_argument(
-        "-v", "--verbose",
+        "-v",
+        "--verbose",
         action="store_true",
         help="Specify whether output should be verbose",
     )

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -23,7 +23,7 @@ def get_parsed_args():
         help="Specify type of output",
     )
     parser.add_argument(
-        "--verbose",
+        "-v", "--verbose",
         action="store_true",
         help="Specify whether output should be verbose",
     )


### PR DESCRIPTION
1. added shorthand (-v) for --verbose flag
2. added missing -h in documentation.