### PR TITLE
Pin dependencies

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read  # Grant read permission to repository contents
-  pages: write  # Grant write permission to GitHub Pages
+  contents: read   # Grant read permission to repository contents
+  pages: write     # Grant write permission to GitHub Pages
   id-token: write  # Required for deploying to GitHub Pages
 
 jobs:

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -11,7 +11,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read  # Grant read permission to repository contents
+  pages: write  # Grant write permission to GitHub Pages
+  id-token: write  # Required for deploying to GitHub Pages
 
 jobs:
   build-docs:

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install spdx-tools
-        pip install sphinx sphinx_rtd_theme
+        pip install pip==25.0
+        pip install spdx-tools==0.8.3 
+        pip install sphinx==8.1.3 sphinx-rtd-theme==3.0.2
 
     - name: Build documentation
       run: |

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -14,8 +14,9 @@ jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Run bandit
-        uses: tj-actions/bandit@0aed5b3da320e0f26781e5aecbbfc1d268ff07e2 # v5.5
+        uses: tj-actions/bandit@0aed5b3da320e0f26781e5aecbbfc1d268ff07e2  # v5.5
         with:
           options: "-c bandit.yml -r"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -15,5 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v2
-      - uses: psf/black@1b2427a2b785cc4aac97c19bb4b9a0de063f9547 # stable
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Black Python code formatter
+        uses: psf/black@1b2427a2b785cc4aac97c19bb4b9a0de063f9547  # v42.10.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,18 +11,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-    - name: Set up Python 3.9
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v4
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - name: Set up Python
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
       with:
         python-version: "3.9"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pipenv
+        pip install pip==25.0
+        pip install pipenv==2024.4.1
         # use --pre flag to enable use of prerelease package versions
         pipenv install
-        pipenv install pytest coverage
+        pipenv install pytest==8.3.4 coverage==7.6.10
     - name: Test with pytest
       env:
           # This token is provided by Actions,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,17 +22,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@094bbe8be86284d004fe1cd9dffcbea6fc3c6c2d # v2
+      uses: github/codeql-action/init@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a  # v2.20.3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@094bbe8be86284d004fe1cd9dffcbea6fc3c6c2d # v2
+      uses: github/codeql-action/autobuild@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a  # v2.20.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@094bbe8be86284d004fe1cd9dffcbea6fc3c6c2d # v2
+      uses: github/codeql-action/analyze@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a  # v2.20.3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,15 +18,16 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v3
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pylint
+        pip install pip==25.0
+        pip install pylint==3.3.3
         pip install spdx-tools==0.8.3
     - name: Analysing the code with pylint
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,19 +15,20 @@ jobs:
        # see: https://docs.pypi.org/trusted-publishers/
        id-token: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v3
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
       with:
         python-version: '3.9'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install build
+        pip install pip==25.0
+        pip install build==1.2.2.post1
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70
+      uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70  # v1.12.4
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46  # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -38,7 +38,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v3.pre.node20
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
         with:
           name: SARIF file
           path: results.sarif
@@ -47,6 +47,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
+        uses: github/codeql-action/upload-sarif@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a  # v2.20.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
To fix some OpenSSF code scanning warnings

- Pin Python dependencies
- Limit scope of permissions in apidoc workflow
- Upgrade actions/upload-artifact to v4 (v3 is deprecated on 30 Nov 2024)

See: https://github.com/spdx/ntia-conformance-checker/security/code-scanning