### PR TITLE
Fix logic error in get_components_without_suppliers

### DIFF
--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -89,16 +89,10 @@ class SbomChecker:
         """Retrieve name and/or SPDX ID of components without suppliers."""
         components_without_suppliers = []
         for package in self.doc.packages:
-            # both package supplier and package originator satisfy the "supplier"
-            # requirement
-            # https://spdx.github.io/spdx-spec/v2.3/package-information/#76-package-originator-field
-            no_package_supplier = package.supplier is None or isinstance(
+            no_supplier = package.supplier is None or isinstance(
                 package.supplier, SpdxNoAssertion
             )
-            no_package_originator = package.originator is None or isinstance(
-                package.originator, SpdxNoAssertion
-            )
-            if no_package_supplier and no_package_originator:
+            if no_supplier:
                 if return_tuples:
                     components_without_suppliers.append((package.name, package.spdx_id))
                 else:

--- a/tests/data/missing_component_version/SPDXJSONExample-v2.3.spdx.json
+++ b/tests/data/missing_component_version/SPDXJSONExample-v2.3.spdx.json
@@ -101,7 +101,7 @@
     "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
     "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
     "name" : "glibc",
-    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "originator" : "NOASSERTION",
     "packageFileName" : "glibc-2.11.1.tar.gz",
     "packageVerificationCode" : {
       "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
@@ -112,7 +112,7 @@
     "releaseDate" : "2012-01-29T18:30:22Z",
     "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
     "summary" : "GNU C library.",
-    "supplier" : "NOASSERTION",
+    "supplier" : "Organization: ExampleCodeInspect (contact@example.com)",
     "validUntilDate" : "2014-01-29T18:30:22Z"
   }],
   "files" : [ {

--- a/tests/data/missing_component_version/SPDXRdfExample-v2.3.spdx.rdf.xml
+++ b/tests/data/missing_component_version/SPDXRdfExample-v2.3.spdx.rdf.xml
@@ -290,9 +290,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</spdx:extractedText>
             <spdx:downloadLocation>http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz</spdx:downloadLocation>
             <spdx:name>glibc</spdx:name>
             <doap:homepage>http://ftp.gnu.org/gnu/glibc</doap:homepage>
-            <spdx:originator>Organization: ExampleCodeInspect (contact@example.com)</spdx:originator>
+            <spdx:originator>NOASSERTION</spdx:originator>
             <spdx:builtDate>2011-01-29T18:30:22Z</spdx:builtDate>
-            <spdx:supplier>NOASSERTION</spdx:supplier>
+            <spdx:supplier>Organization: ExampleCodeInspect (contact@example.com)</spdx:supplier>
             <spdx:licenseDeclared>
               <spdx:ConjunctiveLicenseSet rdf:nodeID="Nab63afe52f1e4b309875af1ea705781f">
                 <spdx:member rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-3"/>

--- a/tests/data/missing_component_version/SPDXTagExample-v2.3.spdx
+++ b/tests/data/missing_component_version/SPDXTagExample-v2.3.spdx
@@ -46,8 +46,8 @@ FileContributor: The Regents of the University of California
 PackageName: glibc
 SPDXID: SPDXRef-Package
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)

--- a/tests/data/missing_component_version/SPDXXMLExample-v2.3.spdx.xml
+++ b/tests/data/missing_component_version/SPDXXMLExample-v2.3.spdx.xml
@@ -220,7 +220,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 		<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
 		<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
 		<name>glibc</name>
-		<originator>Organization: ExampleCodeInspect (contact@example.com)</originator>
+		<originator>NOASSERTION</originator>
 		<packageFileName>glibc-2.11.1.tar.gz</packageFileName>
 		<packageVerificationCode>
 			<packageVerificationCodeExcludedFiles>./package.spdx</packageVerificationCodeExcludedFiles>
@@ -230,7 +230,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 		<releaseDate>2012-01-29T18:30:22Z</releaseDate>
 		<sourceInfo>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</sourceInfo>
 		<summary>GNU C library.</summary>
-		<supplier>NOASSERTION</supplier>
+		<supplier>Organization: ExampleCodeInspect (contact@example.com)</supplier>
 		<validUntilDate>2014-01-29T18:30:22Z</validUntilDate>
 	</packages>
 	<files>

--- a/tests/data/missing_component_version/SPDXYAMLExample-v2.3.spdx.yaml
+++ b/tests/data/missing_component_version/SPDXYAMLExample-v2.3.spdx.yaml
@@ -303,7 +303,7 @@ packages:
   - LicenseRef-2
   - LicenseRef-1
   name: glibc
-  originator: 'Organization: ExampleCodeInspect (contact@example.com)'
+  originator: NOASSERTION
   packageFileName: glibc-2.11.1.tar.gz
   packageVerificationCode:
     packageVerificationCodeExcludedFiles:
@@ -313,7 +313,7 @@ packages:
   releaseDate: '2012-01-29T18:30:22Z'
   sourceInfo: uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.
   summary: GNU C library.
-  supplier: NOASSERTION
+  supplier: 'Organization: ExampleCodeInspect (contact@example.com)'
   validUntilDate: '2014-01-29T18:30:22Z'
 relationships:
 - relatedSpdxElement: SPDXRef-Package

--- a/tests/data/missing_dependency_relationships/SPDXJSONExample-v2.3.spdx.json
+++ b/tests/data/missing_dependency_relationships/SPDXJSONExample-v2.3.spdx.json
@@ -100,7 +100,7 @@
     "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
     "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
     "name" : "glibc",
-    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "originator" : "NOASSERTION",
     "packageFileName" : "glibc-2.11.1.tar.gz",
     "packageVerificationCode" : {
       "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
@@ -110,7 +110,7 @@
     "releaseDate" : "2012-01-29T18:30:22Z",
     "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
     "summary" : "GNU C library.",
-    "supplier" : "NOASSERTION",
+    "supplier" : "Organization: ExampleCodeInspect (contact@example.com)",
     "validUntilDate" : "2014-01-29T18:30:22Z",
     "versionInfo" : "2.11.1"
   } ],

--- a/tests/data/missing_dependency_relationships/SPDXTagExample-v2.3.spdx
+++ b/tests/data/missing_dependency_relationships/SPDXTagExample-v2.3.spdx
@@ -112,8 +112,8 @@ PackageName: glibc
 SPDXID: SPDXRef-Package
 PackageVersion: 2.11.1
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)

--- a/tests/data/missing_dependency_relationships/SPDXXMLExample-v2.3.spdx.xml
+++ b/tests/data/missing_dependency_relationships/SPDXXMLExample-v2.3.spdx.xml
@@ -220,7 +220,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 		<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
 		<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
 		<name>glibc</name>
-		<originator>Organization: ExampleCodeInspect (contact@example.com)</originator>
+		<originator>NOASSERTION</originator>
 		<packageFileName>glibc-2.11.1.tar.gz</packageFileName>
 		<packageVerificationCode>
 			<packageVerificationCodeExcludedFiles>./package.spdx</packageVerificationCodeExcludedFiles>
@@ -230,7 +230,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 		<releaseDate>2012-01-29T18:30:22Z</releaseDate>
 		<sourceInfo>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</sourceInfo>
 		<summary>GNU C library.</summary>
-		<supplier>NOASSERTION</supplier>
+		<supplier>Organization: ExampleCodeInspect (contact@example.com)</supplier>
 		<validUntilDate>2014-01-29T18:30:22Z</validUntilDate>
 		<versionInfo>2.11.1</versionInfo>
 	</packages>

--- a/tests/data/missing_dependency_relationships/SPDXYAMLExample-v2.3.spdx.yaml
+++ b/tests/data/missing_dependency_relationships/SPDXYAMLExample-v2.3.spdx.yaml
@@ -303,7 +303,7 @@ packages:
   - LicenseRef-2
   - LicenseRef-1
   name: glibc
-  originator: 'Organization: ExampleCodeInspect (contact@example.com)'
+  originator: NOASSERTION
   packageFileName: glibc-2.11.1.tar.gz
   packageVerificationCode:
     packageVerificationCodeExcludedFiles:
@@ -313,7 +313,7 @@ packages:
   releaseDate: '2012-01-29T18:30:22Z'
   sourceInfo: uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.
   summary: GNU C library.
-  supplier: NOASSERTION
+  supplier: 'Organization: ExampleCodeInspect (contact@example.com)'
   validUntilDate: '2014-01-29T18:30:22Z'
   versionInfo: 2.11.1
 snippets:

--- a/tests/data/missing_supplier_name/SPDXJSONExample-v2.3.spdx.json
+++ b/tests/data/missing_supplier_name/SPDXJSONExample-v2.3.spdx.json
@@ -101,7 +101,7 @@
     "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
     "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
     "name" : "glibc",
-    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "originator" : "NOASSERTION",
     "packageFileName" : "glibc-2.11.1.tar.gz",
     "packageVerificationCode" : {
       "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],

--- a/tests/data/missing_supplier_name/SPDXRdfExample-v2.3.spdx.rdf.xml
+++ b/tests/data/missing_supplier_name/SPDXRdfExample-v2.3.spdx.rdf.xml
@@ -304,7 +304,7 @@ under the Apache License 2.0 (see: StringUtils.containsWhitespace())</spdx:notic
             </spdx:checksum>
             <spdx:attributionText>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</spdx:attributionText>
             <spdx:versionInfo>2.11.1</spdx:versionInfo>
-            <spdx:originator>Organization: ExampleCodeInspect (contact@example.com)</spdx:originator>
+            <spdx:originator>NOASSERTION</spdx:originator>
             <spdx:licenseComments>The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.</spdx:licenseComments>
             <spdx:validUntilDate>2014-01-29T18:30:22Z</spdx:validUntilDate>
             <spdx:packageFileName>glibc-2.11.1.tar.gz</spdx:packageFileName>

--- a/tests/data/missing_supplier_name/SPDXTagExample-v2.3.spdx
+++ b/tests/data/missing_supplier_name/SPDXTagExample-v2.3.spdx
@@ -48,7 +48,7 @@ SPDXID: SPDXRef-Package
 PackageVersion: 2.11.1
 PackageFileName: glibc-2.11.1.tar.gz
 PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)

--- a/tests/data/missing_supplier_name/SPDXXMLExample-v2.3.spdx.xml
+++ b/tests/data/missing_supplier_name/SPDXXMLExample-v2.3.spdx.xml
@@ -220,7 +220,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 		<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
 		<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
 		<name>glibc</name>
-		<originator>Organization: ExampleCodeInspect (contact@example.com)</originator>
+		<originator>NOASSERTION</originator>
 		<packageFileName>glibc-2.11.1.tar.gz</packageFileName>
 		<packageVerificationCode>
 			<packageVerificationCodeExcludedFiles>./package.spdx</packageVerificationCodeExcludedFiles>

--- a/tests/data/missing_supplier_name/SPDXYAMLExample-v2.3.spdx.yaml
+++ b/tests/data/missing_supplier_name/SPDXYAMLExample-v2.3.spdx.yaml
@@ -303,7 +303,7 @@ packages:
   - LicenseRef-2
   - LicenseRef-1
   name: glibc
-  originator: 'Organization: ExampleCodeInspect (contact@example.com)'
+  originator: 'NOASSERTION'
   packageFileName: glibc-2.11.1.tar.gz
   packageVerificationCode:
     packageVerificationCodeExcludedFiles:

--- a/tests/data/no_elements_missing/SPDXJSONExample-v2.3.spdx.json
+++ b/tests/data/no_elements_missing/SPDXJSONExample-v2.3.spdx.json
@@ -101,7 +101,7 @@
     "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
     "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
     "name" : "glibc",
-    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "originator" : "NOASSERTION",
     "packageFileName" : "glibc-2.11.1.tar.gz",
     "packageVerificationCode" : {
       "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
@@ -112,7 +112,7 @@
     "releaseDate" : "2012-01-29T18:30:22Z",
     "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
     "summary" : "GNU C library.",
-    "supplier" : "NOASSERTION",
+    "supplier" : "Organization: ExampleCodeInspect (contact@example.com)",
     "validUntilDate" : "2014-01-29T18:30:22Z",
     "versionInfo" : "2.11.1"
   } ],

--- a/tests/data/no_elements_missing/SPDXRdfExample-v2.3.spdx.rdf.xml
+++ b/tests/data/no_elements_missing/SPDXRdfExample-v2.3.spdx.rdf.xml
@@ -312,7 +312,7 @@ under the Apache License 2.0 (see: StringUtils.containsWhitespace())</spdx:notic
                 <spdx:referenceLocator>acmecorp/acmenator/4.1.3-alpha</spdx:referenceLocator>
               </spdx:ExternalRef>
             </spdx:externalRef>
-            <spdx:supplier>NOASSERTION</spdx:supplier>
+            <spdx:supplier>Organization: ExampleCodeInspect (contact@example.com)</spdx:supplier>
             <spdx:checksum>
               <spdx:Checksum rdf:nodeID="N98510266a7284a1686da4e459dd5e58b">
                 <spdx:checksumValue>aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706</spdx:checksumValue>
@@ -356,7 +356,7 @@ under the Apache License 2.0 (see: StringUtils.containsWhitespace())</spdx:notic
               </spdx:PackageVerificationCode>
             </spdx:packageVerificationCode>
             <spdx:summary>GNU C library.</spdx:summary>
-            <spdx:originator>Organization: ExampleCodeInspect (contact@example.com)</spdx:originator>
+            <spdx:originator>NOASSERTION</spdx:originator>
             <spdx:builtDate>2011-01-29T18:30:22Z</spdx:builtDate>
             <spdx:licenseDeclared>
               <spdx:ConjunctiveLicenseSet rdf:nodeID="N45c3c34ce93d4d769c3edee387495c95">

--- a/tests/data/no_elements_missing/SPDXTagExample-v2.3.spdx
+++ b/tests/data/no_elements_missing/SPDXTagExample-v2.3.spdx
@@ -47,8 +47,8 @@ PackageName: glibc
 SPDXID: SPDXRef-Package
 PackageVersion: 2.11.1
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)

--- a/tests/data/no_elements_missing/SPDXXMLExample-v2.3.spdx.xml
+++ b/tests/data/no_elements_missing/SPDXXMLExample-v2.3.spdx.xml
@@ -220,7 +220,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 		<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
 		<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
 		<name>glibc</name>
-		<originator>Organization: ExampleCodeInspect (contact@example.com)</originator>
+		<originator>NOASSERTION</originator>
 		<packageFileName>glibc-2.11.1.tar.gz</packageFileName>
 		<packageVerificationCode>
 			<packageVerificationCodeExcludedFiles>./package.spdx</packageVerificationCodeExcludedFiles>
@@ -230,7 +230,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 		<releaseDate>2012-01-29T18:30:22Z</releaseDate>
 		<sourceInfo>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</sourceInfo>
 		<summary>GNU C library.</summary>
-		<supplier>NOASSERTION</supplier>
+		<supplier>Organization: ExampleCodeInspect (contact@example.com)</supplier>
 		<validUntilDate>2014-01-29T18:30:22Z</validUntilDate>
 		<versionInfo>2.11.1</versionInfo>
 	</packages>

--- a/tests/data/no_elements_missing/SPDXYAMLExample-v2.3.spdx.yaml
+++ b/tests/data/no_elements_missing/SPDXYAMLExample-v2.3.spdx.yaml
@@ -303,7 +303,7 @@ packages:
   - LicenseRef-2
   - LicenseRef-1
   name: glibc
-  originator: 'Organization: ExampleCodeInspect (contact@example.com)'
+  originator: NOASSERTION
   packageFileName: glibc-2.11.1.tar.gz
   packageVerificationCode:
     packageVerificationCodeExcludedFiles:
@@ -313,7 +313,7 @@ packages:
   releaseDate: '2012-01-29T18:30:22Z'
   sourceInfo: uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.
   summary: GNU C library.
-  supplier: NOASSERTION
+  supplier: 'Organization: ExampleCodeInspect (contact@example.com)'
   validUntilDate: '2014-01-29T18:30:22Z'
   versionInfo: 2.11.1
 relationships:

--- a/tests/data/other_tests/test_components_without_functions.spdx
+++ b/tests/data/other_tests/test_components_without_functions.spdx
@@ -21,8 +21,8 @@ PackageName: glibc
 SPDXID: SPDXRef-Package
 PackageVersion: 2.4.57+dfsg-3+deb11u1
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)
@@ -56,8 +56,8 @@ PackageName:
 SPDXID: SPDXRef-Package1
 PackageVersion: 2.4.57+dfsg-3+deb11u1
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)
@@ -89,8 +89,8 @@ ValidUntilDate: 2014-01-29T18:30:22Z
 PackageName: glibc-no-version-1
 SPDXID: SPDXRef-Package2
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)
@@ -122,8 +122,8 @@ ValidUntilDate: 2014-01-29T18:30:22Z
 PackageName: glibc-no-version-2
 SPDXID: SPDXRef-Package3
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)
@@ -188,8 +188,8 @@ PackageName: glibc-no-identifier
 SPDXID: SPDXRef-Package5
 PackageVersion: 2.4.57+dfsg-3+deb11u1
 PackageFileName: glibc-2.11.1.tar.gz
-PackageSupplier: NOASSERTION
-PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageSupplier: Organization: ExampleCodeInspect (contact@example.com)
+PackageOriginator: NOASSERTION
 PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
 FilesAnalyzed: true
 PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758 (excludes: ./package.spdx)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -116,7 +116,9 @@ def test_sbomchecker_missing_supplier_name(test_file):
     assert sbom.dependency_relationships
     assert not sbom.components_without_names
     assert not sbom.components_without_versions
-    TestCase().assertCountEqual(sbom.components_without_suppliers, ["Jena", "Saxon"])
+    TestCase().assertCountEqual(
+        sbom.components_without_suppliers, ["glibc", "Jena", "Saxon"]
+    )
     assert not sbom.components_without_identifiers
     assert not sbom.ntia_minimum_elements_compliant
 


### PR DESCRIPTION
Fix #157

Only the supplier field should be checked to determine if the supplier field is missing a value. Previously the code checked both the supplier and the originator fields, on the mistaken assumption that either field counted as the package supplier. Oops.

THIS IS A BREAKING CHANGE.

I revised the test suite substantially since this was a logic error. Many test SBOM documents needed a minor tweak.