### PR TITLE
Separate SPDX 2-specific code to make room for SPDX 3 code

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -241,7 +241,9 @@ class BaseChecker(ABC):
             or a list of tuples with component names and SPDX IDs.
         """
         # Note: concluded license is mandatory in SPDX-2.2 and SPDX-2.3
-        if return_tuples:
+
+        # SPDX 2
+        if self.sbom_spec == "spdx2" and return_tuples:
             components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
@@ -259,21 +261,27 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
-        if not self.doc or not self.doc.packages:
-            return components_name
-        for package in self.doc.packages:
-            no_license = (
-                package.license_concluded is None
-                or isinstance(package.license_concluded, SpdxNoAssertion)
-                or (
-                    isinstance(package.license_concluded, str)
-                    and package.license_concluded.strip() == ""
+        if self.sbom_spec == "spdx2" and not return_tuples:
+            components_name: List[str] = []
+            if not self.doc or not self.doc.packages:
+                return components_name
+            for package in self.doc.packages:
+                no_license = (
+                    package.license_concluded is None
+                    or isinstance(package.license_concluded, SpdxNoAssertion)
+                    or (
+                        isinstance(package.license_concluded, str)
+                        and package.license_concluded.strip() == ""
+                    )
                 )
-            )
-            if no_license:
-                components_name.append(package.name)
-        return components_name
+                if no_license:
+                    components_name.append(package.name)
+            return components_name
+
+        # SPDX 3
+        # Add code to retrieve components without concluded licenses for SPDX 3 here
+
+        return []
 
     def get_components_without_copyright_texts(
         self, return_tuples: bool = False
@@ -290,7 +298,8 @@ class BaseChecker(ABC):
             Union[List[str], List[Tuple[str, str]]]: A list of component names
             or a list of tuples with component names and SPDX IDs.
         """
-        if return_tuples:
+        # SPDX 2
+        if self.sbom_spec == "spdx2" and return_tuples:
             components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
@@ -307,21 +316,26 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
-        if not self.doc or not self.doc.packages:
-            return components_name
-        for package in self.doc.packages:
-            no_license = (
-                package.copyright_text is None
-                or isinstance(package.copyright_text, SpdxNoAssertion)
-                or (
-                    isinstance(package.copyright_text, str)
-                    and package.copyright_text.strip() == ""
+        if self.sbom_spec == "spdx2" and not return_tuples:
+            components_name: List[str] = []
+            if not self.doc or not self.doc.packages:
+                return components_name
+            for package in self.doc.packages:
+                no_license = (
+                    package.copyright_text is None
+                    or isinstance(package.copyright_text, SpdxNoAssertion)
+                    or (
+                        isinstance(package.copyright_text, str)
+                        and package.copyright_text.strip() == ""
+                    )
                 )
-            )
-            if no_license:
-                components_name.append(package.name)
-        return components_name
+                if no_license:
+                    components_name.append(package.name)
+            return components_name
+
+        # SPDX 3
+        # Add code to retrieve components without copyright texts for SPDX 3 here
+        return []
 
     def get_components_without_identifiers(self) -> List[str]:
         """
@@ -333,7 +347,15 @@ class BaseChecker(ABC):
         if not self.doc:
             return []
 
-        return [package.name for package in self.doc.packages if not package.spdx_id]
+        # SPDX 2
+        if self.sbom_spec == "spdx2":
+            return [
+                package.name for package in self.doc.packages if not package.spdx_id
+            ]
+
+        # SPDX 3
+        # Add code to retrieve components without identifiers for SPDX 3 here
+        return []
 
     def get_components_without_names(self) -> List[str]:
         """
@@ -351,11 +373,17 @@ class BaseChecker(ABC):
         if not self.doc:
             return []
 
-        components_without_names: List[str] = []
-        for package in self.doc.packages:
-            if not package.name:
-                components_without_names.append(package.spdx_id)
-        return components_without_names
+        # SPDX 2
+        if self.sbom_spec == "spdx2":
+            components_without_names: List[str] = []
+            for package in self.doc.packages:
+                if not package.name:
+                    components_without_names.append(package.spdx_id)
+            return components_without_names
+
+        # SPDX 3
+        # Add code to retrieve components without names for SPDX 3 here
+        return []
 
     def get_components_without_suppliers(
         self, return_tuples: bool = False
@@ -372,7 +400,8 @@ class BaseChecker(ABC):
             Union[List[str], List[Tuple[str, str]]]: A list of component names
             or a list of tuples with component names and SPDX IDs.
         """
-        if return_tuples:
+        # SPDX 2
+        if self.sbom_spec == "spdx2" and return_tuples:
             components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
@@ -384,16 +413,21 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
-        if not self.doc or not self.doc.packages:
+        if self.sbom_spec == "spdx2" and not return_tuples:
+            components_name: List[str] = []
+            if not self.doc or not self.doc.packages:
+                return components_name
+            for package in self.doc.packages:
+                no_supplier = package.supplier is None or isinstance(
+                    package.supplier, SpdxNoAssertion
+                )
+                if no_supplier:
+                    components_name.append(package.name)
             return components_name
-        for package in self.doc.packages:
-            no_supplier = package.supplier is None or isinstance(
-                package.supplier, SpdxNoAssertion
-            )
-            if no_supplier:
-                components_name.append(package.name)
-        return components_name
+
+        # SPDX 3
+        # Add code to retrieve components without suppliers for SPDX 3 here
+        return []
 
     def get_components_without_versions(
         self, return_tuples: bool = False
@@ -410,7 +444,8 @@ class BaseChecker(ABC):
             Union[List[str], List[Tuple[str, str]]]: A list of component names
             or a list of tuples with component names and SPDX IDs.
         """
-        if return_tuples:
+        # SPDX 2
+        if self.sbom_spec == "spdx2" and return_tuples:
             components_name_id: List[Tuple[str, str]] = []
             if not self.doc or not self.doc.packages:
                 return components_name_id
@@ -419,13 +454,18 @@ class BaseChecker(ABC):
                     components_name_id.append((package.name, package.spdx_id))
             return components_name_id
 
-        components_name: List[str] = []
-        if not self.doc or not self.doc.packages:
+        if self.sbom_spec == "spdx2" and not return_tuples:
+            components_name: List[str] = []
+            if not self.doc or not self.doc.packages:
+                return components_name
+            for package in self.doc.packages:
+                if not package.version:
+                    components_name.append(package.name)
             return components_name
-        for package in self.doc.packages:
-            if not package.version:
-                components_name.append(package.name)
-        return components_name
+
+        # SPDX 3
+        # Add code to retrieve components without versions for SPDX 3 here
+        return []
 
     def get_total_number_components(self) -> int:
         """
@@ -437,7 +477,13 @@ class BaseChecker(ABC):
         if not self.doc:
             return 0
 
-        return len(self.doc.packages)
+        # SPDX 2
+        if self.sbom_spec == "spdx2":
+            return len(self.doc.packages)
+
+        # SPDX 3
+        # Add code to retrieve total number of components for SPDX 3 here
+        return 0
 
     def parse_file(self) -> Optional[Document]:
         """
@@ -451,6 +497,8 @@ class BaseChecker(ABC):
         if not os.path.exists(self.file):
             logging.error("Filename %s not found.", self.file)
             sys.exit(1)
+        
+        # SPDX 2
         try:
             doc = parse_anything.parse_file(self.file)
         except SPDXParsingError as err:
@@ -458,3 +506,14 @@ class BaseChecker(ABC):
             return None
 
         return cast(Document, doc)
+
+    # def parse_spdx3_file(self) -> Optional[spdx3.Spdx3Document]:
+    #     """
+    #     Parse SPDX 3 SBOM document.
+
+    #     Returns:
+    #         Optional[Document]: The parsed SPDX 3 SBOM document if successful,
+    #         otherwise None.
+    #     """
+    #     # Add code to parse SPDX 3 files here
+    #     return None

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -66,6 +66,7 @@ class BaseChecker(ABC):
     @abstractmethod
     def check_compliance(self) -> bool:
         """Abstract method to check compliance."""
+        raise NotImplementedError
 
     @abstractmethod
     def print_components_missing_info(self) -> None:
@@ -79,6 +80,7 @@ class BaseChecker(ABC):
         Returns:
             None
         """
+        raise NotImplementedError
 
     @abstractmethod
     def print_table_output(self, verbose: bool = False) -> None:
@@ -88,6 +90,7 @@ class BaseChecker(ABC):
         Returns:
             None
         """
+        raise NotImplementedError
 
     @abstractmethod
     def output_json(self) -> Dict[str, Any]:
@@ -95,10 +98,12 @@ class BaseChecker(ABC):
         Abstract method to create a dict of results for outputting
         to JSON.
         """
+        raise NotImplementedError
 
     @abstractmethod
     def output_html(self) -> str:
         """Abstract method to create a result in HTML format."""
+        raise NotImplementedError
 
     def __init__(
         self,
@@ -210,6 +215,7 @@ class BaseChecker(ABC):
         if not self.doc:
             return ""
 
+        # SPDX 2
         if self.sbom_spec == "spdx2":
             if self.doc.creation_info and self.doc.creation_info.name:
                 return self.doc.creation_info.name

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -497,7 +497,7 @@ class BaseChecker(ABC):
         if not os.path.exists(self.file):
             logging.error("Filename %s not found.", self.file)
             sys.exit(1)
-        
+
         # SPDX 2
         try:
             doc = parse_anything.parse_file(self.file)

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -40,7 +40,7 @@ class BaseChecker(ABC):
     # file_format: str = ""  # json, rdf-xml, tag-value, yaml, xml
 
     file: str = ""
-    doc: Optional[Document] = None  # TODO: Add SPDX 3 document type
+    doc: Optional[Document] = None  # Add SPDX 3 document type support here
 
     parsing_error: List[str] = []
     validation_messages: List[ValidationMessage] = []
@@ -130,7 +130,7 @@ class BaseChecker(ABC):
         if sbom_spec == "spdx2":
             self.doc = self.parse_file()
         elif sbom_spec == "spdx3":
-            # TODO: Add SPDX 3 parsing
+            # Add SPDX 3 parsing here
             self.doc = None
         else:
             raise ValueError(f"Unsupported SBOM specification: {sbom_spec}")
@@ -176,7 +176,7 @@ class BaseChecker(ABC):
             return True
 
         # SPDX 3
-        # TODO: Check for SPDX 3
+        # Add code to check document version for SPDX 3 here
         return False
 
     def check_dependency_relationships(self) -> bool:
@@ -207,7 +207,7 @@ class BaseChecker(ABC):
             return describes_package
 
         # SPDX 3
-        # TODO: Check for SPDX 3
+        # Add code to check dependency relationships for SPDX 3 here
         return False
 
     def get_sbom_name(self) -> str:
@@ -222,6 +222,7 @@ class BaseChecker(ABC):
             return ""
 
         # SPDX 3
+        # Add code to retrieve SBOM name for SPDX 3 here
         return ""
 
     def get_components_without_concluded_licenses(

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -185,7 +185,14 @@ class FSCT3Checker(BaseChecker):
         # instantiate dict and fields that have > 1 level
         result: Dict[str, Any] = {}
         result["complianceStandard"] = self.compliance_standard
+        result["sbomSpec"] = self.sbom_spec
+
+        result["validationMessages"] = []
+        if self.validation_messages:
+            result["validationMessages"] = list(map(str, self.validation_messages))
+
         result["parsingError"] = self.parsing_error
+
         result["isConformant"] = self.compliant
 
         result["sbomName"] = self.sbom_name
@@ -240,13 +247,9 @@ class FSCT3Checker(BaseChecker):
 
         result["totalNumberComponents"] = self.get_total_number_components()
 
-        result["validationMessages"] = []
-        if self.validation_messages:
-            result["validationMessages"] = list(map(str, self.validation_messages))
-
         return result
 
-    def output_html(self):
+    def output_html(self) -> str:
         """Create a HTML of results."""
         if self.doc:
             result = (

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -19,7 +19,7 @@ from spdx_tools.spdx.parser.parse_anything import parse_file as spdx2_parse_file
 
 from .sbom_checker import SbomChecker
 
-SUPPORT_SPDX_VERSIONS = ["2.2", "2.3"]
+SUPPORTED_SPDX_VERSIONS = {"2.2", "2.3"}
 
 
 def get_parsed_args():
@@ -34,6 +34,12 @@ def get_parsed_args():
         choices=["fsct3-min", "ntia"],
         default="ntia",
         help="Specify which compliance standard to check against",
+    )
+    parser.add_argument(
+        "--sbom-spec",
+        choices=["spdx2", "spdx3"],
+        default="spdx2",
+        help="Specify SBOM specification",
     )
     parser.add_argument(
         "--output",
@@ -51,7 +57,7 @@ def get_parsed_args():
     parser.add_argument(
         "--version",
         action="store_true",
-        help="Display version of ntia-conformance-checker",
+        help="Display version of sbomcheck",
     )
     parser.add_argument(
         "--skip-validation",
@@ -165,18 +171,31 @@ def main():
     )
     logging.info("Detected SPDX version: %s", spdx_version_str)
 
-    if spdx_version_str not in SUPPORT_SPDX_VERSIONS:
+    if spdx_version_str not in SUPPORTED_SPDX_VERSIONS:
         logging.error(
             "Unsupported SPDX version: %s. Only supports versions: %s",
             spdx_version_str,
-            ", ".join(SUPPORT_SPDX_VERSIONS),
+            ", ".join(sorted(SUPPORTED_SPDX_VERSIONS)),
         )
         sys.exit(1)
 
-    # Check SPDX 2 SBOM
-    sbom = SbomChecker(
-        args.file, validate=not args.skip_validation, compliance=args.comply
-    )
+    if spdx_version[0] == 2:
+        sbom = SbomChecker(
+            args.file,
+            validate=not args.skip_validation,
+            compliance=args.comply,
+            sbom_spec="spdx2",
+        )
+    elif spdx_version[0] == 3:
+        sbom = SbomChecker(
+            args.file,
+            validate=not args.skip_validation,
+            compliance=args.comply,
+            sbom_spec="spdx3",
+        )
+    else:
+        logging.error("Unsupported SBOM specification")
+        sys.exit(1)
 
     logging.info("Parsing: %s", "OK" if not sbom.parsing_error else "Failed")
     logging.info("Validation: %s", "OK" if not sbom.validation_messages else "Failed")

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -179,6 +179,7 @@ def main():
         )
         sys.exit(1)
 
+    sbom = None
     if spdx_version[0] == 2:
         sbom = SbomChecker(
             args.file,
@@ -193,7 +194,8 @@ def main():
             compliance=args.comply,
             sbom_spec="spdx3",
         )
-    else:
+
+    if not sbom:
         logging.error("Unsupported SBOM specification")
         sys.exit(1)
 

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -165,7 +165,14 @@ class NTIAChecker(BaseChecker):
         # instantiate dict and fields that have > 1 level
         result: Dict[str, Any] = {}
         result["complianceStandard"] = self.compliance_standard
+        result["sbomSpec"] = self.sbom_spec
+
+        result["validationMessages"] = []
+        if self.validation_messages:
+            result["validationMessages"] = list(map(str, self.validation_messages))
+
         result["parsingError"] = self.parsing_error
+
         result["isConformant"] = self.compliant
         result["isNtiaConformant"] = self.compliant  # for backward compatibility
 
@@ -207,13 +214,9 @@ class NTIAChecker(BaseChecker):
 
         result["totalNumberComponents"] = self.get_total_number_components()
 
-        result["validationMessages"] = []
-        if self.validation_messages:
-            result["validationMessages"] = list(map(str, self.validation_messages))
-
         return result
 
-    def output_html(self):
+    def output_html(self) -> str:
         """Create a HTML of results."""
         if self.doc:
             result = (

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -6,9 +6,8 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Dict
-
-from spdx_tools.spdx.model.relationship import RelationshipType
 
 from .base_checker import BaseChecker
 
@@ -16,11 +15,31 @@ from .base_checker import BaseChecker
 class NTIAChecker(BaseChecker):
     """NTIA Minimum Elements check."""
 
-    def __init__(self, file: str, validate: bool = True, compliance: str = "ntia"):
-        super().__init__(file=file, validate=validate, compliance=compliance)
+    def __init__(
+        self,
+        file: str,
+        validate: bool = True,
+        compliance: str = "ntia",
+        sbom_spec: str = "spdx2",
+    ):
+        """
+        Initialize the NTIA Minimum Element Checker.
+
+        Args:
+            file (str): The name of the file to be checked.
+            validate (bool): Whether to validate the file.
+            compliance (str): The compliance standard to be used.
+            sbom_spec (str): The SBOM specification to be used.
+        """
+        super().__init__(
+            file=file, validate=validate, compliance=compliance, sbom_spec=sbom_spec
+        )
+
+        if compliance not in {"ntia"}:
+            raise ValueError("Only NTIA Minimum Element compliance is supported.")
 
         if self.doc:
-            self.sbom_name = self.doc.creation_info.name
+            self.sbom_name = self.get_sbom_name()
             self.doc_version = self.check_doc_version()
             self.doc_author = True  # Assume author is present?
             self.doc_timestamp = True  # Assume timestamp is present?
@@ -30,39 +49,7 @@ class NTIAChecker(BaseChecker):
             # for backward compatibility
             self.ntia_minimum_elements_compliant = self.compliant
 
-    def check_doc_version(self):
-        """Check for SPDX document version."""
-        if (
-            not self.doc
-            or not self.doc.creation_info
-            or str(self.doc.creation_info.spdx_version) not in ["SPDX-2.2", "SPDX-2.3"]
-        ):
-            return False
-        return True
-
-    def check_dependency_relationships(self):
-        """Check that the document DESCRIBES at least one package."""
-        if not self.doc or not self.doc.relationships:
-            return False
-
-        describes_relationships = [
-            rel
-            for rel in self.doc.relationships
-            if rel.relationship_type == RelationshipType.DESCRIBES
-        ]
-
-        # A set of all package spdx_ids for quick lookup
-        spdx_id_set = {package.spdx_id for package in self.doc.packages}
-
-        # Check if any of the "DESCRIBES" relationships describe a Package
-        describes_package = any(
-            rel.related_spdx_element_id in spdx_id_set
-            for rel in describes_relationships
-        )
-
-        return describes_package
-
-    def check_compliance(self):
+    def check_compliance(self) -> bool:
         """Check overall compliance with NTIA minimum elements."""
         return all(
             [
@@ -77,14 +64,20 @@ class NTIAChecker(BaseChecker):
             ]
         )
 
-    def check_ntia_minimum_elements_compliance(self):
+    def check_ntia_minimum_elements_compliance(self) -> bool:
         """Check overall compliance with NTIA minimum elements.
 
         This method is kept for backward compatibility.
         Please consider using check_compliance() instead."""
+        warnings.warn(
+            "NTIAChecker.check_ntia_minimum_elements_compliance is deprecated; "
+            "use check_compliance() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.check_compliance()
 
-    def print_components_missing_info(self):
+    def print_components_missing_info(self) -> None:
         """Print detailed info about which components are missing info."""
         if not self.parsing_error:
             if all(

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -82,12 +82,6 @@ class SbomChecker(BaseChecker):
     def check_compliance(self) -> bool:
         raise NotImplementedError("This method is not implemented by SbomChecker.")
 
-    def check_doc_version(self) -> bool:
-        raise NotImplementedError("This method is not implemented by SbomChecker.")
-
-    def check_dependency_relationships(self) -> bool:
-        raise NotImplementedError("This method is not implemented by SbomChecker.")
-
     def print_components_missing_info(self) -> None:
         raise NotImplementedError("This method is not implemented by SbomChecker.")
 

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -6,14 +6,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, final
 
-from .base_checker import BaseChecker
+from .base_checker import SUPPORTED_SBOM_SPECS, BaseChecker
 
 
+@final
 class SbomChecker(BaseChecker):
     """
-    SBOM checker factory.
+    SBOM checker factory - do not subclass this class.
+
+    Subclass BaseChecker instead to implement a new compliance checker.
 
     Post-v3.0.2, SbomChecker acts like a factory that returns
     a subclass of BaseChecker based on the given "compliance" argument
@@ -34,49 +37,65 @@ class SbomChecker(BaseChecker):
     # among checkers of different compliance standards are moved to
     # .base_checker.BaseChecker.
 
-    def __new__(cls, file: str, validate: bool = True, compliance: str = "ntia"):
+    def __new__(
+        cls,
+        file: str,
+        validate: bool = True,
+        compliance: str = "ntia",
+        sbom_spec: str = "spdx2",
+    ):
         """
         Returns an instance of a specific compliance checker.
 
         Args:
-            file (str): The file to be checked.
+            file (str): The name of the file to be checked.
             validate (bool): Whether to validate the file.
             compliance (str): The compliance standard to be used. Defaults to "ntia".
+            sbom_spec (str): The SBOM specification to be used. Defaults to "spdx2".
 
         Returns:
             BaseChecker: An instance of a specific compliance checker.
         """
+        if sbom_spec not in SUPPORTED_SBOM_SPECS:
+            raise ValueError(f"Unsupported SBOM specification: {sbom_spec}")
+
         if compliance == "ntia":
             # pylint: disable=import-outside-toplevel
             from .ntia_checker import NTIAChecker
 
-            return NTIAChecker(file, validate)
+            return NTIAChecker(file, validate, sbom_spec=sbom_spec)
 
         if compliance.startswith("fsct3"):
             # pylint: disable=import-outside-toplevel
             from .fsct_checker import FSCT3Checker
 
-            return FSCT3Checker(file, validate)
+            return FSCT3Checker(file, validate, sbom_spec=sbom_spec)
 
         raise ValueError(f"Unknown compliance standard: {compliance}")
 
+    def __init_subclass__(cls, /):  # prevent subclassing
+        raise TypeError(
+            "SbomChecker is a factory/dispatcher and must not be subclassed. "
+            "Please subclass BaseChecker to implement custom checkers."
+        )
+
     def check_compliance(self) -> bool:
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        raise NotImplementedError("This method is not implemented by SbomChecker.")
 
     def check_doc_version(self) -> bool:
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        raise NotImplementedError("This method is not implemented by SbomChecker.")
 
     def check_dependency_relationships(self) -> bool:
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        raise NotImplementedError("This method is not implemented by SbomChecker.")
 
     def print_components_missing_info(self) -> None:
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        raise NotImplementedError("This method is not implemented by SbomChecker.")
 
     def print_table_output(self, verbose: bool = False) -> None:
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        raise NotImplementedError("This method is not implemented by SbomChecker.")
 
     def output_json(self) -> Dict[str, Any]:
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        raise NotImplementedError("This method is not implemented by SbomChecker.")
 
     def output_html(self) -> str:
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        raise NotImplementedError("This method is not implemented by SbomChecker.")


### PR DESCRIPTION
Changes:
- Move duplicate code between NTIAChecker and FSCTChecker classes to BaseChecker
- Mark SPDX 2-specific code and make room for SPDX 3 code to plug in
- Add `sbom_spec` argument to BaseChecker constructor (choices: "spdx2" and "spdx3")

Note:
- This code pass all Pytest tests.
- This code does not contain spdx-python-model dependency.
- The actual SPDX 3 parsing and conformance check will be in another PR. And it will contain spdx-python-model dependency.

