### PR TITLE
Add Makefile for lint, type checks, and formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,47 +15,65 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
-- Add support of SPDX 3.0 (#284, #290).
+- Add support of SPDX 3.0 ([#277][], [#282][] [#284][], [#290][]).
   - Using [spdx-python-model][] to parse and deserialize SPDX 3 documents.
   - The SPDX 3 support in v4.0.0 is completed during the [Google Summer of Code
     (GSoC) 2025][gsoc2025] program by @bact with the mentorship and support of
     @jspeed-meyers @goneall @jpewdev @rtgdk and the Linux Foundation.
+- Add Makefile to simplify common development tasks ([#294][])
 
-[gsoc2025]: https://summerofcode.withgoogle.com/programs/2025/projects/CeR3hQTq
+[#277]: https://github.com/spdx/ntia-conformance-checker/pull/277
+[#282]: https://github.com/spdx/ntia-conformance-checker/pull/282
+[#284]: https://github.com/spdx/ntia-conformance-checker/pull/284
+[#290]: https://github.com/spdx/ntia-conformance-checker/pull/290
 [spdx-python-model]: https://github.com/spdx/spdx-python-model/
+[gsoc2025]: https://summerofcode.withgoogle.com/programs/2025/projects/CeR3hQTq
+[#294]: https://github.com/spdx/ntia-conformance-checker/pull/294
 
 ### Changed
 
-- Print validation context along with validation message (#274, #276).
+- Print validation context along with validation message ([#274][], [#276][]).
 - Drop support for Python 3.8.
   - spdx-python-model requires Python 3.9+.
+
+[#274]: https://github.com/spdx/ntia-conformance-checker/pull/274
+[#276]: https://github.com/spdx/ntia-conformance-checker/pull/276
 
 ### Fixed
 
 - Add components without copyright texts and without concluded licenses in the
-  FSCTv3 output report (#288).
-- Fix and improve type hints (#272). For example:
+  FSCTv3 output report ([#288][]).
+- Fix and improve type hints ([#272][], [#281][]). For example:
   - Fix `BaseChecker.validation_messages` type to `List[ValidationMessage]`.
   - Fix return type of `get_components_without_concluded_licenses`,
     `get_components_without_copyright_texts`, `get_components_without_suppliers`,
     and `get_components_without_versions`
     to honour the `return_tuples` parameter.
-  - Note that the next major version may adopt
-    [PEP 585](https://peps.python.org/pep-0585/) and
-    [PEP 604](https://peps.python.org/pep-0604/) for type hinting,
-    which will require Python 3.10.
+  - Note that the next major version may adopt [PEP 585][] and [PEP 604][]
+    for less verbose type hinting, which will require Python 3.10.
+
+[#288]: https://github.com/spdx/ntia-conformance-checker/pull/288
+[#272]: https://github.com/spdx/ntia-conformance-checker/pull/272
+[#281]: https://github.com/spdx/ntia-conformance-checker/pull/281
+[PEP 585]: https://peps.python.org/pep-0585/
+[PEP 604]: https://peps.python.org/pep-0604/
 
 ## [3.2.0] - 2025-03-12
 
 ### Added
 
-- Add Sphinx documentation generation support (#237).
+- Add Sphinx documentation generation support ([#237][]).
+
+[#237]: https://github.com/spdx/ntia-conformance-checker/pull/237
 
 ## [3.1.0] - 2024-12-31
 
 ### Added
 
-- Add FSCTv3 Common SBOM Baseline Attributes checker (#224, #226).
+- Add FSCTv3 Common SBOM Baseline Attributes checker ([#224][], [#226][]).
+
+[#224]: https://github.com/spdx/ntia-conformance-checker/pull/224
+[#226]: https://github.com/spdx/ntia-conformance-checker/pull/226
 
 ## [0.1.0] - 2023-01-06
 
@@ -70,8 +88,9 @@ Thanks to @goneall, @licquia, and @kestewart for mentoring @linynjosh.
 
 ### Added
 
-- Initial commit from Google Summer of Code 2022 (#1).
+- Initial commit from Google Summer of Code 2022 ([#1][]).
 
+[#1]: https://github.com/spdx/ntia-conformance-checker/pull/1
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/
 [semver]: https://semver.org/spec/v2.0.0.html
 [4.0.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,20 +94,10 @@ Here's the process to make changes to the codebase:
    [`pyright`][pyright], and [`pytype`][pytype]) to get different perspectives
    on the code.
 
-   ```sh
-   mypy ntia_conformance_checker
-   ```
+   Run all type checkers:
 
    ```sh
-   pyrefly check ntia_conformance_checker
-   ```
-
-   ```sh
-   pyright ntia_conformance_checker
-   ```
-
-   ```sh
-   pytype ntia_conformance_checker
+   make type
    ```
 
    If you are certain that a line is correct but the type checker is not able

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,13 @@ It is recommended to use a Python virtual environment for development.
 To install development dependencies, run:
 
 ```sh
-pip install -e ".[dev]"
+pip install -e ".[dev,docs,test]"
+```
+
+Or, if you're on a Unix-like system, you can use `make`:
+
+```sh
+make install-dev
 ```
 
 ## Development process
@@ -87,7 +93,15 @@ Here's the process to make changes to the codebase:
    [pytest]: https://docs.pytest.org/
    [nose]: https://nose.readthedocs.io/
 
-6. Type check your changes:
+6. Lint / static analyse your changes, using [`pylint`][pylint]:
+
+   ```sh
+   pylint ntia_conformance_checker/ tests/
+   ```
+
+   [pylint]: https://github.com/pylint-dev/pylint
+
+7. Type check your changes:
 
    Static type analysis is recommended to catch potential bugs and improve code
    quality. We use several type checkers ([`mypy`][mypy], [`pyrefly`][pyrefly],
@@ -100,6 +114,8 @@ Here's the process to make changes to the codebase:
    make type
    ```
 
+   Or you can run each type checker individually.
+
    If you are certain that a line is correct but the type checker is not able
    to verify it, you may choose to add a `# type: ignore` comment with
    additional explanation at the end of the line to suppress the error.
@@ -109,35 +125,31 @@ Here's the process to make changes to the codebase:
    [pyright]: https://github.com/microsoft/pyright
    [pytype]: https://github.com/google/pytype
 
-7. Format your changes with [`black`][black] and [`pylint`][pylint]:
+8. Format your changes with [`black`][black] and sort import with
+    [`isort`][isort]:
 
    ```sh
-   black pylint ntia_conformance_checker/ tests/
-   ```
-
-   ```sh
-   pylint ntia_conformance_checker/ tests/
+   make format
    ```
 
    [black]: https://github.com/psf/black
-   [pylint]: https://github.com/pylint-dev/pylint
+   [isort]: https://pycqa.github.io/isort/
 
-8. Push the branch to your fork on GitHub:
+9. Push the branch to your fork on GitHub:
 
    ```sh
    git push origin fix-or-improve-something
    ```
 
-9. Make a pull request on GitHub.
-
-10. Continue making more changes and commits on the branch,
+10. Make a pull request on GitHub.
+11. Continue making more changes and commits on the branch,
     with `git commit --signoff` and `git push`.
-11. When done, write a comment on the PR asking for a code review.
-12. Some other developer will review your changes and accept your PR.
+12. When done, write a comment on the PR asking for a code review.
+13. Some other developer will review your changes and accept your PR.
     The merge should be done with `rebase`, if possible, or with `squash`.
-13. The temporary branch on GitHub should be deleted (there is a button for
+14. The temporary branch on GitHub should be deleted (there is a button for
     deleting it).
-14. Delete the local branch as well:
+15. Delete the local branch as well:
 
     ```sh
     git checkout master
@@ -148,8 +160,8 @@ Here's the process to make changes to the codebase:
 
 ## How to run tests
 
-The tests framework is using [pytest][] as the test runner
-and [coverage][] to measure code coverage.
+The tests framework is using [`pytest`][pytest] as the test runner
+and [`Coverage.py`][coverage] to measure code coverage.
 
 Install test dependencies:
 
@@ -169,6 +181,8 @@ Run tests with coverage report and show line numbers of missed lines:
 coverage run -m pytest
 coverage report -m
 ```
+
+[coverage]: https://coverage.readthedocs.io/
 
 ## How to generate API documentation
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY: install-dev format format-check lint type test check clean docs
+
+# Install development dependencies (editable install)
+install-dev:
+	python -m pip install --upgrade pip
+	python -m pip install -e ".[dev,docs,test]"
+
+# Format sources (fix in-place)
+format:
+	black ntia_conformance_checker tests
+	ruff check --fix --select I ntia_conformance_checker tests
+
+# Check formatting (check only, CI-friendly)
+format-check:
+	black --check ntia_conformance_checker tests
+	ruff check --select I ntia_conformance_checker tests
+
+# Lint / static analysis
+lint:
+	pylint ntia_conformance_checker tests
+
+# Type checkers (ensure dev deps installed)
+type:
+	mypy ntia_conformance_checker || true
+	pyrefly check ntia_conformance_checker
+	pyright ntia_conformance_checker
+	pytype ntia_conformance_checker
+
+# Unit tests
+test:
+	pytest -q
+
+# Composite check: format checks, lint, type checks, and tests
+check: format-check lint type test
+	@echo "All checks passed"
+
+# Build docs
+docs:
+	python -m pip install -e ".[docs]"
+	sphinx-apidoc -o docs/ ntia_conformance_checker/
+	cd docs && make html
+
+# Cleanup build/test caches (works on Unix-like systems)
+clean:
+	rm -rf build dist .pytest_cache .mypy_cache .pytype .pyright *.egg-info

--- a/README.md
+++ b/README.md
@@ -174,12 +174,13 @@ Go to this page: <https://tools.spdx.org/app/ntia_checker/>.
 
 - The project is the result of an initial [Google Summer of Code (GSoC)][gsoc]
   contribution in 2022 by [@linynjosh](https://github.com/linynjosh).
-- SPDX 3 support and improved FSCT3 checker, available in v4.0,
+- SPDX 3 support and improved FSCT3 checker, available in [v4.0.0][],
   are [GSoC 2025 contribution][gsoc2025] by [@bact](https://github.com/bact).
 - The project is maintained by a community of SPDX adopters and enthusiasts.
 - See SPDX's participation in Google Summer of Code (GSoC):
   <https://github.com/spdx/GSoC>.
 
+[v4.0.0]: https://github.com/spdx/ntia-conformance-checker/blob/main/CHANGELOG.md#400---2025-09-05
 [gsoc]: https://summerofcode.withgoogle.com/
 [gsoc2025]: https://docs.google.com/document/d/1emyt1AXJUPDoHIoFdWAwdpV6nRpnmeJiCVCAzFG3T-8/edit?usp=sharing
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -196,7 +196,7 @@ class BaseChecker(ABC):
         if self.doc:
             if validate:
                 if sbom_spec == "spdx2":
-                    self.doc = cast(Document, self.doc)
+                    self.doc = cast("Document", self.doc)
                     self.validation_messages = validate_full_spdx_document(self.doc)
                 else:
                     pass
@@ -210,19 +210,19 @@ class BaseChecker(ABC):
 
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = cast(
-                List[str], self.get_components_without_versions()
+                "List[str]", self.get_components_without_versions()
             )  # with return_tuples=False, always get List[str]
             self.components_without_suppliers = cast(
-                List[str], self.get_components_without_suppliers()
+                "List[str]", self.get_components_without_suppliers()
             )
             self.components_without_identifiers = (
                 self.get_components_without_identifiers()
             )
             self.components_without_concluded_licenses = cast(
-                List[str], self.get_components_without_concluded_licenses()
+                "List[str]", self.get_components_without_concluded_licenses()
             )
             self.components_without_copyright_texts = cast(
-                List[str], self.get_components_without_copyright_texts()
+                "List[str]", self.get_components_without_copyright_texts()
             )
 
     def check_doc_version(self) -> bool:
@@ -241,7 +241,7 @@ class BaseChecker(ABC):
             # Note that the spdx-tools's parser will raise an SPDXParsingError
             # anyway, if the document does not contain a creator.
             # So in practice, this section should always return True
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             doc_creation_info = getattr(self.doc, "creation_info", None)
             if doc_creation_info:
                 doc_creators = getattr(doc_creation_info, "creators", [])
@@ -267,7 +267,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.relationships:
                 return False
 
@@ -318,7 +318,7 @@ class BaseChecker(ABC):
             # Note that the spdx-tools's parser will raise an SPDXParsingError,
             # if the document does not contain a timestamp.
             # So in practice, this section should always return True.
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             doc_creation_info = getattr(self.doc, "creation_info", None)
             if doc_creation_info:
                 doc_created = getattr(doc_creation_info, "created", None)
@@ -345,7 +345,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             doc_creation_info = getattr(self.doc, "creation_info", None)
             if doc_creation_info:
                 doc_spec_version = getattr(doc_creation_info, "spdx_version", None)
@@ -369,7 +369,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             doc_creation_info = getattr(self.doc, "creation_info", None)
             if doc_creation_info:
                 name = getattr(doc_creation_info, "name", "")
@@ -405,7 +405,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return []
 
@@ -440,7 +440,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
             has_concluded_license_ids: Set[str] = {
                 from_id
@@ -498,7 +498,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return []
 
@@ -533,7 +533,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
             if return_tuples:
                 return [
@@ -577,7 +577,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return []
             return [
@@ -586,7 +586,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
             return [
                 name
@@ -610,7 +610,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return []
             components_without_names: List[str] = []
@@ -621,7 +621,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
             return [
                 spdx_id
@@ -655,7 +655,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return []
 
@@ -680,7 +680,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
             if return_tuples:
                 return [
@@ -721,7 +721,7 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return []
 
@@ -740,7 +740,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
             if return_tuples:
                 return [
@@ -773,14 +773,14 @@ class BaseChecker(ABC):
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
-            self.doc = cast(Document, self.doc)
+            self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return 0
             return len(self.doc.packages)
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast(spdx3.SHACLObjectSet, self.doc)
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
             objects: Set[spdx3.SHACLObject] = getattr(self.doc, "objects", set())
             return len(objects)
 
@@ -808,7 +808,7 @@ class BaseChecker(ABC):
             self.parsing_error.extend(err.get_messages())
             return None
 
-        return cast(Document, doc)
+        return cast("Document", doc)
 
     def parse_spdx3_file(self) -> Optional[spdx3.SHACLObjectSet]:
         """

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -47,7 +47,8 @@ def validate_spdx3_data(
     validation_messages: List[ValidationMessage] = []
 
     spdx_documents: List[spdx3.SpdxDocument] = [
-        cast(spdx3.SpdxDocument, obj) for obj in object_set.foreach_type("SpdxDocument")
+        cast("spdx3.SpdxDocument", obj)
+        for obj in object_set.foreach_type("SpdxDocument")
     ]
 
     if not spdx_documents:
@@ -185,7 +186,7 @@ def iter_relationships_by_type(
 def get_all_packages(object_set: spdx3.SHACLObjectSet) -> Set[spdx3.software_Package]:
     """Retrieve all /Software/Package objects from an SHACLObjectSet."""
     packages: Set[spdx3.software_Package] = {
-        cast(spdx3.software_Package, obj)
+        cast("spdx3.software_Package", obj)
         for obj in object_set.foreach_type("software_Package")
     }
     return packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "pyrefly>=0.31.0",
     "pyright>=1.1.405",
     "pytype>=2024.9.13", # 2024.9.13 is the last version supporting Python 3.9
+    "ruff>=0.12.12",
 ]
 docs = ["sphinx>=8.1.3", "sphinx-rtd-theme>=3.0.2"]
 test = ["beartype==0.21.0", "coverage==7.6.10", "pytest==8.4.1"]
@@ -73,6 +74,32 @@ test = ["beartype==0.21.0", "coverage==7.6.10", "pytest==8.4.1"]
 # to accommodate other compliance standards.
 ntia-checker = "ntia_conformance_checker.main:main"
 sbomcheck = "ntia_conformance_checker.main:main"
+
+[tool.ruff]
+line-length = 88        # Same as black
+indent-width = 4        # Same as black
+target-version = "py39"
+exclude = [
+  "build",
+  "dist",
+  ".venv",
+  ".git",
+  "__pycache__",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".venv/*"
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "C", "I", "N", "TC"]
+ignore = ["E203", "E501"]
+fixable = ["ALL"]
 
 [tool.setuptools]
 packages = ["ntia_conformance_checker"]


### PR DESCRIPTION
- Add a Makefile with targets to check types, lint, and format.
  - As suggusted by @@jspeed-meyers in https://github.com/spdx/ntia-conformance-checker/pull/292#pullrequestreview-3189068745
- Use ruff for import sorting
- Fix linting issues, putting quotes for type in cast()
- Also update README with links to PRs