### PR TITLE
Print validation context only if verbose = True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: DOCUMENTATION
+# SPDX-License-Identifier: Apache-2.0
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: 2025 SPDX contributors
-# SPDX-FileType: DOCUMENTATION
-# SPDX-License-Identifier: Apache-2.0
+---
+SPDX-FileCopyrightText: 2025 SPDX contributors
+SPDX-FileType: DOCUMENTATION
+SPDX-License-Identifier: Apache-2.0
+---
 
 # Changelog
 
@@ -13,7 +15,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
-- Print validation context along with validation message (#274).
+- Print validation context along with validation message (#274, #276).
 - Add type hints and make it stays compatible with Python 3.8 (#272).
   - Note: The next major version may adopt
     [PEP 585](https://peps.python.org/pep-0585/) and

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -83,7 +83,7 @@ class BaseChecker(ABC):
         """
 
     @abstractmethod
-    def print_table_output(self) -> None:
+    def print_table_output(self, verbose: bool = False) -> None:
         """
         Abstract method to print element-by-element result table.
 

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -141,7 +141,7 @@ class FSCT3Checker(BaseChecker):
                 )
                 print()
 
-    def print_table_output(self):
+    def print_table_output(self, verbose: bool = False) -> None:
         """Print element-by-element result table."""
         # pylint: disable=line-too-long
         if self.parsing_error:
@@ -186,14 +186,12 @@ class FSCT3Checker(BaseChecker):
             if self.validation_messages:
                 print(
                     "The provided document is not valid according to the SPDX specification. "
-                    "The following errors were found:\n\n"
+                    "The following errors were found:\n"
                 )
                 for msg in self.validation_messages:
                     if msg.validation_message:
-                        print("Validation message:")
                         print(msg.validation_message)
-                        if msg.context:
-                            print("Validation context:")
+                        if verbose and msg.context:
                             print(f"- SPDX ID: {msg.context.spdx_id}")
                             print(f"- Parent ID: {msg.context.parent_id}")
                             print(f"- Element type: {msg.context.element_type}")

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -90,7 +90,7 @@ def main():
         logging.info("SBOM name: %s", sbom.sbom_name)
 
     if args.output == "print":
-        sbom.print_table_output()
+        sbom.print_table_output(verbose=args.verbose)
         if args.verbose:
             sbom.print_components_missing_info()
     if args.output == "json":

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -118,7 +118,7 @@ class NTIAChecker(BaseChecker):
                 )
                 print()
 
-    def print_table_output(self):
+    def print_table_output(self, verbose: bool = False) -> None:
         """Print element-by-element result table."""
         # pylint: disable=line-too-long
         if self.parsing_error:
@@ -156,14 +156,12 @@ class NTIAChecker(BaseChecker):
             if self.validation_messages:
                 print(
                     "The provided document is not valid according to the SPDX specification. "
-                    "The following errors were found:\n\n"
+                    "The following errors were found:\n"
                 )
                 for msg in self.validation_messages:
                     if msg.validation_message:
-                        print("Validation message:")
                         print(msg.validation_message)
-                        if msg.context:
-                            print("Validation context:")
+                        if verbose and msg.context:
                             print(f"- SPDX ID: {msg.context.spdx_id}")
                             print(f"- Parent ID: {msg.context.parent_id}")
                             print(f"- Element type: {msg.context.element_type}")

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -72,7 +72,7 @@ class SbomChecker(BaseChecker):
     def print_components_missing_info(self) -> None:
         raise NotImplementedError("This method should be implemented by subclasses.")
 
-    def print_table_output(self) -> None:
+    def print_table_output(self, verbose: bool = False) -> None:
         raise NotImplementedError("This method should be implemented by subclasses.")
 
     def output_json(self) -> Dict[str, Any]:


### PR DESCRIPTION
A follow-up of #274, to honour the `--verbose` command line parameter. Give user a control of how much information to be printed.

Without `--verbose`, it will print the validation message just like in v3.2.0:

    The provided document is not valid according to the SPDX specification. The following errors were found:
    
    only SPDX versions "SPDX-2.2" and "SPDX-2.3" are supported, but the document's spdx_version is: SPDX-2.3TEST
    
    There are issues concerning the SPDX version of the document. As subsequent validation relies on the correct version, the validation process has been cancelled.

With `--verbose`, it will print validation context along with the validation message:

    The provided document is not valid according to the SPDX specification. The following errors were found:
    
    only SPDX versions "SPDX-2.2" and "SPDX-2.3" are supported, but the document's spdx_version is: SPDX-2.3TEST
    - SPDX ID: SPDXRef-DOCUMENT
    - Parent ID: None
    - Element type: SpdxElementType.DOCUMENT
    
    There are issues concerning the SPDX version of the document. As subsequent validation relies on the correct version, the validation process has been cancelled.
    - SPDX ID: SPDXRef-DOCUMENT
    - Parent ID: None
    - Element type: SpdxElementType.DOCUMENT
    
    No components with missing information.
