### PR TITLE
Set IgnoredVulns in osv-scanner config

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,38 @@
+[[IgnoredVulns]]
+id = "CVE-2022-48174"
+reason = "Alpine/BusyBox-related, which is not used by this package. The matching vulnerability data may come from an SBOM test file in /tests directory."
+
+[[IgnoredVulns]]
+id = "CVE-2023-42363"
+reason = "Alpine/BusyBox-related, which is not used by this package. The matching vulnerability data may come from an SBOM test file in /tests directory."
+
+[[IgnoredVulns]]
+id = "CVE-2023-42364"
+reason = "Alpine/BusyBox-related, which is not used by this package. The matching vulnerability data may come from an SBOM test file in /tests directory."
+
+[[IgnoredVulns]]
+id = "CVE-2023-42365"
+reason = "Alpine/BusyBox-related, which is not used by this package. The matching vulnerability data may come from an SBOM test file in /tests directory."
+
+[[IgnoredVulns]]
+id = "CVE-2023-42366"
+reason = "Alpine/BusyBox-related, which is not used by this package. The matching vulnerability data may come from an SBOM test file in /tests directory."
+
+[[IgnoredVulns]]
+id = "GHSA-269g-pwp5-87pp"
+reason = "Maven/JUnit-related, which is not used by this package. The matching vulnerability data may come from an SBOM test file in /tests directory."
+
+# We can also ignore the entire category of vulnerabilities,
+# using PackageOverrides
+
+# # ignore packages named "busybox" in the Alpine ecosystem
+# [[PackageOverrides]]
+# name = "busybox"
+# ecosystem = "Alpine"
+# ignore = true
+
+# # ignore packages named "junit:junit" in the Maven ecosystem
+# [[PackageOverrides]]
+# name = "junit:junit"
+# ecosystem = "Maven"
+# ignore = true

--- a/tests/data/osv-scanner.toml
+++ b/tests/data/osv-scanner.toml
@@ -1,4 +1,0 @@
-# ignore everything in the current directory
-[[PackageOverrides]]
-ignore = true
-reason = "This directory contains SBOM test files. A SBOM test file may contains data that represent vulnerabilities of a system, but that system is not this particular ntia-conformance-checker package."

--- a/tests/doc_fest/osv-scanner.toml
+++ b/tests/doc_fest/osv-scanner.toml
@@ -1,4 +1,0 @@
-# ignore everything in the current directory
-[[PackageOverrides]]
-ignore = true
-reason = "This directory contains SBOM test files. A SBOM test file may contains data that represent vulnerabilities of a system, but that system is not this particular ntia-conformance-checker package."


### PR DESCRIPTION
The one osv-scanner.toml per directory approach does not work.
Looks like osv-scanner.toml has to be at the root directory only.

This PR put osv-scanner.toml to root dir and use specific `IgnoredVulns` for each vuln id.

An attempt to fix #222
