### PR TITLE
Add type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][keepachangelog]
+and this project adheres to [Semantic Versioning][semver].
+
+## [Unreleased]
+
+### Changed
+
+- Add type hints and make it stays compatible with Python 3.8 (#272).
+  - Note: The next major version may adopt
+    [PEP 585](https://www.python.org/dev/peps/pep-0585/) and
+    [PEP 604](https://www.python.org/dev/peps/pep-0604/)
+    which will require Python 3.9 and Python 3.10.
+- Print validation context along with validation message.
+
+### Fixed
+
+- Fix type cast to avoid lint errors.
+- Fix return type of `get_components_without_concluded_licenses`,
+  `get_components_without_copyright_texts`, `get_components_without_suppliers`,
+  and `get_components_without_versions`
+  to honour the `return_tuples` parameter.
+
+## [3.2.0] - 2025-03-12
+
+### Added
+
+- Add Sphinx documentation generation support (#237).
+
+## [3.1.0] - 2024-12-31
+
+### Added
+
+- Add FSCTv3 Common SBOM Baseline Attributes checker (#224, #226).
+
+## [0.1.0] - 2023-01-06
+
+First official release.
+
+Special shoutout:
+
+Credit to @linynjosh for bringing this project to life, implementing
+an excellent test suite and comprehensive functionality related to checking
+for minimum elements.
+Thanks to @goneall, @licquia, and @kestewart for mentoring @linynjosh.
+
+### Added
+
+- Initial commit from Google Summer of Code 2022 (#1).
+
+[keepachangelog]: https://keepachangelog.com/en/1.1.0/
+[semver]: https://semver.org/spec/v2.0.0.html
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v3.2.0
+[3.1.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v3.1.0
+[0.1.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning][semver].
 - Print validation context along with validation message (#274).
 - Add type hints and make it stays compatible with Python 3.8 (#272).
   - Note: The next major version may adopt
-    [PEP 585](https://www.python.org/dev/peps/pep-0585/) and
-    [PEP 604](https://www.python.org/dev/peps/pep-0604/)
+    [PEP 585](https://peps.python.org/pep-0585/) and
+    [PEP 604](https://peps.python.org/pep-0604/)
     which will require Python 3.9 and Python 3.10.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,20 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Print validation context along with validation message (#274).
 - Add type hints and make it stays compatible with Python 3.8 (#272).
   - Note: The next major version may adopt
     [PEP 585](https://www.python.org/dev/peps/pep-0585/) and
     [PEP 604](https://www.python.org/dev/peps/pep-0604/)
     which will require Python 3.9 and Python 3.10.
-- Print validation context along with validation message.
 
 ### Fixed
 
-- Fix `BaseChecker.validation_messages` type to `List[ValidationMessage]`.
+- Fix `BaseChecker.validation_messages` type to `List[ValidationMessage]` (#272).
 - Fix return type of `get_components_without_concluded_licenses`,
   `get_components_without_copyright_texts`, `get_components_without_suppliers`,
   and `get_components_without_versions`
-  to honour the `return_tuples` parameter.
+  to honour the `return_tuples` parameter (#272).
 
 ## [3.2.0] - 2025-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
-- Fix type cast to avoid lint errors.
+- Fix `BaseChecker.validation_messages` type to `List[ValidationMessage]`.
 - Fix return type of `get_components_without_concluded_licenses`,
   `get_components_without_copyright_texts`, `get_components_without_suppliers`,
   and `get_components_without_versions`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,14 +9,17 @@ For a full list of available options, see:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+from __future__ import annotations
+
 import os
 import sys
+from typing import List
 
 # Path setup
 sys.path.insert(0, os.path.abspath(".."))
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path: list[str] = ["_templates"]
+templates_path: List[str] = ["_templates"]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -43,4 +46,4 @@ extensions = [
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: list[str] = []
+exclude_patterns: List[str] = []

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -7,9 +7,9 @@ import logging
 import os
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, cast
 
-from spdx_tools.spdx.model import Document
+from spdx_tools.spdx.model.document import Document
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 from spdx_tools.spdx.parser import parse_anything
 from spdx_tools.spdx.parser.error import SPDXParsingError
@@ -30,18 +30,18 @@ class BaseChecker(ABC):
     compliance_standard: str = ""
 
     file: str = ""
-    doc: Optional[Document] = None
+    doc: Document | None = None
 
-    parsing_error: List[str] = []
-    validation_messages: Optional[List[str]] = None
+    parsing_error: list[str] = []
+    validation_messages: list[str] | None = None
 
     sbom_name: str = ""
-    components_without_names: List[str] = []
-    components_without_versions: List[str] = []
-    components_without_suppliers: List[str] = []
-    components_without_identifiers: List[str] = []
-    components_without_concluded_licenses: List[str] = []
-    components_without_copyright_texts: List[str] = []
+    components_without_names: list[str] = []
+    components_without_versions: list[str] = []
+    components_without_suppliers: list[str] = []
+    components_without_identifiers: list[str] = []
+    components_without_concluded_licenses: list[str] = []
+    components_without_copyright_texts: list[str] = []
 
     doc_version: bool = False
     doc_author: bool = False
@@ -88,7 +88,7 @@ class BaseChecker(ABC):
         """
 
     @abstractmethod
-    def output_json(self) -> Dict[str, Any]:
+    def output_json(self) -> dict[str, Any]:
         """
         Abstract method to create a dict of results for outputting
         to JSON.
@@ -98,7 +98,7 @@ class BaseChecker(ABC):
     def output_html(self) -> str:
         """Abstract method to create a result in HTML format."""
 
-    def __init__(self, file, validate=True, compliance=""):
+    def __init__(self, file: str, validate: bool = True, compliance: str = ""):
         """
         Initialize the BaseChecker.
 
@@ -112,7 +112,6 @@ class BaseChecker(ABC):
         self.doc = self.parse_file()  # Document or None
 
         if self.doc:
-            self.doc = cast(Document, self.doc)
             if validate:
                 self.validation_messages = validate_full_spdx_document(self.doc)
             self.components_without_names = self.get_components_without_names()
@@ -129,8 +128,8 @@ class BaseChecker(ABC):
             )
 
     def get_components_without_concluded_licenses(
-        self, return_tuples=False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+        self, return_tuples: bool = False
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve names and/or SPDX IDs of components without concluded licenses.
 
@@ -148,7 +147,7 @@ class BaseChecker(ABC):
             return []
 
         if return_tuples:
-            components_name_id: List[Tuple[str, str]] = []
+            components_name_id: list[tuple[str, str]] = []
             for package in self.doc.packages:
                 no_license = (
                     package.license_concluded is None
@@ -162,7 +161,7 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
+        components_name: list[str] = []
         for package in self.doc.packages:
             no_license = (
                 package.license_concluded is None
@@ -177,8 +176,8 @@ class BaseChecker(ABC):
         return components_name
 
     def get_components_without_copyright_texts(
-        self, return_tuples=False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+        self, return_tuples: bool = False
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve names and/or SPDX IDs of components without copyright texts.
 
@@ -195,7 +194,7 @@ class BaseChecker(ABC):
             return []
 
         if return_tuples:
-            components_name_id: List[Tuple[str, str]] = []
+            components_name_id: list[tuple[str, str]] = []
             for package in self.doc.packages:
                 no_license = (
                     package.copyright_text is None
@@ -209,7 +208,7 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
+        components_name: list[str] = []
         for package in self.doc.packages:
             no_license = (
                 package.copyright_text is None
@@ -251,15 +250,15 @@ class BaseChecker(ABC):
         if not self.doc:
             return []
 
-        components_without_names = []
+        components_without_names: list[str] = []
         for package in self.doc.packages:
             if not package.name:
                 components_without_names.append(package.spdx_id)
         return components_without_names
 
     def get_components_without_suppliers(
-        self, return_tuples=False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+        self, return_tuples: bool = False
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve names and/or SPDX IDs of components without suppliers.
 
@@ -276,7 +275,7 @@ class BaseChecker(ABC):
             return []
 
         if return_tuples:
-            components_name_id: List[Tuple[str, str]] = []
+            components_name_id: list[tuple[str, str]] = []
             for package in self.doc.packages:
                 no_supplier = package.supplier is None or isinstance(
                     package.supplier, SpdxNoAssertion
@@ -285,7 +284,7 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
+        components_name: list[str] = []
         for package in self.doc.packages:
             no_supplier = package.supplier is None or isinstance(
                 package.supplier, SpdxNoAssertion
@@ -295,8 +294,8 @@ class BaseChecker(ABC):
         return components_name
 
     def get_components_without_versions(
-        self, return_tuples=False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+        self, return_tuples: bool = False
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve name and/or SPDX ID of components without versions.
 
@@ -313,13 +312,13 @@ class BaseChecker(ABC):
             return []
 
         if return_tuples:
-            components_name_id: List[Tuple[str, str]] = []
+            components_name_id: list[tuple[str, str]] = []
             for package in self.doc.packages:
                 if not package.version:
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
+        components_name: list[str] = []
         for package in self.doc.packages:
             if not package.version:
                 components_name.append(package.name)
@@ -337,7 +336,7 @@ class BaseChecker(ABC):
 
         return len(self.doc.packages)
 
-    def parse_file(self) -> Optional[Document]:
+    def parse_file(self) -> Document | None:
         """
         Parse SBOM document.
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -17,6 +17,7 @@ from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 from spdx_tools.spdx.parser import parse_anything
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.validation.validation_message import ValidationMessage
 
 
 # pylint: disable=too-many-instance-attributes
@@ -36,7 +37,7 @@ class BaseChecker(ABC):
     doc: Optional[Document] = None
 
     parsing_error: List[str] = []
-    validation_messages: Optional[List[str]] = None
+    validation_messages: List[ValidationMessage] = []
 
     sbom_name: str = ""
     components_without_names: List[str] = []
@@ -116,13 +117,7 @@ class BaseChecker(ABC):
 
         if self.doc:
             if validate:
-                self.validation_messages = [
-                    f"SPDX ID: {msg.context.spdx_id} | "
-                    f"Parent ID: {msg.context.parent_id} | "
-                    f"Element Type: {msg.context.element_type} | "
-                    f"{msg.validation_message}"
-                    for msg in validate_full_spdx_document(self.doc)
-                ]
+                self.validation_messages = validate_full_spdx_document(self.doc)
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = cast(
                 List[str], self.get_components_without_versions()

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -113,18 +113,24 @@ class BaseChecker(ABC):
 
         if self.doc:
             if validate:
-                self.validation_messages = validate_full_spdx_document(self.doc)
+                self.validation_messages = [
+                    str(msg) for msg in validate_full_spdx_document(self.doc)
+                ]
             self.components_without_names = self.get_components_without_names()
-            self.components_without_versions = self.get_components_without_versions()
-            self.components_without_suppliers = self.get_components_without_suppliers()
+            self.components_without_versions = cast(
+                list[str], self.get_components_without_versions()
+            )  # with return_tuples=False, always get list[str]
+            self.components_without_suppliers = cast(
+                list[str], self.get_components_without_suppliers()
+            )
             self.components_without_identifiers = (
                 self.get_components_without_identifiers()
             )
-            self.components_without_concluded_licenses = (
-                self.get_components_without_concluded_licenses()
+            self.components_without_concluded_licenses = cast(
+                list[str], self.get_components_without_concluded_licenses()
             )
-            self.components_without_copyright_texts = (
-                self.get_components_without_copyright_texts()
+            self.components_without_copyright_texts = cast(
+                list[str], self.get_components_without_copyright_texts()
             )
 
     def get_components_without_concluded_licenses(

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -3,11 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Base checking functionality."""
+
+from __future__ import annotations
+
 import logging
 import os
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from spdx_tools.spdx.model.document import Document
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
@@ -32,16 +35,16 @@ class BaseChecker(ABC):
     file: str = ""
     doc: Optional[Document] = None
 
-    parsing_error: list[str] = []
-    validation_messages: Optional[list[str]] = None
+    parsing_error: List[str] = []
+    validation_messages: Optional[List[str]] = None
 
     sbom_name: str = ""
-    components_without_names: list[str] = []
-    components_without_versions: list[str] = []
-    components_without_suppliers: list[str] = []
-    components_without_identifiers: list[str] = []
-    components_without_concluded_licenses: list[str] = []
-    components_without_copyright_texts: list[str] = []
+    components_without_names: List[str] = []
+    components_without_versions: List[str] = []
+    components_without_suppliers: List[str] = []
+    components_without_identifiers: List[str] = []
+    components_without_concluded_licenses: List[str] = []
+    components_without_copyright_texts: List[str] = []
 
     doc_version: bool = False
     doc_author: bool = False
@@ -88,7 +91,7 @@ class BaseChecker(ABC):
         """
 
     @abstractmethod
-    def output_json(self) -> dict[str, Any]:
+    def output_json(self) -> Dict[str, Any]:
         """
         Abstract method to create a dict of results for outputting
         to JSON.
@@ -118,24 +121,24 @@ class BaseChecker(ABC):
                 ]
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = cast(
-                list[str], self.get_components_without_versions()
-            )  # with return_tuples=False, always get list[str]
+                List[str], self.get_components_without_versions()
+            )  # with return_tuples=False, always get List[str]
             self.components_without_suppliers = cast(
-                list[str], self.get_components_without_suppliers()
+                List[str], self.get_components_without_suppliers()
             )
             self.components_without_identifiers = (
                 self.get_components_without_identifiers()
             )
             self.components_without_concluded_licenses = cast(
-                list[str], self.get_components_without_concluded_licenses()
+                List[str], self.get_components_without_concluded_licenses()
             )
             self.components_without_copyright_texts = cast(
-                list[str], self.get_components_without_copyright_texts()
+                List[str], self.get_components_without_copyright_texts()
             )
 
     def get_components_without_concluded_licenses(
         self, return_tuples: bool = False
-    ) -> Union[list[str], list[tuple[str, str]]]:
+    ) -> Union[List[str], List[Tuple[str, str]]]:
         """
         Retrieve names and/or SPDX IDs of components without concluded licenses.
 
@@ -150,7 +153,7 @@ class BaseChecker(ABC):
         """
         # Note: concluded license is mandatory in SPDX-2.2 and SPDX-2.3
         if return_tuples:
-            components_name_id: list[tuple[str, str]] = []
+            components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
 
@@ -167,7 +170,7 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: list[str] = []
+        components_name: List[str] = []
         if not self.doc or not self.doc.packages:
             return components_name
         for package in self.doc.packages:
@@ -185,7 +188,7 @@ class BaseChecker(ABC):
 
     def get_components_without_copyright_texts(
         self, return_tuples: bool = False
-    ) -> Union[list[str], list[tuple[str, str]]]:
+    ) -> Union[List[str], List[Tuple[str, str]]]:
         """
         Retrieve names and/or SPDX IDs of components without copyright texts.
 
@@ -199,7 +202,7 @@ class BaseChecker(ABC):
             or a list of tuples with component names and SPDX IDs.
         """
         if return_tuples:
-            components_name_id: list[tuple[str, str]] = []
+            components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
             for package in self.doc.packages:
@@ -215,7 +218,7 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: list[str] = []
+        components_name: List[str] = []
         if not self.doc or not self.doc.packages:
             return components_name
         for package in self.doc.packages:
@@ -231,7 +234,7 @@ class BaseChecker(ABC):
                 components_name.append(package.name)
         return components_name
 
-    def get_components_without_identifiers(self) -> list[str]:
+    def get_components_without_identifiers(self) -> List[str]:
         """
         Retrieve name of components without identifiers.
 
@@ -243,7 +246,7 @@ class BaseChecker(ABC):
 
         return [package.name for package in self.doc.packages if not package.spdx_id]
 
-    def get_components_without_names(self) -> list[str]:
+    def get_components_without_names(self) -> List[str]:
         """
         Retrieve SPDX ID of components without names.
 
@@ -259,7 +262,7 @@ class BaseChecker(ABC):
         if not self.doc:
             return []
 
-        components_without_names: list[str] = []
+        components_without_names: List[str] = []
         for package in self.doc.packages:
             if not package.name:
                 components_without_names.append(package.spdx_id)
@@ -267,7 +270,7 @@ class BaseChecker(ABC):
 
     def get_components_without_suppliers(
         self, return_tuples: bool = False
-    ) -> Union[list[str], list[tuple[str, str]]]:
+    ) -> Union[List[str], List[Tuple[str, str]]]:
         """
         Retrieve names and/or SPDX IDs of components without suppliers.
 
@@ -281,7 +284,7 @@ class BaseChecker(ABC):
             or a list of tuples with component names and SPDX IDs.
         """
         if return_tuples:
-            components_name_id: list[tuple[str, str]] = []
+            components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
             for package in self.doc.packages:
@@ -292,7 +295,7 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: list[str] = []
+        components_name: List[str] = []
         if not self.doc or not self.doc.packages:
             return components_name
         for package in self.doc.packages:
@@ -305,7 +308,7 @@ class BaseChecker(ABC):
 
     def get_components_without_versions(
         self, return_tuples: bool = False
-    ) -> Union[list[str], list[tuple[str, str]]]:
+    ) -> Union[List[str], List[Tuple[str, str]]]:
         """
         Retrieve name and/or SPDX ID of components without versions.
 
@@ -319,7 +322,7 @@ class BaseChecker(ABC):
             or a list of tuples with component names and SPDX IDs.
         """
         if return_tuples:
-            components_name_id: list[tuple[str, str]] = []
+            components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
             for package in self.doc.packages:
@@ -327,7 +330,7 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: list[str] = []
+        components_name: List[str] = []
         if not self.doc or not self.doc.packages:
             return components_name
         for package in self.doc.packages:

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -117,7 +117,11 @@ class BaseChecker(ABC):
         if self.doc:
             if validate:
                 self.validation_messages = [
-                    str(msg) for msg in validate_full_spdx_document(self.doc)
+                    f"SPDX ID: {msg.context.spdx_id} | "
+                    f"Parent ID: {msg.context.parent_id} | "
+                    f"Element Type: {msg.context.element_type} | "
+                    f"{msg.validation_message}"
+                    for msg in validate_full_spdx_document(self.doc)
                 ]
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = cast(

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -28,14 +28,12 @@ class FSCT3Checker(BaseChecker):
     """
 
     def __init__(self, file: str, validate: bool = True, compliance: str = "fsct3-min"):
-        super().__init__(file=file, validate=validate)
+        super().__init__(file=file, validate=validate, compliance=compliance)
 
         if compliance != "fsct3-min":
             raise ValueError(
                 "Only FSCTv3 Baseline Attributes Minimum Expected compliance is supported."
             )
-
-        self.compliance_standard = "fsct3-min"
 
         if self.doc:
             self.sbom_name = self.doc.creation_info.name
@@ -188,7 +186,7 @@ class FSCT3Checker(BaseChecker):
                     "The following errors were found:\n"
                 )
                 for message in self.validation_messages:
-                    print(message.validation_message)
+                    print(message)
 
     def output_json(self) -> Dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
@@ -286,7 +284,7 @@ class FSCT3Checker(BaseChecker):
                     "The following errors were found:</p>\n"
                 )
                 for message in self.validation_messages:
-                    result += f"<p>{message.validation_message}</p>\n"
+                    result += f"<p>{message}</p>\n"
         else:
             result = f"""
             <h2>FSCTv3-Minimum Expected Conformance Results</h2>

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -4,7 +4,9 @@
 
 """FSCT Common BOM checking functionality."""
 
-from spdx_tools.spdx.model import RelationshipType
+from typing import Any
+
+from spdx_tools.spdx.model.relationship import RelationshipType
 
 from .base_checker import BaseChecker
 
@@ -23,7 +25,7 @@ class FSCT3Checker(BaseChecker):
     https://www.cisa.gov/resources-tools/resources/framing-software-component-transparency-2024
     """
 
-    def __init__(self, file, validate=True, compliance="fsct3-min"):
+    def __init__(self, file: str, validate: bool = True, compliance: str = "fsct3-min"):
         super().__init__(file=file, validate=validate)
 
         if compliance != "fsct3-min":
@@ -39,12 +41,19 @@ class FSCT3Checker(BaseChecker):
 
     def check_doc_version(self):
         """Check for SPDX document version."""
-        if str(self.doc.creation_info.spdx_version) not in ["SPDX-2.2", "SPDX-2.3"]:
+        if (
+            not self.doc
+            or not self.doc.creation_info
+            or str(self.doc.creation_info.spdx_version) not in ["SPDX-2.2", "SPDX-2.3"]
+        ):
             return False
         return True
 
     def check_dependency_relationships(self):
         """Check that the document DESCRIBES at least one package."""
+        if not self.doc or not self.doc.relationships:
+            return False
+
         describes_relationships = [
             rel
             for rel in self.doc.relationships
@@ -175,10 +184,10 @@ class FSCT3Checker(BaseChecker):
                 for message in self.validation_messages:
                     print(message.validation_message)
 
-    def output_json(self):
+    def output_json(self) -> dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
         # instantiate dict and fields that have > 1 level
-        result = {}
+        result: dict[str, Any] = {}
         result["complianceStandard"] = self.compliance_standard
         result["parsingError"] = self.parsing_error
         result["isConformant"] = self.compliant
@@ -270,8 +279,8 @@ class FSCT3Checker(BaseChecker):
                     "<p>The provided document is not valid according to the SPDX specification. "
                     "The following errors were found:</p>\n"
                 )
-            for message in self.validation_messages:
-                result += f"<p>{message.validation_message}</p>\n"
+                for message in self.validation_messages:
+                    result += f"<p>{message.validation_message}</p>\n"
         else:
             result = f"""
             <h2>FSCTv3-Minimum Expected Conformance Results</h2>

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -31,8 +31,10 @@ class FSCT3Checker(BaseChecker):
         super().__init__(file=file, validate=validate)
 
         if compliance != "fsct3-min":
-            raise ValueError("Only FSCTv3 Baseline Attributes Minimum Expected compliance is supported.")
-        
+            raise ValueError(
+                "Only FSCTv3 Baseline Attributes Minimum Expected compliance is supported."
+            )
+
         self.compliance_standard = "fsct3-min"
 
         if self.doc:

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -4,7 +4,9 @@
 
 """FSCT Common BOM checking functionality."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import Any, Dict
 
 from spdx_tools.spdx.model.relationship import RelationshipType
 
@@ -184,10 +186,10 @@ class FSCT3Checker(BaseChecker):
                 for message in self.validation_messages:
                     print(message.validation_message)
 
-    def output_json(self) -> dict[str, Any]:
+    def output_json(self) -> Dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
         # instantiate dict and fields that have > 1 level
-        result: dict[str, Any] = {}
+        result: Dict[str, Any] = {}
         result["complianceStandard"] = self.compliance_standard
         result["parsingError"] = self.parsing_error
         result["isConformant"] = self.compliant

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -186,7 +186,7 @@ class FSCT3Checker(BaseChecker):
                     "The following errors were found:\n"
                 )
                 for message in self.validation_messages:
-                    print(message)
+                    print(message.validation_message)
 
     def output_json(self) -> Dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
@@ -284,7 +284,7 @@ class FSCT3Checker(BaseChecker):
                     "The following errors were found:</p>\n"
                 )
                 for message in self.validation_messages:
-                    result += f"<p>{message}</p>\n"
+                    result += f"<p>{message.validation_message}</p>\n"
         else:
             result = f"""
             <h2>FSCTv3-Minimum Expected Conformance Results</h2>

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -31,7 +31,9 @@ class FSCT3Checker(BaseChecker):
         super().__init__(file=file, validate=validate)
 
         if compliance != "fsct3-min":
-            raise ValueError("Only FSCTv3 Minimum Expected compliance is supported.")
+            raise ValueError("Only FSCTv3 Baseline Attributes Minimum Expected compliance is supported.")
+        
+        self.compliance_standard = "fsct3-min"
 
         if self.doc:
             self.sbom_name = self.doc.creation_info.name

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -91,7 +91,7 @@ def main():
         if args.verbose:
             sbom.print_components_missing_info()
     if args.output == "json":
-        result_dict = sbom.output_json()
+        result_dict: dict[str, Any] = sbom.output_json()
         if args.output_path:
             with open(args.output_path, "w", encoding="utf-8") as outfile:
                 json.dump(result_dict, outfile)

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -9,6 +9,7 @@ import json
 import logging
 import sys
 from importlib.metadata import version
+from typing import Any
 
 from .sbom_checker import SbomChecker
 

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -4,12 +4,14 @@
 
 """Entrypoint for CLI."""
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging
 import sys
 from importlib.metadata import version
-from typing import Any
+from typing import Any, Dict
 
 from .sbom_checker import SbomChecker
 
@@ -92,7 +94,7 @@ def main():
         if args.verbose:
             sbom.print_components_missing_info()
     if args.output == "json":
-        result_dict: dict[str, Any] = sbom.output_json()
+        result_dict: Dict[str, Any] = sbom.output_json()
         if args.output_path:
             with open(args.output_path, "w", encoding="utf-8") as outfile:
                 json.dump(result_dict, outfile)

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -4,7 +4,9 @@
 
 """NTIA minimum elements checking functionality."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import Any, Dict
 
 from spdx_tools.spdx.model.relationship import RelationshipType
 
@@ -159,10 +161,10 @@ class NTIAChecker(BaseChecker):
                 for message in self.validation_messages:
                     print(message.validation_message)
 
-    def output_json(self) -> dict[str, Any]:
+    def output_json(self) -> Dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
         # instantiate dict and fields that have > 1 level
-        result: dict[str, Any] = {}
+        result: Dict[str, Any] = {}
         result["complianceStandard"] = self.compliance_standard
         result["parsingError"] = self.parsing_error
         result["isConformant"] = self.compliant

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -4,7 +4,9 @@
 
 """NTIA minimum elements checking functionality."""
 
-from spdx_tools.spdx.model import RelationshipType
+from typing import Any
+
+from spdx_tools.spdx.model.relationship import RelationshipType
 
 from .base_checker import BaseChecker
 
@@ -12,7 +14,7 @@ from .base_checker import BaseChecker
 class NTIAChecker(BaseChecker):
     """NTIA Minimum Elements check."""
 
-    def __init__(self, file, validate=True, compliance="ntia"):
+    def __init__(self, file: str, validate: bool = True, compliance: str = "ntia"):
         super().__init__(file=file, validate=validate)
 
         if self.doc:
@@ -28,12 +30,19 @@ class NTIAChecker(BaseChecker):
 
     def check_doc_version(self):
         """Check for SPDX document version."""
-        if str(self.doc.creation_info.spdx_version) not in ["SPDX-2.2", "SPDX-2.3"]:
+        if (
+            not self.doc
+            or not self.doc.creation_info
+            or str(self.doc.creation_info.spdx_version) not in ["SPDX-2.2", "SPDX-2.3"]
+        ):
             return False
         return True
 
     def check_dependency_relationships(self):
         """Check that the document DESCRIBES at least one package."""
+        if not self.doc or not self.doc.relationships:
+            return False
+
         describes_relationships = [
             rel
             for rel in self.doc.relationships
@@ -150,10 +159,10 @@ class NTIAChecker(BaseChecker):
                 for message in self.validation_messages:
                     print(message.validation_message)
 
-    def output_json(self):
+    def output_json(self) -> dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
         # instantiate dict and fields that have > 1 level
-        result = {}
+        result: dict[str, Any] = {}
         result["complianceStandard"] = self.compliance_standard
         result["parsingError"] = self.parsing_error
         result["isConformant"] = self.compliant
@@ -232,8 +241,8 @@ class NTIAChecker(BaseChecker):
                     "<p>The provided document is not valid according to the SPDX specification. "
                     "The following errors were found:</p>\n"
                 )
-            for message in self.validation_messages:
-                result += f"<p>{message.validation_message}</p>\n"
+                for message in self.validation_messages:
+                    result += f"<p>{message.validation_message}</p>\n"
         else:
             result = f"""
             <h2>NTIA Conformance Results</h2>

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -19,6 +19,8 @@ class NTIAChecker(BaseChecker):
     def __init__(self, file: str, validate: bool = True, compliance: str = "ntia"):
         super().__init__(file=file, validate=validate)
 
+        self.compliance_standard = "ntia"
+
         if self.doc:
             self.sbom_name = self.doc.creation_info.name
             self.doc_version = self.check_doc_version()

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -159,7 +159,7 @@ class NTIAChecker(BaseChecker):
                     "The following errors were found:\n"
                 )
                 for message in self.validation_messages:
-                    print(message)
+                    print(message.validation_message)
 
     def output_json(self) -> Dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
@@ -245,7 +245,7 @@ class NTIAChecker(BaseChecker):
                     "The following errors were found:</p>\n"
                 )
                 for message in self.validation_messages:
-                    result += f"<p>{message}</p>\n"
+                    result += f"<p>{message.validation_message}</p>\n"
         else:
             result = f"""
             <h2>NTIA Conformance Results</h2>

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -17,9 +17,7 @@ class NTIAChecker(BaseChecker):
     """NTIA Minimum Elements check."""
 
     def __init__(self, file: str, validate: bool = True, compliance: str = "ntia"):
-        super().__init__(file=file, validate=validate)
-
-        self.compliance_standard = "ntia"
+        super().__init__(file=file, validate=validate, compliance=compliance)
 
         if self.doc:
             self.sbom_name = self.doc.creation_info.name
@@ -161,7 +159,7 @@ class NTIAChecker(BaseChecker):
                     "The following errors were found:\n"
                 )
                 for message in self.validation_messages:
-                    print(message.validation_message)
+                    print(message)
 
     def output_json(self) -> Dict[str, Any]:
         """Create a dict of results for outputting to JSON."""
@@ -240,13 +238,14 @@ class NTIAChecker(BaseChecker):
                 f"<td>{self.dependency_relationships}</td> </tr> "
                 f"</table>"
             )
+
             if self.validation_messages:
                 result += (
                     "<p>The provided document is not valid according to the SPDX specification. "
                     "The following errors were found:</p>\n"
                 )
                 for message in self.validation_messages:
-                    result += f"<p>{message.validation_message}</p>\n"
+                    result += f"<p>{message}</p>\n"
         else:
             result = f"""
             <h2>NTIA Conformance Results</h2>

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -4,7 +4,9 @@
 
 """Main checking functionality."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import Any, Dict
 
 from .base_checker import BaseChecker
 
@@ -73,7 +75,7 @@ class SbomChecker(BaseChecker):
     def print_table_output(self) -> None:
         raise NotImplementedError("This method should be implemented by subclasses.")
 
-    def output_json(self) -> dict[str, Any]:
+    def output_json(self) -> Dict[str, Any]:
         raise NotImplementedError("This method should be implemented by subclasses.")
 
     def output_html(self) -> str:

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -4,6 +4,8 @@
 
 """Main checking functionality."""
 
+from typing import Any
+
 from .base_checker import BaseChecker
 
 
@@ -30,7 +32,7 @@ class SbomChecker(BaseChecker):
     # among checkers of different compliance standards are moved to
     # .base_checker.BaseChecker.
 
-    def __new__(cls, file, validate=True, compliance="ntia"):
+    def __new__(cls, file: str, validate: bool = True, compliance: str = "ntia"):
         """
         Returns an instance of a specific compliance checker.
 
@@ -71,7 +73,7 @@ class SbomChecker(BaseChecker):
     def print_table_output(self) -> None:
         raise NotImplementedError("This method should be implemented by subclasses.")
 
-    def output_json(self) -> dict:
+    def output_json(self) -> dict[str, Any]:
         raise NotImplementedError("This method should be implemented by subclasses.")
 
     def output_html(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -38,7 +39,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 urls = { Homepage = "https://github.com/spdx/ntia-conformance-checker" }
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 keywords = [
     "spdx",
     "sbom",
@@ -51,6 +52,7 @@ keywords = [
     "common SBOM",
     "software package data exchange",
     "software component transparency",
+    "supply chain security",
 ]
 dependencies = ["spdx-tools==0.8.3"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,17 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ntia_conformance_checker"
-version = "3.2.0"
+version = "3.2.1"
 authors = [
     { name = "Josh Lin", email = "linynjosh@gmail.com" },
     { name = "John Speed Meyers", email = "johnmeyersster@gmail.com" },
-    { name = "Arthit Suriyawongkul", email = "arthit@gmail.com" },
+    { name = "Arthit Suriyawongkul", email = "suriyawa@tcd.ie" },
 ]
 maintainers = [
     { name = "John Speed Meyers", email = "johnmeyersster@gmail.com" },
     { name = "Gary O'Neall", email = "gary@sourceauditor.com" },
     { name = "Josh Lin", email = "linynjosh@gmail.com" },
-    { name = "Arthit Suriyawongkul", email = "arthit@gmail.com" },
+    { name = "Arthit Suriyawongkul", email = "suriyawa@tcd.ie" },
     { name = "SPDX group at the Linux Foundation and others", email = "spdx-implementers+owner@lists.spdx.org" },
 ]
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ maintainers = [
     { name = "John Speed Meyers", email = "johnmeyersster@gmail.com" },
     { name = "Gary O'Neall", email = "gary@sourceauditor.com" },
     { name = "Josh Lin", email = "linynjosh@gmail.com" },
+    { name = "Arthit Suriyawongkul", email = "arthit@gmail.com" },
     { name = "SPDX group at the Linux Foundation and others", email = "spdx-implementers+owner@lists.spdx.org" },
 ]
 license = { text = "Apache-2.0" }
@@ -27,7 +28,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -38,7 +38,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 urls = { Homepage = "https://github.com/spdx/ntia-conformance-checker" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
     "spdx",
     "sbom",


### PR DESCRIPTION
- <s>Use native type in type hints, as supported in Python 3.9+</s>
  - <s>Note that `|` operator for type hinting is not supported yet in Python 3.9, so have to keep `Union` (X | Y) and `Optional` (X | None)</s>
- <s>With this, support of Python 3.8 has to be dropped</s>
- Follow up of #271 
- Add type hints that compatible with Python 3.8
- Fix type errors + cast what necessary
- Fix BaseChecker.validation_messages type
- Add a change log 
