### PR TITLE
Ignore SBOM test data dirs when OSV scan

### DIFF
--- a/tests/data/osv-scanner.toml
+++ b/tests/data/osv-scanner.toml
@@ -1,0 +1,4 @@
+# ignore everything in the current directory
+[[PackageOverrides]]
+ignore = true
+reason = "This directory contains SBOM test files. A SBOM test file may contains data that represent vulnerabilities of a system, but that system is not this particular ntia-conformance-checker package."

--- a/tests/doc_fest/osv-scanner.toml
+++ b/tests/doc_fest/osv-scanner.toml
@@ -1,0 +1,4 @@
+# ignore everything in the current directory
+[[PackageOverrides]]
+ignore = true
+reason = "This directory contains SBOM test files. A SBOM test file may contains data that represent vulnerabilities of a system, but that system is not this particular ntia-conformance-checker package."


### PR DESCRIPTION
Add PackageOverrides to directories that contain SBOM test files to ignore false positive warnings.

See how to config at https://google.github.io/osv-scanner/configuration/

Will resolve #222
