### PR TITLE
Add malware scanner to GitHub Actions

### DIFF
--- a/.github/workflows/malcontent.yaml
+++ b/.github/workflows/malcontent.yaml
@@ -9,10 +9,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@93bad3a2bbadfec044b6ec423d740686d8f00d50 # v0.3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       
-      - uses: chainguard-dev/malcontent-action...
+      - uses: chainguard-dev/malcontent-action@93bad3a2bbadfec044b6ec423d740686d8f00d50 # v0.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/malcontent.yaml
+++ b/.github/workflows/malcontent.yaml
@@ -1,0 +1,18 @@
+name: Malcontent Malware Analysis
+on:
+  pull_request:
+
+jobs:
+  malcontent:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93bad3a2bbadfec044b6ec423d740686d8f00d50 # v0.3
+        with:
+          fetch-depth: 0
+      
+      - uses: chainguard-dev/malcontent-action...
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I propose this as an experiment. I've been meaning to add a malware scanner to the GitHub Actions. I am not wedded to this one. A co-worker created this and he's smart. So I thought it was worth an experiment.