### PR TITLE
Set permissions: contents: read at workflow top level

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -10,6 +10,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -7,11 +7,12 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   bandit:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,11 +8,12 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,11 +8,12 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -11,7 +14,6 @@ jobs:
        # 'id-token: write' is mandatory for trusted publishing
        # see: https://docs.pypi.org/trusted-publishers/
        id-token: write
-       contents: read
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
PR #245 improves the OpenSSF Scorecard from 7.5 to 8.1 but we probably can do better in the Token-Permission category (currently got 7).

Apart from set the write permission at job level, we have to set the read permission at the top level as well, as suggested in Remediation section of the code scanning report.
