### PR TITLE
Add static type check workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install .
           pip install mypy pyrefly pyright pytype
       - name: mypy type check
         run: |

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -36,13 +36,13 @@ jobs:
           pip install mypy pyrefly pyright pytype
       - name: mypy type check
         run: |
-          mypy ntia_conformance_checker
+          mypy ntia_conformance_checker tests
       - name: pyrefly type check
         run: |
-          pyrefly check
+          pyrefly check ntia_conformance_checker tests
       - name: pyright type check
         run: |
-          pyright .
+          pyright ntia_conformance_checker tests
       - name: pytype type check
         run: |
-          pytype ntia_conformance_checker
+          pytype ntia_conformance_checker tests

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,7 +23,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -37,13 +37,13 @@ jobs:
           pip install mypy pyrefly pyright pytype
       - name: mypy type check
         run: |
-          mypy ntia_conformance_checker tests
+          mypy ntia_conformance_checker
       - name: pyrefly type check
         run: |
-          pyrefly check ntia_conformance_checker tests
+          pyrefly check ntia_conformance_checker
       - name: pyright type check
         run: |
-          pyright ntia_conformance_checker tests
+          pyright ntia_conformance_checker
       - name: pytype type check
         run: |
-          pytype ntia_conformance_checker tests
+          pytype ntia_conformance_checker

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+name: Static type check
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mypy pyrefly pyright pytype
+      - name: mypy type check
+        run: |
+          mypy ntia_conformance_checker
+      - name: pyrefly type check
+        run: |
+          pyrefly check
+      - name: pyright type check
+        run: |
+          pyright .
+      - name: pytype type check
+        run: |
+          pytype ntia_conformance_checker

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -72,26 +72,26 @@ def get_parsed_args():
     return args
 
 
-def get_spdx_version(file_name: str) -> Tuple[int, ...]:
+def get_spdx_version(file: str) -> Tuple[int, ...]:
     """
     Check the SPDX version of the SBOM file.
 
     XLS file format is not supported.
 
     Args:
-        file_name (str): The name of the file to be checked.
+        file (str): The name of the file to be checked.
 
     Returns:
         Tuple[int, ...]: The SPDX version of the SBOM. E.g. (2, 3) for version 2.3.
     """
-    if file_name.lower().endswith(".xls") or file_name.lower().endswith(".xlsx"):
+    if file.lower().endswith(".xls") or file.lower().endswith(".xlsx"):
         logging.debug("Excel file format is not supported")
         return tuple()
 
     # Try parsing the file with spdx_tools first
     doc = None
     try:
-        doc = spdx2_parse_file(file_name)
+        doc = spdx2_parse_file(file)
     except SPDXParsingError as exc:
         logging.debug("spdx_tools parser failed: %s", exc)
         doc = None
@@ -112,7 +112,7 @@ def get_spdx_version(file_name: str) -> Tuple[int, ...]:
     # This will also cover SPDX 3 format.
     content = ""
     try:
-        with open(file_name, "r", encoding="utf-8") as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = f.read()
     except (OSError, UnicodeDecodeError) as exc:
         logging.debug("Could not read file: %s", exc)

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -12,7 +12,7 @@ import logging
 import re
 import sys
 from importlib.metadata import version
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.parse_anything import parse_file as spdx2_parse_file
@@ -72,23 +72,26 @@ def get_parsed_args():
     return args
 
 
-def get_spdx_version(file: str) -> tuple[int, ...]:
+def get_spdx_version(filename: str) -> Tuple[int, ...]:
     """
     Check the SPDX version of the SBOM file.
 
     XLS file format is not supported.
 
     Args:
-        file (str): The file to be checked.
+        filename (str): The name of the file to be checked.
 
     Returns:
-        str: The SPDX version of the SBOM.
+        Tuple[int, ...]: The SPDX version of the SBOM. E.g. (2, 3) for version 2.3.
     """
+    if filename.lower().endswith(".xls") or filename.lower().endswith(".xlsx"):
+        logging.debug("XLS file format is not supported")
+        return tuple()
 
     # Try parsing the file with spdx_tools first
     doc = None
     try:
-        doc = spdx2_parse_file(file)
+        doc = spdx2_parse_file(filename)
     except SPDXParsingError as exc:
         logging.debug("spdx_tools parser failed: %s", exc)
         doc = None
@@ -109,7 +112,7 @@ def get_spdx_version(file: str) -> tuple[int, ...]:
     # This will also cover SPDX 3 format.
     content = ""
     try:
-        with open(file, "r", encoding="utf-8") as f:
+        with open(filename, "r", encoding="utf-8") as f:
             content = f.read()
     except (OSError, UnicodeDecodeError) as exc:
         logging.debug("Could not read file: %s", exc)

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -72,26 +72,26 @@ def get_parsed_args():
     return args
 
 
-def get_spdx_version(filename: str) -> Tuple[int, ...]:
+def get_spdx_version(file_name: str) -> Tuple[int, ...]:
     """
     Check the SPDX version of the SBOM file.
 
     XLS file format is not supported.
 
     Args:
-        filename (str): The name of the file to be checked.
+        file_name (str): The name of the file to be checked.
 
     Returns:
         Tuple[int, ...]: The SPDX version of the SBOM. E.g. (2, 3) for version 2.3.
     """
-    if filename.lower().endswith(".xls") or filename.lower().endswith(".xlsx"):
-        logging.debug("XLS file format is not supported")
+    if file_name.lower().endswith(".xls") or file_name.lower().endswith(".xlsx"):
+        logging.debug("Excel file format is not supported")
         return tuple()
 
     # Try parsing the file with spdx_tools first
     doc = None
     try:
-        doc = spdx2_parse_file(filename)
+        doc = spdx2_parse_file(file_name)
     except SPDXParsingError as exc:
         logging.debug("spdx_tools parser failed: %s", exc)
         doc = None
@@ -112,7 +112,7 @@ def get_spdx_version(filename: str) -> Tuple[int, ...]:
     # This will also cover SPDX 3 format.
     content = ""
     try:
-        with open(filename, "r", encoding="utf-8") as f:
+        with open(file_name, "r", encoding="utf-8") as f:
             content = f.read()
     except (OSError, UnicodeDecodeError) as exc:
         logging.debug("Could not read file: %s", exc)


### PR DESCRIPTION
Run the following static type checks against Python source code when push/pull request:

- mypy
- pyrefly
- pyright
- pytype

Also fix a wrong return type in a docstring.