### PR TITLE
Make bandit Github Action read-only

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -7,6 +7,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   bandit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a first installment of making the GitHub Actions read-only, part of what the OpenSSF scorecard tool looks for. See issue #192. 