### PR TITLE
Implement all SPDX 3 getters

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install spdx-python-model==0.0.2 spdx-tools==0.8.3
+        pip install .
         pip install sphinx==8.1.3 sphinx-rtd-theme==3.0.2
 
     - name: Build documentation

--- a/README.md
+++ b/README.md
@@ -174,13 +174,14 @@ Go to this page: <https://tools.spdx.org/app/ntia_checker/>.
 
 - The project is the result of an initial [Google Summer of Code (GSoC)][gsoc]
   contribution in 2022 by [@linynjosh](https://github.com/linynjosh).
-- SPDX 3 support and improved FSCT3 checker are GSoC 2025 contribution by
-  [@bact](https://github.com/bact).
+- SPDX 3 support and improved FSCT3 checker, available in v4.0,
+  are [GSoC 2025 contribution][gsoc2025] by [@bact](https://github.com/bact).
 - The project is maintained by a community of SPDX adopters and enthusiasts.
-
-<!-- Add Linux Foundation/SPDX GSoC links here -->
+- See SPDX's participation in Google Summer of Code (GSoC):
+  <https://github.com/spdx/GSoC>.
 
 [gsoc]: https://summerofcode.withgoogle.com/
+[gsoc2025]: https://docs.google.com/document/d/1emyt1AXJUPDoHIoFdWAwdpV6nRpnmeJiCVCAzFG3T-8/edit?usp=sharing
 
 ## License
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -22,11 +22,11 @@ from spdx_tools.spdx.validation.document_validator import validate_full_spdx_doc
 from spdx_tools.spdx.validation.validation_message import ValidationMessage
 
 from .spdx3_utils import (
-    get_spdx3_boms_from_spdx_document,
-    get_spdx3_packages_from_bom,
+    get_boms_from_spdx_document,
+    get_packages_from_bom,
     iter_objects_with_property,
     iter_relationships_by_type,
-    validate_spdx3_document,
+    validate_spdx3_data,
 )
 
 SUPPORTED_SBOM_SPECS_DESC = {
@@ -183,10 +183,9 @@ class BaseChecker(ABC):
                 logging.error("Failed to parse the SPDX 3 file.")
             else:
                 self.doc = object_set
-                _doc, _validation_messages = validate_spdx3_document(object_set)
+                _doc, _validation_messages = validate_spdx3_data(object_set)
                 if not _doc or _validation_messages:
                     logging.error("SpdxDocument not found or invalid.")
-                    raise ValueError("SpdxDocument not found or invalid.")
                 self.__spdx3_doc = _doc  # cache the extracted SpdxDocument
                 self.validation_messages.extend(_validation_messages)
         else:
@@ -300,10 +299,10 @@ class BaseChecker(ABC):
 
             # There is a BOM and an /Software/Package,
             # check if there is at least one package listed in any BOM/SBOM
-            boms = get_spdx3_boms_from_spdx_document(self.__spdx3_doc)
+            boms = get_boms_from_spdx_document(self.__spdx3_doc)
             if boms:
                 for bom in boms:
-                    packages = get_spdx3_packages_from_bom(bom)
+                    packages = get_packages_from_bom(bom)
                     if packages:
                         return True
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
 from spdx_tools.spdx.model.document import Document
@@ -21,7 +21,13 @@ from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.validation.validation_message import ValidationMessage
 
-from .spdx3_utils import iter_objects_with_property, validate_spdx3_document
+from .spdx3_utils import (
+    get_spdx3_boms_from_spdx_document,
+    get_spdx3_packages_from_bom,
+    iter_objects_with_property,
+    iter_relationships_by_type,
+    validate_spdx3_document,
+)
 
 SUPPORTED_SBOM_SPECS_DESC = {
     "spdx2": "Software Package Data Exchange (SPDX) 2.x",
@@ -34,28 +40,26 @@ SUPPORTED_COMPLIANCE_STANDARDS_DESC = {
     # "cisasbom2025": "2025 CISA SBOM Minimum Elements",
     # https://www.cisa.gov/resources-tools/resources/2025-minimum-elements-software-bill-materials-sbom
     "fsct3-min": "2024 CISA Framing Software Component Transparency (minimum expectation)",
-    # https://www.cisa.gov/resources-tools/resources/framing-software-component-transparency-2024
     "ntia": "2021 NTIA SBOM Minimum Elements",
-    # https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom
 }
 DEFAULT_COMPLIANCE_STANDARD = "ntia"
 SUPPORTED_COMPLIANCE_STANDARDS = set(SUPPORTED_COMPLIANCE_STANDARDS_DESC.keys())
 
 SUPPORTED_SPDX_VERSIONS = {(2, 2), (2, 3), (3, 0)}  # (Major, Minor)
-SUPPORTED_SPDX2_VERSIONS = {
+SUPPORTED_SPDX2_VERSION_STRINGS = {
     f"SPDX-{maj}.{min}" for (maj, min) in SUPPORTED_SPDX_VERSIONS if maj == 2
-}
-SUPPORTED_SPDX3_VERSIONS = {
+}  # e.g. "SPDX-2.2", "SPDX-2.3"
+SUPPORTED_SPDX3_VERSION_STRINGS = {
     f"{maj}.{min}" for (maj, min) in SUPPORTED_SPDX_VERSIONS if maj == 3
-}
+}  # e.g. "3.0"
 
 
 # pylint: disable=too-many-instance-attributes
 class BaseChecker(ABC):
     """Base class for all compliance/conformance checkers.
 
-    This base class contains methods for common tasks like file loading
-    and parsing.
+    This base class contains methods for common tasks like file parsing
+    and information extractions from the SBOM.
 
     Any class inheriting from BaseChecker must implement its abstract methods,
     such as `check_compliance` and `output_json`.
@@ -70,7 +74,7 @@ class BaseChecker(ABC):
     file: str = ""
     # For SPDX 3, we have to use SHACLObjectSet instead of SpdxDocument,
     # because we need access to relationships and other elements that are not
-    # part of SpdxDocument.
+    # accesible from SpdxDocument.
     doc: Union[Document, spdx3.SHACLObjectSet, None] = None
     __spdx3_doc: Optional[spdx3.SpdxDocument] = None  # cached SPDX 3 document
 
@@ -159,6 +163,11 @@ class BaseChecker(ABC):
 
         self.file = file
 
+        # Make sure the logs are instance variables and not class variables
+        # to avoid shared state between instances.
+        self.parsing_error = []
+        self.validation_messages = []
+
         # SPDX 2
         if sbom_spec == "spdx2":
             self.doc = self.parse_file()
@@ -177,6 +186,7 @@ class BaseChecker(ABC):
                 _doc, _validation_messages = validate_spdx3_document(object_set)
                 if not _doc or _validation_messages:
                     logging.error("SpdxDocument not found or invalid.")
+                    raise ValueError("SpdxDocument not found or invalid.")
                 self.__spdx3_doc = _doc  # cache the extracted SpdxDocument
                 self.validation_messages.extend(_validation_messages)
         else:
@@ -191,6 +201,13 @@ class BaseChecker(ABC):
                     self.validation_messages = validate_full_spdx_document(self.doc)
                 else:
                     pass
+
+            self.sbom_name = self.get_sbom_name()
+
+            self.doc_version = self.check_doc_version()
+            self.doc_author = self.check_author()
+            self.doc_timestamp = self.check_timestamp()
+            self.dependency_relationships = self.check_dependency_relationships()
 
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = cast(
@@ -209,32 +226,39 @@ class BaseChecker(ABC):
                 List[str], self.get_components_without_copyright_texts()
             )
 
-    def get_doc_spec_version(self) -> Optional[str]:
-        """Retrieve the document's specification version."""
-        if not self.doc:
-            return None
-
-        doc_spec_version: Optional[str] = None
-
-        # SPDX 2
-        if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
-            doc_creation_info = getattr(self.doc, "creation_info", None)
-            if doc_creation_info:
-                doc_spec_version = getattr(doc_creation_info, "spdx_version", None)
-
-        # SPDX 3
-        if self.sbom_spec == "spdx3" and isinstance(self.__spdx3_doc, spdx3.SpdxDocument):
-            doc_creation_info = getattr(self.__spdx3_doc, "creationInfo", None)
-            if doc_creation_info:
-                doc_spec_version = getattr(doc_creation_info, "specVersion", None)
-
-        return doc_spec_version
-
     def check_doc_version(self) -> bool:
         """Check if the document's specification version exists."""
         if self.get_doc_spec_version():
             return True
+        return False
+
+    def check_author(self) -> bool:
+        """Check if the author of SBOM data exists."""
+        if not self.doc:
+            return False
+
+        # SPDX 2
+        if self.sbom_spec == "spdx2":
+            # Note that the spdx-tools's parser will raise an SPDXParsingError
+            # anyway, if the document does not contain a creator.
+            # So in practice, this section should always return True
+            self.doc = cast(Document, self.doc)
+            doc_creation_info = getattr(self.doc, "creation_info", None)
+            if doc_creation_info:
+                doc_creators = getattr(doc_creation_info, "creators", [])
+                if doc_creators:
+                    return True
+            return False
+
+        # SPDX 3
+        if self.sbom_spec == "spdx3" and self.__spdx3_doc is not None:
+            doc_creation_info = getattr(self.__spdx3_doc, "creationInfo", None)
+            if doc_creation_info:
+                doc_creators = getattr(doc_creation_info, "createdBy", [])
+                if doc_creators:
+                    return True
+            return False
+
         return False
 
     def check_dependency_relationships(self) -> bool:
@@ -267,9 +291,75 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            return False
+            # If a BOM/an SBOM's rootElement is a /Software/Package (or its subclass),
+            # it is considered to have a relationship.
+            #
+            # Note that if there is neither /Software/Package(s) nor /Core/Bom,
+            # a DESCRIBES relationship is not needed; however, this method may still
+            # return False, since it is factually considered as "no relationship".
+
+            # There is a BOM and an /Software/Package,
+            # check if there is at least one package listed in any BOM/SBOM
+            boms = get_spdx3_boms_from_spdx_document(self.__spdx3_doc)
+            if boms:
+                for bom in boms:
+                    packages = get_spdx3_packages_from_bom(bom)
+                    if packages:
+                        return True
 
         return False
+
+    def check_timestamp(self) -> bool:
+        """Check if the SBOM creation timestamp exists."""
+        if not self.doc:
+            return False
+
+        # SPDX 2
+        if self.sbom_spec == "spdx2":
+            # Note that the spdx-tools's parser will raise an SPDXParsingError,
+            # if the document does not contain a timestamp.
+            # So in practice, this section should always return True.
+            self.doc = cast(Document, self.doc)
+            doc_creation_info = getattr(self.doc, "creation_info", None)
+            if doc_creation_info:
+                doc_created = getattr(doc_creation_info, "created", None)
+                if doc_created:
+                    return True
+            return False
+
+        # SPDX 3
+        if self.sbom_spec == "spdx3" and self.__spdx3_doc is not None:
+            doc_creation_info = getattr(self.__spdx3_doc, "creationInfo", None)
+            if doc_creation_info:
+                doc_created = getattr(doc_creation_info, "created", None)
+                if doc_created:
+                    return True
+
+        return False
+
+    def get_doc_spec_version(self) -> Optional[str]:
+        """Retrieve the document's specification version."""
+        if not self.doc:
+            return None
+
+        doc_spec_version: Optional[str] = None
+
+        # SPDX 2
+        if self.sbom_spec == "spdx2":
+            self.doc = cast(Document, self.doc)
+            doc_creation_info = getattr(self.doc, "creation_info", None)
+            if doc_creation_info:
+                doc_spec_version = getattr(doc_creation_info, "spdx_version", None)
+
+        # SPDX 3
+        if self.sbom_spec == "spdx3" and isinstance(
+            self.__spdx3_doc, spdx3.SpdxDocument
+        ):
+            doc_creation_info = getattr(self.__spdx3_doc, "creationInfo", None)
+            if doc_creation_info:
+                doc_spec_version = getattr(doc_creation_info, "specVersion", None)
+
+        return doc_spec_version
 
     def get_sbom_name(self) -> str:
         """Retrieve the name of the SBOM."""
@@ -286,11 +376,15 @@ class BaseChecker(ABC):
                 name = getattr(doc_creation_info, "name", "")
 
         # SPDX 3
-        if self.sbom_spec == "spdx3" and isinstance(self.__spdx3_doc, spdx3.SpdxDocument):
+        elif self.sbom_spec == "spdx3" and isinstance(
+            self.__spdx3_doc, spdx3.SpdxDocument
+        ):
             name = getattr(self.__spdx3_doc, "name", "")
 
         return name
 
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-return-statements
     def get_components_without_concluded_licenses(
         self, return_tuples: bool = False
     ) -> Union[List[str], List[Tuple[str, str]]]:
@@ -346,9 +440,45 @@ class BaseChecker(ABC):
             return components_name
 
         # SPDX 3
-        # Add code to retrieve components without concluded licenses for SPDX 3 here
+        if self.sbom_spec == "spdx3":
+            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+
+            has_concluded_license_ids: Set[str] = {
+                from_id
+                for from_id, to_id in iter_relationships_by_type(
+                    self.doc, "hasConcludedLicense"
+                )
+                if to_id.strip()
+                != spdx3.expandedlicensing_IndividualLicensingInfo.NAMED_INDIVIDUALS[
+                    "NoAssertionLicense"
+                ]
+            }
+
+            if return_tuples:
+                return [
+                    (name, spdx_id)
+                    for name, spdx_id, _ in iter_objects_with_property(
+                        self.doc,
+                        spdx3.software_Package,
+                        "spdxId",
+                    )
+                    if spdx_id not in has_concluded_license_ids
+                ]
+
+            return [
+                name
+                for name, spdx_id, _ in iter_objects_with_property(
+                    self.doc,
+                    spdx3.software_Package,
+                    "spdxId",
+                )
+                if spdx_id not in has_concluded_license_ids
+            ]
+
         return []
 
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-return-statements
     def get_components_without_copyright_texts(
         self, return_tuples: bool = False
     ) -> Union[List[str], List[Tuple[str, str]]]:
@@ -403,15 +533,45 @@ class BaseChecker(ABC):
             return components_name
 
         # SPDX 3
-        # Add code to retrieve components without copyright texts for SPDX 3 here
+        if self.sbom_spec == "spdx3":
+            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+
+            if return_tuples:
+                return [
+                    (name, spdx_id)
+                    for name, spdx_id, copyright_text in iter_objects_with_property(
+                        self.doc,
+                        spdx3.software_Package,
+                        "software_copyrightText",
+                    )
+                    if not copyright_text
+                    or (
+                        isinstance(copyright_text, str) and copyright_text.strip() == ""
+                    )
+                ]
+
+            return [
+                name
+                for name, _, copyright_text in iter_objects_with_property(
+                    self.doc, spdx3.software_Package, "software_copyrightText"
+                )
+                if not copyright_text
+                or (isinstance(copyright_text, str) and copyright_text.strip() == "")
+            ]
+
         return []
 
     def get_components_without_identifiers(self) -> List[str]:
         """
         Retrieve name of components without identifiers.
 
+        Note that SPDX 3 requires identifiers for all elements,
+        so this should not happen in a valid SPDX 3 document.
+        spdx-python-model JSON deserializer will raise a ValueError
+        if any element is missing an identifier.
+
         Returns:
-            List[str]: A list of component names that do not have identifiers.
+            List[str]: A list of component names.
         """
         if not self.doc:
             return []
@@ -426,21 +586,25 @@ class BaseChecker(ABC):
             ]
 
         # SPDX 3
-        # Add code to retrieve components without identifiers for SPDX 3 here
+        if self.sbom_spec == "spdx3":
+            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+
+            return [
+                name
+                for name, _, spdx_id in iter_objects_with_property(
+                    self.doc, spdx3.Element, "spdxId"
+                )
+                if not spdx_id or spdx_id.strip() == ""
+            ]
+
         return []
 
     def get_components_without_names(self) -> List[str]:
         """
         Retrieve SPDX ID of components without names.
 
-        Args:
-            return_tuples (bool): If True, return a list of tuples with
-                                  component names and SPDX IDs.
-                                  If False, return a list of component names.
-
         Returns:
-            Union[List[str], List[Tuple[str, str]]]: A list of component names
-            or a list of tuples with component names and SPDX IDs.
+            List[str]: A list of component SPDX IDs.
         """
         if not self.doc:
             return []
@@ -457,7 +621,17 @@ class BaseChecker(ABC):
             return components_without_names
 
         # SPDX 3
-        # Add code to retrieve components without names for SPDX 3 here
+        if self.sbom_spec == "spdx3":
+            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+
+            return [
+                spdx_id
+                for _, spdx_id, name in iter_objects_with_property(
+                    self.doc, spdx3.software_Package, "name"
+                )
+                if not name or name.strip() == ""
+            ]
+
         return []
 
     # pylint: disable=too-many-branches
@@ -512,18 +686,18 @@ class BaseChecker(ABC):
             if return_tuples:
                 return [
                     (name, spdx_id)
-                    for name, spdx_id, supplier_name in iter_objects_with_property(
-                        self.doc, spdx3.Artifact, "suppliedBy"
+                    for name, spdx_id, supplier in iter_objects_with_property(
+                        self.doc, spdx3.software_Package, "suppliedBy"
                     )
-                    if not supplier_name
+                    if not supplier or not supplier.name or supplier.name.strip() == ""
                 ]
 
             return [
                 name
-                for name, _, supplier_name in iter_objects_with_property(
-                    self.doc, spdx3.Artifact, "suppliedBy"
+                for name, _, supplier in iter_objects_with_property(
+                    self.doc, spdx3.software_Package, "suppliedBy"
                 )
-                if not supplier_name
+                if not supplier or not supplier.name or supplier.name.strip() == ""
             ]
 
         return []
@@ -566,7 +740,26 @@ class BaseChecker(ABC):
             return components_name
 
         # SPDX 3
-        # Add code to retrieve components without versions for SPDX 3 here
+        if self.sbom_spec == "spdx3":
+            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+
+            if return_tuples:
+                return [
+                    (name, spdx_id)
+                    for name, spdx_id, package_version in iter_objects_with_property(
+                        self.doc, spdx3.software_Package, "software_packageVersion"
+                    )
+                    if not package_version or package_version.strip() == ""
+                ]
+
+            return [
+                name
+                for name, _, package_version in iter_objects_with_property(
+                    self.doc, spdx3.software_Package, "software_packageVersion"
+                )
+                if not package_version or package_version.strip() == ""
+            ]
+
         return []
 
     def get_total_number_components(self) -> int:
@@ -587,7 +780,11 @@ class BaseChecker(ABC):
             return len(self.doc.packages)
 
         # SPDX 3
-        # Add code to retrieve total number of components for SPDX 3 here
+        if self.sbom_spec == "spdx3":
+            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            objects: Set[spdx3.SHACLObject] = getattr(self.doc, "objects", set())
+            return len(objects)
+
         return 0
 
     def parse_file(self) -> Optional[Document]:

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -54,8 +54,8 @@ def get_parsed_args() -> argparse.Namespace:
         + "\n\n"
         "Examples:\n"
         "  sbomcheck sbom.spdx\n"
-        "  sbomcheck --sbom-spec spdx3 --comply fsct3-min -v sbom.json\n"
-        "  sbomcheck --output json --output-file report.json sbom.yaml\n"
+        "  sbomcheck -s spdx3 -c fsct3-min -v sbom.json\n"
+        "  sbomcheck sbom.yaml --output json --output-file report.json\n"
     )
 
     parser = argparse.ArgumentParser(
@@ -157,7 +157,7 @@ def get_parsed_args() -> argparse.Namespace:
     return args
 
 
-def get_spdx_version(file: str, sbom_spec="spdx2") -> Optional[Tuple[int, int]]:
+def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> Optional[Tuple[int, int]]:
     """
     Detect the SPDX version of the SBOM file.
 

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -24,7 +24,7 @@ class FSCT3Checker(BaseChecker):
     This checker currently only checks for Minimum Expected maturity level.
 
     See:
-    https://www.cisa.gov/resources-tools/resources/framing-software-component-transparency-2024
+        https://www.cisa.gov/resources-tools/resources/framing-software-component-transparency-2024
     """
 
     def __init__(
@@ -51,12 +51,10 @@ class FSCT3Checker(BaseChecker):
             raise ValueError("Only FSCTv3 Minimum Expected compliance is supported.")
 
         if self.doc:
-            self.sbom_name = self.get_sbom_name()
-            self.doc_version = self.check_doc_version()
-            self.doc_author = True  # Assume author is present?
-            self.doc_timestamp = True  # Assume timestamp is present?
-            self.dependency_relationships = self.check_dependency_relationships()
             self.compliant = self.check_compliance()
+
+            # for backward compatibility
+            self.ntia_minimum_elements_compliant = self.compliant
 
     def check_compliance(self) -> bool:
         """Check overall compliance with FSCTv3 Minimum Expected"""

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -15,7 +15,7 @@ from .base_checker import BaseChecker
 class NTIAChecker(BaseChecker):
     """
     NTIA Minimum Elements check.
-    
+
     See:
         https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom
     """

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -13,7 +13,12 @@ from .base_checker import BaseChecker
 
 
 class NTIAChecker(BaseChecker):
-    """NTIA Minimum Elements check."""
+    """
+    NTIA Minimum Elements check.
+    
+    See:
+        https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom
+    """
 
     def __init__(
         self,
@@ -39,11 +44,6 @@ class NTIAChecker(BaseChecker):
             raise ValueError("Only NTIA Minimum Element compliance is supported.")
 
         if self.doc:
-            self.sbom_name = self.get_sbom_name()
-            self.doc_version = self.check_doc_version()
-            self.doc_author = True  # Assume author is present?
-            self.doc_timestamp = True  # Assume timestamp is present?
-            self.dependency_relationships = self.check_dependency_relationships()
             self.compliant = self.check_compliance()
 
             # for backward compatibility

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -93,7 +93,7 @@ def get_spdx3_boms_from_spdx_document(
     spdx_doc: Optional[spdx3.SpdxDocument],
 ) -> Optional[List[spdx3.Bom]]:
     """
-    Retrieve the BOMs that are rootElements of an SPDX 3 document.
+    Retrieve the BOMs that are rootElements of an SPDX 3 SpdxDocument.
 
     Args:
         spdx_doc (spdx3.SpdxDocument): The SPDX 3 SpdxDocument.
@@ -111,7 +111,7 @@ def get_spdx3_boms_from_spdx_document(
     return root_elements
 
 
-def get_spdx3_packages_from_spdx_bom(
+def get_spdx3_packages_from_bom(
     bom: Optional[spdx3.Bom],
 ) -> Optional[List[spdx3.software_Package]]:
     """

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -15,7 +15,7 @@ from spdx_tools.spdx.validation.validation_message import (
 )
 
 
-def validate_spdx3_document(
+def validate_spdx3_data(
     object_set: spdx3.SHACLObjectSet,
 ) -> Tuple[Optional[spdx3.SpdxDocument], List[ValidationMessage]]:
     """
@@ -89,7 +89,7 @@ def validate_spdx3_document(
     return (doc, validation_messages)
 
 
-def get_spdx3_boms_from_spdx_document(
+def get_boms_from_spdx_document(
     spdx_doc: Optional[spdx3.SpdxDocument],
 ) -> Optional[List[spdx3.Bom]]:
     """
@@ -111,7 +111,7 @@ def get_spdx3_boms_from_spdx_document(
     return root_elements
 
 
-def get_spdx3_packages_from_bom(
+def get_packages_from_bom(
     bom: Optional[spdx3.Bom],
 ) -> Optional[List[spdx3.software_Package]]:
     """
@@ -185,6 +185,7 @@ def iter_relationships_by_type(
 def get_all_packages(object_set: spdx3.SHACLObjectSet) -> Set[spdx3.software_Package]:
     """Retrieve all /Software/Package objects from an SHACLObjectSet."""
     packages: Set[spdx3.software_Package] = {
-        cast(spdx3.software_Package, obj) for obj in object_set.foreach_type("software_Package")
+        cast(spdx3.software_Package, obj)
+        for obj in object_set.foreach_type("software_Package")
     }
     return packages

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for SPDX 3."""
+
+from __future__ import annotations
+
+from typing import Any, Iterator, List, Optional, Set, Tuple, Type, cast
+
+from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
+from spdx_tools.spdx.validation.validation_message import (
+    ValidationContext,
+    ValidationMessage,
+)
+
+
+def validate_spdx3_document(
+    object_set: spdx3.SHACLObjectSet,
+) -> Tuple[Optional[spdx3.SpdxDocument], List[ValidationMessage]]:
+    """
+    Validate an SHACLObjectSet if it contains a valid SpdxDocument.
+
+    The SPDX 3.0 specification states that "Any instance of serialization of
+    SPDX data MUST NOT contain more than one SpdxDocument element definition."
+
+    See: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/SpdxDocument/
+
+    For the purpose of BOM/SBOM application, it also requires that the
+    SpdxDocument should have a Bom or Software/Sbom as its rootElement.
+
+    See: https://github.com/spdx/ntia-conformance-checker/issues/268
+
+    Args:
+        object_set (spdx3.SHACLObjectSet): The SHACLObjectSet containing
+                                            the SPDX 3 document.
+    Returns:
+        Optional[spdx3.SpdxDocument]: An SpdxDocument if found, otherwise None.
+        List[ValidationMessage]: A list of validation messages. Empty if no errors.
+
+    """
+    # Note that we use spdx_tools.spdx.validation.validation_message,
+    # which is originally meant for SPDX 2, to report validation errors for
+    # SPDX 3 as well, so the print/HTML/JSON output functions can be reused.
+
+    doc: Optional[spdx3.SpdxDocument] = None
+    validation_messages: List[ValidationMessage] = []
+
+    spdx_documents: List[spdx3.SpdxDocument] = [
+        cast(spdx3.SpdxDocument, obj) for obj in object_set.foreach_type("SpdxDocument")
+    ]
+
+    if not spdx_documents:
+        error_msg = (
+            "No SpdxDocument object found in the SPDX 3 JSON file. "
+            "Expected exactly one."
+        )
+        validation_messages.append(ValidationMessage(error_msg, ValidationContext()))
+        return (doc, validation_messages)
+
+    if len(spdx_documents) != 1:
+        error_msg = "Multiple SpdxDocument objects found. Allows exactly one."
+        validation_messages.append(ValidationMessage(error_msg, ValidationContext()))
+        return (doc, validation_messages)
+
+    doc = spdx_documents[0]
+    doc_id = getattr(doc, "spdxId", None)
+    root_element = getattr(doc, "rootElement", None)
+
+    if not root_element:
+        error_msg = "No rootElement found in the SpdxDocument. Expected exactly one."
+        context = ValidationContext(parent_id=doc_id)
+        validation_messages.append(ValidationMessage(error_msg, context))
+    elif len(root_element) != 1:
+        error_msg = "Multiple root elements found in SpdxDocument. Allows exactly one."
+        context = ValidationContext(parent_id=doc_id)
+        validation_messages.append(ValidationMessage(error_msg, context))
+    else:
+        root_element = root_element[0]
+        if not isinstance(root_element, (spdx3.Bom, spdx3.software_Sbom)):
+            error_msg = (
+                "The root element must be of type Bom or software_Sbom. "
+                f"Found: {type(root_element)}"
+            )
+            root_element_id = getattr(root_element, "spdxId", None)
+            context = ValidationContext(parent_id=doc_id, spdx_id=root_element_id)
+            validation_messages.append(ValidationMessage(error_msg, context))
+
+    return (doc, validation_messages)
+
+
+def get_spdx3_boms_from_spdx_document(
+    spdx_doc: Optional[spdx3.SpdxDocument],
+) -> Optional[List[spdx3.Bom]]:
+    """
+    Retrieve the BOMs that are rootElements of an SPDX 3 document.
+
+    Args:
+        spdx_doc (spdx3.SpdxDocument): The SPDX 3 SpdxDocument.
+
+    Returns:
+        Optional[List[spdx3.Bom]]: The Boms if found, otherwise None.
+    """
+    if not spdx_doc:
+        return None
+
+    root_elements: List[spdx3.Bom] = getattr(spdx_doc, "rootElement", [])
+    if not root_elements:
+        return None
+
+    return root_elements
+
+
+def get_spdx3_packages_from_spdx_bom(
+    bom: Optional[spdx3.Bom],
+) -> Optional[List[spdx3.software_Package]]:
+    """
+    Retrieve the /Software/Packages that are rootElements of an SPDX 3 BOM.
+
+    Args:
+        spdx_doc (spdx3.Bom): The SPDX 3 Bom.
+
+    Returns:
+        Optional[List[spdx3.software_Package]]: The packages if found, otherwise None.
+    """
+    if not bom:
+        return None
+
+    root_elements: List[spdx3.software_Package] = getattr(bom, "rootElement", [])
+    if not root_elements or len(root_elements) != 1:
+        return None
+
+    return root_elements
+
+
+def iter_objects_with_property(
+    object_set: spdx3.SHACLObjectSet,
+    typ: Type[spdx3.SHACLObject] = spdx3.Artifact,
+    property_name: str = "spdxId",
+) -> Iterator[Tuple[str, str, Any]]:
+    """
+    Yield (name, spdxId, property) for each SPDX 3 object.
+
+    Args:
+        object_set (spdx3.SHACLObjectSet): The SHACLObjectSet to iterate over.
+        typ (Type[spdx3.SHACLObject]): The type of SPDX3 object
+        property_name (str): The property name to retrieve.
+
+    Yields:
+        Iterator[Tuple[str, str, Any]]: A tuple containing the name,
+        SPDX ID, and the specified property of the object.
+    """
+
+    for obj in object_set.foreach_type(typ.__name__):
+        name = (getattr(obj, "name", "") or "").strip()
+        spdx_id = (getattr(obj, "spdxId", "") or "").strip()
+        property_ = getattr(obj, property_name, None)
+        yield name, spdx_id, property_
+
+
+def iter_relationships_by_type(
+    object_set: spdx3.SHACLObjectSet,
+    rel_type: str,
+) -> Iterator[Tuple[str, str]]:
+    """
+    Yield (from_id, to_id) for each relationship of the specified relationship type.
+    """
+
+    for obj in object_set.foreach_type("Relationship"):
+        _rel_type = getattr(obj, "relationshipType", "")
+        # Remove the IRI prefix of entry name before compare
+        if not _rel_type or _rel_type.split("/")[-1] != rel_type:
+            continue
+        from_: Optional[spdx3.Element] = getattr(obj, "from_", None)
+        to: Optional[spdx3.Element] = getattr(obj, "to", None)
+        if not from_ or not to:
+            continue
+
+        from_id = getattr(from_, "spdxId", "")
+        to_id = getattr(to, "spdxId", "")
+
+        yield from_id, to_id
+
+
+def get_all_packages(object_set: spdx3.SHACLObjectSet) -> Set[spdx3.software_Package]:
+    """Retrieve all /Software/Package objects from an SHACLObjectSet."""
+    packages: Set[spdx3.software_Package] = {
+        cast(spdx3.software_Package, obj) for obj in object_set.foreach_type("software_Package")
+    }
+    return packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ keywords = [
     "software component transparency",
     "supply chain security",
 ]
-dependencies = ["spdx-python-model==0.0.2", "spdx-tools==0.8.3"]
+dependencies = ["spdx-python-model==0.0.3", "spdx-tools==0.8.3"]
 
 [project.optional-dependencies]
 test = ["beartype==0.21.0", "coverage==7.6.10", "pytest==8.4.1"]

--- a/tests/data/spdx3/missing_identifier.json
+++ b/tests/data/spdx3/missing_identifier.json
@@ -50,7 +50,8 @@
       ],
       "rootElement": [
         "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab"
-      ]
+      ],
+      "name": "SBOM for CO2 Emissions dataset"
     },
     {
       "type": "software_Sbom",
@@ -71,7 +72,7 @@
       "type": "dataset_DatasetPackage",
       "spdxId": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
       "creationInfo": "_:creationinfo",
-      "name": "Our World in Data CO2 and Greenhouse Gas Emissions dataset",
+      "name": "CO2 Emissions dataset",
       "originatedBy": [
         "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
       ],
@@ -116,7 +117,6 @@
     },
     {
       "type": "software_File",
-      "spdxId": "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
       "creationInfo": "_:creationinfo",
       "name": "data.csv",
       "contentType": "text/csv;charset=UTF-8",
@@ -146,21 +146,9 @@
       "relationshipType": "contains",
       "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
       "to": [
-        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
         "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f"
       ],
       "description": "DatasetPackage1 contains data.csv and codebook.csv."
-    },
-    {
-      "type": "Relationship",
-      "spdxId": "https://spdx.org/spdxdocs/Relationship/describes-de3f5855-bd5a-403f-9aa6-95dd97599c32",
-      "creationInfo": "_:creationinfo",
-      "relationshipType": "describes",
-      "from": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
-      "to": [
-        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8"
-      ],
-      "description": "codebook.csv describes data.csv."
     },
     {
       "type": "Relationship",

--- a/tests/data/spdx3/missing_supplier_name.json
+++ b/tests/data/spdx3/missing_supplier_name.json
@@ -1,0 +1,196 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": [
+        "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1"
+      ],
+      "created": "2024-05-31T00:00:00Z"
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1",
+      "creationInfo": "_:creationinfo",
+      "name": "Arthit Suriyawongkul",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "suriyawa@tcd.ie"
+        }
+      ]
+    },
+    {
+      "type": "Organization",
+      "spdxId": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
+      "creationInfo": "_:creationinfo",
+      "name": "Our World in Data",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "other",
+          "issuingAuthority": "GitHub",
+          "identifier": "owid",
+          "identifierLocator": [
+            "https://github.com/owid/"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://spdx.org/spdxdocs/Document1-a7a6f7a8-68d5-4052-b3f7-a005d6af28f1",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab"
+      ],
+      "name": "SBOM for CO2 Emissions dataset"
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b"
+      ],
+      "software_sbomType": [
+        "analyzed"
+      ]
+    },
+    {
+      "type": "dataset_DatasetPackage",
+      "spdxId": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "creationInfo": "_:creationinfo",
+      "name": "CO2 Emissions dataset",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "builtTime": "2023-12-16T11:22:38Z",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "software_packageVersion": "2024-04-15",
+      "software_copyrightText": "Copyright Our World in Data",
+      "software_downloadLocation": "https://github.com/owid/co2-data/",
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "32657f0d033fc07a7420be36a6af9083c6a63489"
+        },
+        {
+          "type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "434d75c84cf86456c16193dbc53beef31eb63f3387425882ddb2ef6acb9d472c"
+        }
+      ],
+      "software_primaryPurpose": "data",
+      "dataset_confidentialityLevel": "clear",
+      "dataset_dataPreprocessing": [
+        "The dataset is built upon a number of datasets and processing steps.",
+        "See https://github.com/owid/co2-data/blob/master/README.md for sources and processing codes."
+      ],
+      "dataset_datasetAvailability": "directDownload",
+      "dataset_dataCollectionProcess": "The data is collected from various sources, including international organizations and research institutions.",
+      "dataset_datasetSize": 2689,
+      "dataset_datasetType": [
+        "structured",
+        "timestamp"
+      ],
+      "dataset_datasetUpdateMechanism": "Publish updated data as it becomes available. Most are on an annual basis.",
+      "dataset_hasSensitivePersonalInformation": "no",
+      "dataset_intendedUse": "To make the data about greenhouse gas emissions accessible.",
+      "dataset_knownBias": [
+        "Data in some geographical areas are more completed than the others."
+      ],
+      "comment": "This is a small excerpt of the full dataset."
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+      "creationInfo": "_:creationinfo",
+      "name": "data.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "creationInfo": "_:creationinfo",
+      "name": "codebook.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "description": "A description of each column in data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/contains-c64903fa-cab9-4880-8065-0b9b226ce009",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "contains",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+        "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f"
+      ],
+      "description": "DatasetPackage1 contains data.csv and codebook.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/describes-de3f5855-bd5a-403f-9aa6-95dd97599c32",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "describes",
+      "from": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8"
+      ],
+      "description": "codebook.csv describes data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/concludedLicense-8575546c-c4f7-41ec-bb8f-cbd66e70090a",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasConcludedLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a concluded license as CC-BY-4.0."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/declaredLicense-e5536c5e-c8b5-4d24-947f-674c27c0b6c1",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasDeclaredLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a declared license as CC-BY-4.0."
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://spdx.org/licenses/CC-BY-4.0",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "CC-BY-4.0",
+      "simplelicensing_licenseListVersion": "3.25.0",
+      "comment": "Added as a workaround for the lack of https://spdx.org/licenses/CC-BY-4.0 as a valid ListedLicense in SPDX 3.0.1 RDF. This will be removed once https://github.com/spdx/LicenseListPublisher/issues/183 is implemented."
+    }
+  ]
+}

--- a/tests/data/spdx3/missing_version.json
+++ b/tests/data/spdx3/missing_version.json
@@ -1,0 +1,196 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": [
+        "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1"
+      ],
+      "created": "2024-05-31T00:00:00Z"
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1",
+      "creationInfo": "_:creationinfo",
+      "name": "Arthit Suriyawongkul",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "suriyawa@tcd.ie"
+        }
+      ]
+    },
+    {
+      "type": "Organization",
+      "spdxId": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
+      "creationInfo": "_:creationinfo",
+      "name": "Our World in Data",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "other",
+          "issuingAuthority": "GitHub",
+          "identifier": "owid",
+          "identifierLocator": [
+            "https://github.com/owid/"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://spdx.org/spdxdocs/Document1-a7a6f7a8-68d5-4052-b3f7-a005d6af28f1",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab"
+      ],
+      "name": "SBOM for CO2 Emissions dataset"
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b"
+      ],
+      "software_sbomType": [
+        "analyzed"
+      ]
+    },
+    {
+      "type": "dataset_DatasetPackage",
+      "spdxId": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "creationInfo": "_:creationinfo",
+      "name": "CO2 Emissions dataset",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "suppliedBy": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
+      "builtTime": "2023-12-16T11:22:38Z",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "software_copyrightText": "Copyright Our World in Data",
+      "software_downloadLocation": "https://github.com/owid/co2-data/",
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "32657f0d033fc07a7420be36a6af9083c6a63489"
+        },
+        {
+          "type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "434d75c84cf86456c16193dbc53beef31eb63f3387425882ddb2ef6acb9d472c"
+        }
+      ],
+      "software_primaryPurpose": "data",
+      "dataset_confidentialityLevel": "clear",
+      "dataset_dataPreprocessing": [
+        "The dataset is built upon a number of datasets and processing steps.",
+        "See https://github.com/owid/co2-data/blob/master/README.md for sources and processing codes."
+      ],
+      "dataset_datasetAvailability": "directDownload",
+      "dataset_dataCollectionProcess": "The data is collected from various sources, including international organizations and research institutions.",
+      "dataset_datasetSize": 2689,
+      "dataset_datasetType": [
+        "structured",
+        "timestamp"
+      ],
+      "dataset_datasetUpdateMechanism": "Publish updated data as it becomes available. Most are on an annual basis.",
+      "dataset_hasSensitivePersonalInformation": "no",
+      "dataset_intendedUse": "To make the data about greenhouse gas emissions accessible.",
+      "dataset_knownBias": [
+        "Data in some geographical areas are more completed than the others."
+      ],
+      "comment": "This is a small excerpt of the full dataset."
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+      "creationInfo": "_:creationinfo",
+      "name": "data.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "creationInfo": "_:creationinfo",
+      "name": "codebook.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "description": "A description of each column in data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/contains-c64903fa-cab9-4880-8065-0b9b226ce009",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "contains",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+        "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f"
+      ],
+      "description": "DatasetPackage1 contains data.csv and codebook.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/describes-de3f5855-bd5a-403f-9aa6-95dd97599c32",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "describes",
+      "from": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8"
+      ],
+      "description": "codebook.csv describes data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/concludedLicense-8575546c-c4f7-41ec-bb8f-cbd66e70090a",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasConcludedLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a concluded license as CC-BY-4.0."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/declaredLicense-e5536c5e-c8b5-4d24-947f-674c27c0b6c1",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasDeclaredLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a declared license as CC-BY-4.0."
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://spdx.org/licenses/CC-BY-4.0",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "CC-BY-4.0",
+      "simplelicensing_licenseListVersion": "3.25.0",
+      "comment": "Added as a workaround for the lack of https://spdx.org/licenses/CC-BY-4.0 as a valid ListedLicense in SPDX 3.0.1 RDF. This will be removed once https://github.com/spdx/LicenseListPublisher/issues/183 is implemented."
+    }
+  ]
+}

--- a/tests/data/spdx3/no_elements_missing.json
+++ b/tests/data/spdx3/no_elements_missing.json
@@ -1,0 +1,197 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": [
+        "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1"
+      ],
+      "created": "2024-05-31T00:00:00Z"
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://spdx.org/spdxdocs/Person1-1000e6a2-0229-4875-baa7-c99be213b6e1",
+      "creationInfo": "_:creationinfo",
+      "name": "Arthit Suriyawongkul",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "suriyawa@tcd.ie"
+        }
+      ]
+    },
+    {
+      "type": "Organization",
+      "spdxId": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
+      "creationInfo": "_:creationinfo",
+      "name": "Our World in Data",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "other",
+          "issuingAuthority": "GitHub",
+          "identifier": "owid",
+          "identifierLocator": [
+            "https://github.com/owid/"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://spdx.org/spdxdocs/Document1-a7a6f7a8-68d5-4052-b3f7-a005d6af28f1",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab"
+      ],
+      "name": "SBOM for CO2 Emissions dataset"
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "https://spdx.org/spdxdocs/SBOM1-d44af211-2646-43bc-9058-f6aabd30f7ab",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "dataset"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b"
+      ],
+      "software_sbomType": [
+        "analyzed"
+      ]
+    },
+    {
+      "type": "dataset_DatasetPackage",
+      "spdxId": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "creationInfo": "_:creationinfo",
+      "name": "CO2 Emissions dataset",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "suppliedBy": "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b",
+      "builtTime": "2023-12-16T11:22:38Z",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "software_packageVersion": "2024-04-15",
+      "software_copyrightText": "Copyright Our World in Data",
+      "software_downloadLocation": "https://github.com/owid/co2-data/",
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "32657f0d033fc07a7420be36a6af9083c6a63489"
+        },
+        {
+          "type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "434d75c84cf86456c16193dbc53beef31eb63f3387425882ddb2ef6acb9d472c"
+        }
+      ],
+      "software_primaryPurpose": "data",
+      "dataset_confidentialityLevel": "clear",
+      "dataset_dataPreprocessing": [
+        "The dataset is built upon a number of datasets and processing steps.",
+        "See https://github.com/owid/co2-data/blob/master/README.md for sources and processing codes."
+      ],
+      "dataset_datasetAvailability": "directDownload",
+      "dataset_dataCollectionProcess": "The data is collected from various sources, including international organizations and research institutions.",
+      "dataset_datasetSize": 2689,
+      "dataset_datasetType": [
+        "structured",
+        "timestamp"
+      ],
+      "dataset_datasetUpdateMechanism": "Publish updated data as it becomes available. Most are on an annual basis.",
+      "dataset_hasSensitivePersonalInformation": "no",
+      "dataset_intendedUse": "To make the data about greenhouse gas emissions accessible.",
+      "dataset_knownBias": [
+        "Data in some geographical areas are more completed than the others."
+      ],
+      "comment": "This is a small excerpt of the full dataset."
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+      "creationInfo": "_:creationinfo",
+      "name": "data.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "creationInfo": "_:creationinfo",
+      "name": "codebook.csv",
+      "contentType": "text/csv;charset=UTF-8",
+      "software_primaryPurpose": "data",
+      "releaseTime": "2024-04-15T08:10:00Z",
+      "originatedBy": [
+        "https://spdx.org/spdxdocs/Organization1-cb617656-1023-45e7-84c7-a9311644337b"
+      ],
+      "description": "A description of each column in data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/contains-c64903fa-cab9-4880-8065-0b9b226ce009",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "contains",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8",
+        "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f"
+      ],
+      "description": "DatasetPackage1 contains data.csv and codebook.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/describes-de3f5855-bd5a-403f-9aa6-95dd97599c32",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "describes",
+      "from": "https://spdx.org/spdxdocs/File2-caf55baf-cd02-406a-b7ec-838842ca869f",
+      "to": [
+        "https://spdx.org/spdxdocs/File1-d029fccb-7ee9-42be-a445-5e2066db0de8"
+      ],
+      "description": "codebook.csv describes data.csv."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/concludedLicense-8575546c-c4f7-41ec-bb8f-cbd66e70090a",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasConcludedLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a concluded license as CC-BY-4.0."
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship/declaredLicense-e5536c5e-c8b5-4d24-947f-674c27c0b6c1",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "hasDeclaredLicense",
+      "from": "https://spdx.org/spdxdocs/DatasetPackage1-035470d9-3ede-4952-91c8-c2abb943c90b",
+      "to": [
+        "https://spdx.org/licenses/CC-BY-4.0"
+      ],
+      "description": "DatasetPackage1 has a declared license as CC-BY-4.0."
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://spdx.org/licenses/CC-BY-4.0",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "CC-BY-4.0",
+      "simplelicensing_licenseListVersion": "3.25.0",
+      "comment": "Added as a workaround for the lack of https://spdx.org/licenses/CC-BY-4.0 as a valid ListedLicense in SPDX 3.0 RDF. This will be removed once https://github.com/spdx/LicenseListPublisher/issues/183 is implemented."
+    }
+  ]
+}

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -16,7 +16,7 @@ from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
 
 import ntia_conformance_checker.sbom_checker as sbom_checker
 from ntia_conformance_checker import FSCT3Checker, NTIAChecker
-from ntia_conformance_checker.base_checker import validate_spdx3_document
+from ntia_conformance_checker.base_checker import validate_spdx3_data
 
 ### Test no element missing
 
@@ -315,7 +315,7 @@ def test_sbomchecker_spdx3_general():
     assert sbom.doc is not None
     assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
     assert sbom.sbom_name == "hello"
-    spdx3_spdx_document, validation_messages = validate_spdx3_document(sbom.doc)
+    spdx3_spdx_document, validation_messages = validate_spdx3_data(sbom.doc)
     assert (
         len(validation_messages) >= 1
     )  # There should be a message about missing /Core/Bom.

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -331,9 +331,7 @@ def test_sbomchecker_spdx3_no_elements_missing():
     # This file contains no /Software/Package/,
     # but it does contain its subclass /Dataset/DatasetPackage/.
     # It should be treated as a regular software BOM.
-    test_file = (
-        Path(__file__).parent / "data" / "spdx3" / "no_elements_missing.json"
-    )
+    test_file = Path(__file__).parent / "data" / "spdx3" / "no_elements_missing.json"
     sbom = sbom_checker.SbomChecker(str(test_file), sbom_spec="spdx3")
     assert sbom is not None
     assert sbom.doc is not None
@@ -355,9 +353,7 @@ def test_sbomchecker_spdx3_no_elements_missing():
 
 
 def test_sbomchecker_fsct3_spdx3_no_elements_missing():
-    test_file = (
-        Path(__file__).parent / "data" / "spdx3" / "no_elements_missing.json"
-    )
+    test_file = Path(__file__).parent / "data" / "spdx3" / "no_elements_missing.json"
     sbom = sbom_checker.SbomChecker(
         str(test_file), sbom_spec="spdx3", compliance="fsct3-min"
     )


### PR DESCRIPTION
*(Replacing PR #286. With this PR, SPDX 3 support should be completed for the existing checkers (NTIA and FSCTv3))*

Add check methods for both SPDX 2 and SPDX 3:
- check_author()
- check_timestamp()

Implement SDPX 3 support for:

- get_components_without_names()
- get_components_without_identifiers()
- get_components_without_versions()
- get_components_without_concluded_licenses()
- get_components_without_copyright_texts()

With a number of basic pytests.

Notes:

- See this [GSoC 2025 report](https://docs.google.com/document/d/1emyt1AXJUPDoHIoFdWAwdpV6nRpnmeJiCVCAzFG3T-8/edit?usp=sharing) for design details
- The SPDX 3 `get_components_without_*` methods will searching for `/Software/Package/` (and subclasses) that does not have the properties.
  - ** The exception is `get_components_without_identifiers()` where it works at `/Core/Element` level.
  - Working at `/Software/Package/` level means they will not cover `/Software/File`, `/Software/Snippet` and other `/Software/SoftwareArtifact`. This is to follow the existing implementation for SPDX 2 which iterate over `self.doc.packages`.
  - We can change which set of objects we like to iterate over. See code lines that we call `iter_objects_with_property()`.
  - The NTIA document uses the term "component" and may be it's up to the interpretation what "component" (and "subcomponent") should cover. Future version of checker may allow user to choose the subcomponent level to scan.
- Also note that as SPDX 3 requires all elements to have spdxId, the JSON deserializer will raise a ValueError if there is a missing spdxId - so in practice, `get_components_without_identifiers()` may never be used. If we need an ability to check this, we need a parser/deserializer that can work with invalid/incomplete SBOM.
- The code is updated and fixed to work with type checks based on type hints from the new [spdx-python-model 0.0.3](https://github.com/spdx/spdx-python-model/releases/tag/v0.0.3)
