### PR TITLE
Fix Sphinx version to 7.4.7 to compatible with Python 3.9

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -173,11 +173,6 @@ class BaseChecker(ABC):
             self.doc = self.parse_file()
         # SPDX 3
         elif sbom_spec == "spdx3":
-            logging.warning(
-                "SPDX 3 support is under development. "
-                "Some features may not work as expected. "
-                "Do not use in production."
-            )
             object_set = self.parse_spdx3_file()
             if not object_set:
                 logging.error("Failed to parse the SPDX 3 file.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,10 @@ dev = [
     "pytype>=2024.9.13", # 2024.9.13 is the last version supporting Python 3.9
     "ruff>=0.12.12",
 ]
-docs = ["sphinx>=8.1.3", "sphinx-rtd-theme>=3.0.2"]
+docs = [
+    "sphinx>=7.4.7", # 7.4.7 is the last version supporting Python 3.9
+    "sphinx-rtd-theme>=3.0.2",
+]
 test = ["beartype==0.21.0", "coverage==7.10.6", "pytest==8.4.2"]
 
 [project.scripts]
@@ -76,18 +79,18 @@ ntia-checker = "ntia_conformance_checker.main:main"
 sbomcheck = "ntia_conformance_checker.main:main"
 
 [tool.ruff]
-line-length = 88        # Same as black
-indent-width = 4        # Same as black
+line-length = 88 # Same as black
+indent-width = 4 # Same as black
 target-version = "py39"
 exclude = [
-  "build",
-  "dist",
-  ".venv",
-  ".git",
-  "__pycache__",
-  ".mypy_cache",
-  ".pytest_cache",
-  ".venv/*"
+    "build",
+    "dist",
+    ".venv",
+    ".git",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv/*",
 ]
 
 [tool.ruff.format]


### PR DESCRIPTION
- 7.4.7 is the latest version supporting Python 3.9
- Also remove SPDX 3 warning of not running on production