### PR TITLE
Add CITATION.cff for standardised citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,11 +31,12 @@ identifiers:
 repository-code: 'https://github.com/spdx/ntia-conformance-checker'
 url: 'https://pypi.org/project/ntia-conformance-checker/'
 abstract: >-
-  This software is a SPDX Software Bill of Materials (SBOM)
+  This software is an SPDX Software Bill of Materials (SBOM)
   validator that checks for NTIA minimum elements and CISA
   baseline attributes. It reports missing elements and can
   be used as both a command-line tool and a library. Output
   formats include plain text, JSON, and HTML.
+  Supports SPDX specification versions 2.2, 2.3, and 3.0.
 keywords:
   - software supply chain security
   - SBOM

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ authors:
     family-names: Meyers
     name-particle: Speed
     email: johnmeyersster@gmail.com
-    affiliation: Chainguard Labs
+    affiliation: Chainguard
     orcid: 'https://orcid.org/0000-0003-2016-7695'
   - given-names: Arthit
     family-names: Suriyawongkul

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,6 +22,12 @@ authors:
     email: suriyawa@tcd.ie
     affiliation: 'ADAPT Centre, Trinity College Dublin'
     orcid: 'https://orcid.org/0000-0002-9698-1899'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.17068670
+    description: >-
+      This is the collection of archived snapshots of all
+      versions of NTIA Conformance Checker.
 repository-code: 'https://github.com/spdx/ntia-conformance-checker'
 url: 'https://pypi.org/project/ntia-conformance-checker/'
 abstract: >-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: NTIA Conformance Checker
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Josh
+    family-names: Lin
+    email: linynjosh@gmail.com
+  - given-names: John
+    family-names: Meyers
+    name-particle: Speed
+    email: johnmeyersster@gmail.com
+    affiliation: Chainguard Labs
+    orcid: 'https://orcid.org/0000-0003-2016-7695'
+  - given-names: Arthit
+    family-names: Suriyawongkul
+    email: suriyawa@tcd.ie
+    affiliation: 'ADAPT Centre, Trinity College Dublin'
+    orcid: 'https://orcid.org/0000-0002-9698-1899'
+repository-code: 'https://github.com/spdx/ntia-conformance-checker'
+url: 'https://pypi.org/project/ntia-conformance-checker/'
+abstract: >-
+  This software is a SPDX Software Bill of Materials (SBOM)
+  validator that checks for NTIA minimum elements and CISA
+  baseline attributes. It reports missing elements and can
+  be used as both a command-line tool and a library. Output
+  formats include plain text, JSON, and HTML.
+keywords:
+  - software supply chain security
+  - SBOM
+  - software bill of materials
+  - conformance
+  - SPDX
+  - minimum elements
+  - software package data exchange
+  - software component transparency
+  - NTIA
+  - CISA
+license: Apache-2.0
+commit: 0ea788768fc39f0eacf9c9300c75a328799fbbd3
+version: 4.0.0
+date-released: '2025-09-05'

--- a/README.md
+++ b/README.md
@@ -173,16 +173,19 @@ Go to this page: <https://tools.spdx.org/app/ntia_checker/>.
 ## History
 
 - The project is the result of an initial [Google Summer of Code (GSoC)][gsoc]
-  contribution in 2022 by [@linynjosh](https://github.com/linynjosh).
+  [contribution in 2022][gsoc2022] by [@linynjosh][].
 - SPDX 3 support and improved FSCT3 checker, available in [v4.0.0][],
-  are [GSoC 2025 contribution][gsoc2025] by [@bact](https://github.com/bact).
+  are [GSoC 2025 contribution][gsoc2025] by [@bact][].
 - The project is maintained by a community of SPDX adopters and enthusiasts.
 - See SPDX's participation in Google Summer of Code (GSoC):
   <https://github.com/spdx/GSoC>.
 
-[v4.0.0]: https://github.com/spdx/ntia-conformance-checker/blob/main/CHANGELOG.md#400---2025-09-05
 [gsoc]: https://summerofcode.withgoogle.com/
-[gsoc2025]: https://docs.google.com/document/d/1emyt1AXJUPDoHIoFdWAwdpV6nRpnmeJiCVCAzFG3T-8/edit?usp=sharing
+[gsoc2022]: https://github.com/spdx/ntia-conformance-checker/wiki/Project-Origin
+[@linynjosh]: https://github.com/linynjosh
+[v4.0.0]: https://github.com/spdx/ntia-conformance-checker/blob/main/CHANGELOG.md#400---2025-09-05
+[gsoc2025]: https://github.com/spdx/ntia-conformance-checker/wiki/Adding-SPDX-3.0-Support
+[@bact]: https://github.com/bact
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/ntia-conformance-checker.svg)](https://pypi.org/project/ntia-conformance-checker/)
 [![Pylint Score](https://img.shields.io/badge/pylint-10/10-green)](https://github.com/spdx/ntia-conformance-checker)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/spdx/ntia-conformance-checker/badge)](https://scorecard.dev/viewer/?uri=github.com/spdx/ntia-conformance-checker)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17068670.svg)](https://doi.org/10.5281/zenodo.17068670)
 
 This tool determines whether a [SPDX](https://spdx.dev/) software bill of
 materials (SBOM) document contains informational items as required by a


### PR DESCRIPTION
- Add CITATION.cff for standardised citation info/format
  - CITATION.cff [format](https://citation-file-format.github.io/)
  - GitHub [supports CITATION files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)
- Also add links to [GSoC 2022][gsoc2022] and [2025][gsoc2025] pages in wiki

[gsoc2022]: https://github.com/spdx/ntia-conformance-checker/wiki/Project-Origin
[gsoc2025]: https://github.com/spdx/ntia-conformance-checker/wiki/Adding-SPDX-3.0-Support
