### PR TITLE
Add SPDX version detector

### DIFF
--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -66,7 +66,7 @@ def get_parsed_args():
     return args
 
 
-def detect_spdx_version(file: str) -> str:
+def get_spdx_version(file: str) -> str:
     """
     Check the SPDX version of the SBOM file.
 
@@ -134,7 +134,7 @@ def main():
     )
     logging.info("Checking SBOM: %s", args.file)
 
-    spdx_version = detect_spdx_version(args.file)
+    spdx_version = get_spdx_version(args.file)
     logging.info("Detected SPDX version: %s", spdx_version)
 
     # Only support 2.2 and 2.3, check only major and minor version

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -92,7 +92,7 @@ def get_spdx_version(file: str) -> tuple[int, ...]:
     except SPDXParsingError as exc:
         logging.debug("spdx_tools parser failed: %s", exc)
         doc = None
-    except Exception as exc:
+    except (ValueError, TypeError, OSError) as exc:
         logging.debug("Unexpected error while parsing with spdx_tools: %s", exc)
         doc = None
 
@@ -111,7 +111,7 @@ def get_spdx_version(file: str) -> tuple[int, ...]:
     try:
         with open(file, "r", encoding="utf-8") as f:
             content = f.read()
-    except Exception as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         logging.debug("Could not read file: %s", exc)
         return tuple()
 

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -109,10 +109,7 @@ def detect_spdx_version(file: str) -> str:
             # to handle that later with regular expression
             if ":specVersion>" in line:
                 return (
-                    line.split(":specVersion>")[1]
-                    .split("<")[0]
-                    .strip()
-                    .split("-")[-1]
+                    line.split(":specVersion>")[1].split("<")[0].strip().split("-")[-1]
                 )
             # SPDX 3.x JSON-LD
             # Can have cases that the RDF URL is in another line,

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -107,10 +107,10 @@ def detect_spdx_version(file: str) -> str:
             # SPDX 2.x RDF XML
             # Can have cases that the SPDX version is in another line,
             # to handle that later with regular expression
-            if line.startswith("<spdx:specVersion>"):
+            if ":specVersion>" in line:
                 return (
-                    line.split("<spdx:specVersion>")[-1]
-                    .split("</spdx:specVersion>")[0]
+                    line.split(":specVersion>")[1]
+                    .split("<")[0]
                     .strip()
                     .split("-")[-1]
                 )

--- a/tests/data/spdx3/dataset-example01.json
+++ b/tests/data/spdx3/dataset-example01.json
@@ -1,0 +1,196 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": [
+        "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1"
+      ],
+      "created": "2024-05-31T00:00:00Z"
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1",
+      "creationInfo": "_:creationinfo",
+      "name": "Arthit Suriyawongkul",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "suriyawa@tcd.ie"
+        }
+      ]
+    },
+    {
+      "type": "Organization",
+      "spdxId": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
+      "creationInfo": "_:creationinfo",
+      "name": "Our World in Data",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "other",
+          "issuingAuthority": "GitHub",
+          "identifier": "owid",
+          "identifierLocator": [
+            "https://github.com/owid/"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://spdx.org/spdxdocs/Document1-a7a6f7a8-68d5-4052-b3f7-a005d6af28f1",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab"
+      ]
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b"
+      ],
+      "software_sbomType": [
+        "analyzed"
+      ]
+    },
+    {
+      "type": "dataset_DatasetPackage",
+      "spdxId": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "creationInfo": "_:creationinfo",
+      "name": "Our World in Data CO2 and Greenhouse Gas Emissions dataset",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "suppliedBy": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
+      "builtTime": "2023-12-16T11:22:38Z",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "software_packageVersion": "2024-04-15",
+      "software_copyrightText": "Copyright Our World in Data",
+      "software_downloadLocation": "https://github.com/owid/co2-data/",
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "32657f0d033fc07a7420be36a6af9083c6a63489"
+        },
+        {
+          "type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "434d75c84cf86456c16193dbc53beef31eb63f3387425882ddb2ef6acb9d472c"
+        }
+      ],
+      "software_primaryPurpose": "data",
+      "dataset_confidentialityLevel": "clear",
+      "dataset_dataPreprocessing": [
+        "The dataset is built upon a number of datasets and processing steps.",
+        "See https://github.com/owid/co2-data/blob/master/README.md for sources and processing codes."
+      ],
+      "dataset_datasetAvailability": "directDownload",
+      "dataset_dataCollectionProcess": "The data is collected from various sources, including international organizations and research institutions.",
+      "dataset_datasetSize": 2689,
+      "dataset_datasetType": [
+        "structured",
+        "timestamp"
+      ],
+      "dataset_datasetUpdateMechanism": "Publish updated data as it becomes available. Most are on an annual basis.",
+      "dataset_hasSensitivePersonalInformation": "no",
+      "dataset_intendedUse": "To make the data about greenhouse gas emissions accessible.",
+      "dataset_knownBias": [
+        "Data in some geographical areas are more completed than the others."
+      ],
+      "comment": "This is a small excerpt of the full dataset."
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+      "creationInfo": "_:creationinfo",
+      "name": "data.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "creationInfo": "_:creationinfo",
+      "name": "codebook.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "description": "A description of each column in data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/contains-c64903fa-cab9-4880-8065-0b9b226ce009",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "contains",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+        "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f"
+      ],
+      "description": "DatasetPackage1 contains data.csv and codebook.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/describes-de3f5855-bd5a-403f-9aa6-95dd97599c32",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "describes",
+      "from": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8"
+      ],
+      "description": "codebook.csv describes data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/concludedLicense-8575546c-c4f7-41ec-bb8f-cbd66e70090a",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasConcludedLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a concluded license as CC-BY-4.0."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/declaredLicense-e5536c5e-c8b5-4d24-947f-674c27c0b6c1",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasDeclaredLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a declared license as CC-BY-4.0."
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://spdx.org/licenses/CC-BY-4.0",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "CC-BY-4.0",
+      "simplelicensing_licenseListVersion": "3.25.0",
+      "comment": "Added as a workaround for the lack of https://spdx.org/licenses/CC-BY-4.0 as a valid ListedLicense in SPDX 3.0.1 RDF. This will be removed once https://github.com/spdx/LicenseListPublisher/issues/183 is implemented."
+    }
+  ]
+}

--- a/tests/data/spdx3/software-example01.json
+++ b/tests/data/spdx3/software-example01.json
@@ -1,0 +1,238 @@
+{
+  "@context" : "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph" : [ {
+    "@id" : "_:creationInfo_0",
+    "type" : "CreationInfo",
+    "specVersion" : "3.0.1",
+    "createdBy" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd0" ],
+    "createdUsing" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/additionalToolSPDXRef-gnrtd2", "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/additionalToolSPDXRef-gnrtd1" ],
+    "created" : "2021-08-26T01:46:00Z"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd3",
+    "type" : "Relationship",
+    "relationshipType" : "describes",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/document0",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd5",
+    "type" : "Relationship",
+    "relationshipType" : "contains",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd6" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd7",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd6",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd9",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd6",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd10",
+    "type" : "Relationship",
+    "relationshipType" : "contains",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd11" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd12",
+    "type" : "Relationship",
+    "relationshipType" : "generates",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd11" ],
+    "completeness" : "noAssertion",
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd13",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd15",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd13",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd16",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd13",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd17",
+    "type" : "Relationship",
+    "relationshipType" : "generates",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd11" ],
+    "completeness" : "noAssertion",
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd6",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd18",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd11",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd19",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd20" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd11",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd21",
+    "type" : "Relationship",
+    "relationshipType" : "contains",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd13" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd22",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd23",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/document0",
+    "type" : "SpdxDocument",
+    "dataLicense" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd24",
+    "rootElement" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4" ],
+    "name" : "hello",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/additionalToolSPDXRef-gnrtd1",
+    "type" : "Tool",
+    "name" : "github.com/spdx/tools-golang/builder",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/additionalToolSPDXRef-gnrtd2",
+    "type" : "Tool",
+    "name" : "github.com/spdx/tools-golang/idsearcher",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd8",
+    "type" : "simplelicensing_LicenseExpression",
+    "simplelicensing_licenseExpression" : "GPL-3.0-or-later",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd20",
+    "type" : "simplelicensing_LicenseExpression",
+    "simplelicensing_licenseExpression" : "NOASSERTION",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd24",
+    "type" : "simplelicensing_LicenseExpression",
+    "simplelicensing_licenseExpression" : "CC0-1.0",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd14",
+    "type" : "LifecycleScopedRelationship",
+    "relationshipType" : "usesTool",
+    "scope" : "build",
+    "to" : [ "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd13" ],
+    "completeness" : "noAssertion",
+    "from" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd0",
+    "type" : "Person",
+    "externalIdentifier" : [ {
+      "type" : "ExternalIdentifier",
+      "identifier" : "steve@swinslow.net",
+      "externalIdentifierType" : "email"
+    } ],
+    "name" : "Steve Winslow",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd6",
+    "type" : "software_File",
+    "software_copyrightText" : "Copyright Contributors to the spdx-examples project.",
+    "verifiedUsing" : [ {
+      "type" : "Hash",
+      "algorithm" : "md5",
+      "hashValue" : "935054fe899ca782e11003bbae5e166c"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha1",
+      "hashValue" : "20862a6d08391d07d09344029533ec644fac6b21"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha256",
+      "hashValue" : "b4e5ca56d1f9110ca94ed0bf4e6d9ac11c2186eb7cd95159c6fdb50e8db5a823"
+    } ],
+    "name" : "./src/hello.c",
+    "software_primaryPurpose" : "source",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd11",
+    "type" : "software_File",
+    "software_copyrightText" : "NOASSERTION",
+    "verifiedUsing" : [ {
+      "type" : "Hash",
+      "algorithm" : "sha1",
+      "hashValue" : "20291a81ef065ff891b537b64d4fdccaf6f5ac02"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha256",
+      "hashValue" : "83a33ff09648bb5fc5272baca88cf2b59fd81ac4cc6817b86998136af368708e"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "md5",
+      "hashValue" : "08a12c966d776864cc1eb41fd03c3c3d"
+    } ],
+    "name" : "./build/hello",
+    "contentType" : "application/octet-stream",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd13",
+    "type" : "software_File",
+    "software_copyrightText" : "NOASSERTION",
+    "verifiedUsing" : [ {
+      "type" : "Hash",
+      "algorithm" : "sha1",
+      "hashValue" : "69a2e85696fff1865c3f0686d6c3824b59915c80"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha256",
+      "hashValue" : "5da19033ba058e322e21c90e6d6d859c90b1b544e7840859c12cae5da005e79c"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "md5",
+      "hashValue" : "559424589a4f3f75fd542810473d8bc1"
+    } ],
+    "name" : "./src/Makefile",
+    "software_primaryPurpose" : "source",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example1/hello-v3-specv3/SPDXRef-gnrtd4",
+    "type" : "software_Package",
+    "software_copyrightText" : "NOASSERTION",
+    "software_downloadLocation" : "git+https://github.com/swinslow/spdx-examples.git#example1/content",
+    "verifiedUsing" : [ {
+      "type" : "PackageVerificationCode",
+      "algorithm" : "sha1",
+      "hashValue" : "9d20237bb72087e87069f96afb41c6ca2fa2a342"
+    } ],
+    "name" : "hello",
+    "creationInfo" : "_:creationInfo_0"
+  } ]
+}

--- a/tests/data/spdx3/software-example03.json
+++ b/tests/data/spdx3/software-example03.json
@@ -1,0 +1,227 @@
+{
+  "@context" : "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph" : [ {
+    "@id" : "_:creationInfo_0",
+    "type" : "CreationInfo",
+    "specVersion" : "3.0.1",
+    "createdBy" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd0" ],
+    "createdUsing" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/additionalToolSPDXRef-gnrtd2", "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/additionalToolSPDXRef-gnrtd1" ],
+    "created" : "2021-08-26T01:50:30Z"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd3",
+    "type" : "Relationship",
+    "relationshipType" : "describes",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/document0",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd5",
+    "type" : "Relationship",
+    "relationshipType" : "contains",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd6" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd7",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd6",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd9",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd8" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd6",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd10",
+    "type" : "Relationship",
+    "relationshipType" : "contains",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd11" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd13",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd14" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd11",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd15",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd14" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd11",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd16",
+    "type" : "Relationship",
+    "relationshipType" : "contains",
+    "completeness" : "noAssertion",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd17" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd18",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd14" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd17",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd19",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd14" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd17",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd20",
+    "type" : "Relationship",
+    "relationshipType" : "hasConcludedLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd21" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd22",
+    "type" : "Relationship",
+    "relationshipType" : "hasDeclaredLicense",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd14" ],
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/document0",
+    "type" : "SpdxDocument",
+    "dataLicense" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd23",
+    "rootElement" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4" ],
+    "name" : "main-src",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/additionalToolSPDXRef-gnrtd1",
+    "type" : "Tool",
+    "name" : "github.com/spdx/tools-golang/builder",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/additionalToolSPDXRef-gnrtd2",
+    "type" : "Tool",
+    "name" : "github.com/spdx/tools-golang/idsearcher",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd8",
+    "type" : "simplelicensing_LicenseExpression",
+    "simplelicensing_licenseExpression" : "BSD-3-Clause",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd14",
+    "type" : "simplelicensing_LicenseExpression",
+    "simplelicensing_licenseExpression" : "GPL-3.0-or-later",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd21",
+    "type" : "simplelicensing_LicenseExpression",
+    "simplelicensing_licenseExpression" : "(BSD-3-Clause AND GPL-3.0-or-later)",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd23",
+    "type" : "simplelicensing_LicenseExpression",
+    "simplelicensing_licenseExpression" : "CC0-1.0",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd12",
+    "type" : "LifecycleScopedRelationship",
+    "relationshipType" : "usesTool",
+    "scope" : "build",
+    "to" : [ "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd11" ],
+    "completeness" : "noAssertion",
+    "from" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd0",
+    "type" : "Person",
+    "externalIdentifier" : [ {
+      "type" : "ExternalIdentifier",
+      "identifier" : "steve@swinslow.net",
+      "externalIdentifierType" : "email"
+    } ],
+    "name" : "Steve Winslow",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd6",
+    "type" : "software_File",
+    "software_copyrightText" : "NOASSERTION",
+    "verifiedUsing" : [ {
+      "type" : "Hash",
+      "algorithm" : "sha1",
+      "hashValue" : "f66be0b05dc754a545be49f599a7ce2c41db2b1e"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha256",
+      "hashValue" : "c1d6c93251d8af86c9d354510c7c7735cfb012c1a96b8b90e22d3ec1d5a5fdb2"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "md5",
+      "hashValue" : "fbda409f6aec0504e600c57a392660c2"
+    } ],
+    "name" : "./lib.c",
+    "software_primaryPurpose" : "source",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd11",
+    "type" : "software_File",
+    "software_copyrightText" : "NOASSERTION",
+    "verifiedUsing" : [ {
+      "type" : "Hash",
+      "algorithm" : "sha256",
+      "hashValue" : "4031bd733239f0fe89a5c3a4d1a62301b0ce4e654207afff8564a3d45e41f85e"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "md5",
+      "hashValue" : "ef4cccbe2ad9bbedc870848c5b711e4d"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha1",
+      "hashValue" : "a496da160a7d2dec3fef13d4cb1397d15269e367"
+    } ],
+    "name" : "./Makefile",
+    "software_primaryPurpose" : "source",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd17",
+    "type" : "software_File",
+    "software_copyrightText" : "NOASSERTION",
+    "verifiedUsing" : [ {
+      "type" : "Hash",
+      "algorithm" : "md5",
+      "hashValue" : "74c1464f8122373151a4e032494045fe"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha1",
+      "hashValue" : "9dfa5009f890dbd4bab5624a7fbf110de5b95a40"
+    }, {
+      "type" : "Hash",
+      "algorithm" : "sha256",
+      "hashValue" : "dd089736525455d65c283d3698bc403d12acc04736c0bcbad5fc65c80a0e46d5"
+    } ],
+    "name" : "./main.c",
+    "software_primaryPurpose" : "source",
+    "creationInfo" : "_:creationInfo_0"
+  }, {
+    "spdxId" : "https://swinslow.net/spdx-examples/example3/main-src-v2-specv3/SPDXRef-gnrtd4",
+    "type" : "software_Package",
+    "software_copyrightText" : "NOASSERTION",
+    "software_downloadLocation" : "git+https://github.com/swinslow/spdx-examples.git#example1/content/src",
+    "verifiedUsing" : [ {
+      "type" : "PackageVerificationCode",
+      "algorithm" : "sha1",
+      "hashValue" : "7f560718ca985c9334efbb56291e494df22ed97c"
+    } ],
+    "name" : "main-src",
+    "creationInfo" : "_:creationInfo_0"
+  } ]
+}

--- a/tests/data/spdx3/software-example13.json
+++ b/tests/data/spdx3/software-example13.json
@@ -1,0 +1,153 @@
+{
+	 "@context": "https://spdx.org/rdf/3.0.0/spdx-context.jsonld",
+	 "@graph": [
+		 {
+			 "type": "Person",
+			 "spdxId": "urn:jane-doe-1@acme.com-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "Application Owner Jane Doe",
+			 "externalIdentifier": [
+				 {
+					 "type": "ExternalIdentifier",
+					 "externalIdentifierType": "email",
+					 "identifier": "jane-doe-1@acme.com"
+				 }
+			 ]
+		 },
+		 {
+			 "type": "Organization",
+			 "spdxId": "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "Acme Company"
+		 },
+		 {
+			 "type": "Person",
+			 "spdxId": "urn:github.com-indutny-c4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "Fedor Indutny",
+			 "externalIdentifier": [
+				 {
+					 "type": "ExternalIdentifier",
+					 "externalIdentifierType": "other",
+					 "identifier": "https://github.com/indutny"
+				 }
+			 ]
+		 },
+		 {
+			 "type": "Organization",
+			 "spdxId": "urn:github.com-alpinelinux-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "Alpine Linux"
+
+		 },
+		 {
+			 "type": "CreationInfo",
+			 "@id": "_:creationinfo",
+			 "specVersion": "3.0.0",
+			 "createdBy": [
+				 "urn:jane-doe-1@acme.com-4fe40e24-20e3-11ee-be56-0242ac120002",
+				 "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002"
+			 ],
+			 "created": "2024-05-02T00:00:00Z"
+		 },
+		 {
+			 "type": "SpdxDocument",
+			 "spdxId": "http://spdx.example.com/Document1",
+			 "creationInfo": "_:creationinfo",
+			 "profileConformance": [
+				 "core",
+				 "software"
+			 ],
+			 "rootElement": [
+				 "urn:example13-sbom.com-4fe40e24-20e3-11ee-be56-0242ac120002"
+			 ]
+		 },
+		 {
+			 "type": "software_Sbom",
+			 "spdxId": "urn:example13-sbom.com-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "profileConformance": [
+                                 "core",
+                                 "software"
+                         ],
+			 "rootElement": [
+				 "urn:product-acme-application-1.3-4fe40e24-20e3-11ee-be56-0242ac120002"
+			 ]
+		 },
+		 {
+			 "type": "software_Package",
+			 "spdxId": "urn:product-acme-application-1.3-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "Acme Application",
+			 "software_packageVersion": "1.3",
+			 "suppliedBy": "urn:acme.com-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "software_primaryPurpose": "application"
+		 },
+		 {
+			 "type": "software_Package",
+			 "spdxId": "urn:npm-elliptic-6.5.2-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "npm-elliptic",
+			 "software_packageVersion": "6.5.2",
+			 "suppliedBy": "urn:github.com-indutny-c4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "software_primaryPurpose": "library",
+			 "externalIdentifier": [
+				 {
+					 "type": "ExternalIdentifier",
+					 "externalIdentifierType": "other",
+					 "identifier": "https://github.com/indutny/elliptic/releases/tag/v6.5.2"
+                                 }
+                         ]
+
+		 },
+		 {
+			 "type": "software_Package",
+			 "spdxId": "urn:container-alpine-latest-sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "alpine:latest",
+			 "software_packageVersion": "69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a",
+			 "suppliedBy": "urn:github.com-alpinelinux-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "software_primaryPurpose": "container"
+		 },
+		 {
+			 "type": "software_Package",
+			 "spdxId": "urn:openssl-3.0.4-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "name": "openssl",
+			 "software_packageVersion": "3.0.4",
+			 "software_primaryPurpose": "library"
+		 },
+		 {
+			 "type": "Relationship",
+			 "spdxId": "urn:acme-relationship-1-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "from": "urn:product-acme-application-1.3-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "to": ["urn:jane-doe-1@acme.com-4fe40e24-20e3-11ee-be56-0242ac120002"],
+			 "relationshipType": "availableFrom"
+		 },
+		 {
+			 "type": "Relationship",
+			 "spdxId": "urn:acme-relationship-2-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "from": "urn:product-acme-application-1.3-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "to": ["urn:npm-elliptic-6.5.2-4fe40e24-20e3-11ee-be56-0242ac120002"],
+			 "relationshipType": "contains"
+		 },
+		 {
+			 "type": "Relationship",
+			 "spdxId": "urn:acme-relationship-3-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "from": "urn:product-acme-application-1.3-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "to": ["urn:container-alpine-latest-sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a-4fe40e24-20e3-11ee-be56-0242ac120002"],
+			 "relationshipType": "dependsOn"
+		 },
+		 {
+			 "type": "Relationship",
+			 "spdxId": "urn:acme-relationship-4-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "creationInfo": "_:creationinfo",
+			 "from": "urn:container-alpine-latest-sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a-4fe40e24-20e3-11ee-be56-0242ac120002",
+			 "to": ["urn:openssl-3.0.4-4fe40e24-20e3-11ee-be56-0242ac120002"],
+			 "relationshipType": "contains"
+		 }
+	 ]
+}

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2,7 +2,7 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests using pytest framework."""
+"""Tests checkers"""
 
 # pylint: disable=missing-function-docstring,import-error,consider-using-from-import
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests functions in main"""
+
+# pylint: disable=missing-function-docstring
+
+from pathlib import Path
+from typing import List, Tuple
+
+from ntia_conformance_checker.main import detect_spdx_version
+
+spdx2_2_dir = Path(__file__).parent / "data" / "missing_component_name"
+spdx2_3_dir = Path(__file__).parent / "data" / "missing_timestamp"
+spdx3_0_dir = Path(__file__).parent / "data" / "spdx3"
+
+
+detect_version_test: List[Tuple[Path, str]] = [
+    (spdx2_2_dir / "SPDXJsonExample.json", "2.2"),
+    (spdx2_2_dir / "SPDXXmlExample.xml", "2.2"),
+    (spdx2_2_dir / "SPDXYamlExample.yaml", "2.2"),
+    (spdx2_3_dir / "SPDXJSONExample-v2.3.spdx.json", "2.3"),
+    (spdx2_3_dir / "SPDXRdfExample-v2.3.spdx.rdf.xml", "2.3"),
+    (spdx2_3_dir / "SPDXTagExample-v2.3.spdx", "2.3"),
+    (spdx2_3_dir / "SPDXXMLExample-v2.3.spdx.xml", "2.3"),
+    (spdx2_3_dir / "SPDXYAMLExample-v2.3.spdx.yaml", "2.3"),
+    (spdx3_0_dir / "dataset-example01.json", "3.0.1"),
+]
+
+
+def test_detect_spdx_version():
+    for file_path, expected_version in detect_version_test:
+        version = detect_spdx_version(str(file_path))
+        assert (
+            version == expected_version
+        ), f"Expected {expected_version}, got {version} for {file_path}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,16 +16,16 @@ spdx2_3_dir = Path(__file__).parent / "data" / "missing_timestamp"
 spdx3_0_dir = Path(__file__).parent / "data" / "spdx3"
 
 
-detect_version_test: List[Tuple[Path, str]] = [
-    (spdx2_2_dir / "SPDXJsonExample.json", "2.2"),
-    (spdx2_2_dir / "SPDXXmlExample.xml", "2.2"),
-    (spdx2_2_dir / "SPDXYamlExample.yaml", "2.2"),
-    (spdx2_3_dir / "SPDXJSONExample-v2.3.spdx.json", "2.3"),
-    (spdx2_3_dir / "SPDXRdfExample-v2.3.spdx.rdf.xml", "2.3"),
-    (spdx2_3_dir / "SPDXTagExample-v2.3.spdx", "2.3"),
-    (spdx2_3_dir / "SPDXXMLExample-v2.3.spdx.xml", "2.3"),
-    (spdx2_3_dir / "SPDXYAMLExample-v2.3.spdx.yaml", "2.3"),
-    (spdx3_0_dir / "dataset-example01.json", "3.0.1"),
+detect_version_test: List[Tuple[Path, Tuple[int, ...]]] = [
+    (spdx2_2_dir / "SPDXJsonExample.json", (2, 2)),
+    (spdx2_2_dir / "SPDXXmlExample.xml", (2, 2)),
+    (spdx2_2_dir / "SPDXYamlExample.yaml", (2, 2)),
+    (spdx2_3_dir / "SPDXJSONExample-v2.3.spdx.json", (2, 3)),
+    (spdx2_3_dir / "SPDXRdfExample-v2.3.spdx.rdf.xml", (2, 3)),
+    (spdx2_3_dir / "SPDXTagExample-v2.3.spdx", (2, 3)),
+    (spdx2_3_dir / "SPDXXMLExample-v2.3.spdx.xml", (2, 3)),
+    (spdx2_3_dir / "SPDXYAMLExample-v2.3.spdx.yaml", (2, 3)),
+    (spdx3_0_dir / "dataset-example01.json", (3, 0)),
 ]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@
 from pathlib import Path
 from typing import List, Tuple
 
-from ntia_conformance_checker.main import detect_spdx_version
+from ntia_conformance_checker.main import get_spdx_version
 
 spdx2_2_dir = Path(__file__).parent / "data" / "missing_component_name"
 spdx2_3_dir = Path(__file__).parent / "data" / "missing_timestamp"
@@ -31,7 +31,7 @@ detect_version_test: List[Tuple[Path, str]] = [
 
 def test_detect_spdx_version():
     for file_path, expected_version in detect_version_test:
-        version = detect_spdx_version(str(file_path))
+        version = get_spdx_version(str(file_path))
         assert (
             version == expected_version
         ), f"Expected {expected_version}, got {version} for {file_path}"


### PR DESCRIPTION
Add `detect_spdx_version()` function to detect SPDX version of an SBOM file.

- SPDX version information will be used later to select conformance checker
- This implementation uses simple exact string match and assume that all signature are in one single line

WIP:
- [x] Unit tests
- [x] SPDX 3 test data