### PR TITLE
Refactor output functions

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -895,7 +895,17 @@ class BaseChecker(ABC):
         self,
         table_elements: Optional[List[Tuple[str, bool]]] = None,
     ) -> str:
-        """Create a HTML of results."""
+        """
+        Create element-by-element result table in HTML.
+
+        Args:
+            table_elements (Optional[List[Tuple[str, bool]]]): A list of tuples
+                            where each tuple contains a label and a boolean
+                            value indicating the status of that element.
+
+        Returns:
+            str: The HTML representation of the results.
+        """
         html_parts: List[str] = []
 
         if not self.doc:
@@ -930,7 +940,8 @@ class BaseChecker(ABC):
 
         if self.validation_messages:
             html_parts.append(
-                "<p>The provided document is not valid according to the SBOM specification.</p>"
+                "<p>The document is not valid according to the SBOM "
+                f'specification ("{self.sbom_spec}").</p>'
             )
             html_parts.append("<p>The following errors were found:</p>")
             html_parts.append(get_validation_messages_html(self.validation_messages))

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -16,7 +16,7 @@ from typing import Optional, Tuple
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.parse_anything import parse_file as parse_spdx2_file
 
-from .base_checker import (
+from .constants import (
     DEFAULT_COMPLIANCE_STANDARD,
     DEFAULT_SBOM_SPEC,
     SUPPORTED_COMPLIANCE_STANDARDS,

--- a/ntia_conformance_checker/constants.py
+++ b/ntia_conformance_checker/constants.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Constants."""
+
+SUPPORTED_SBOM_SPECS_DESC = {
+    "spdx2": "Software Package Data Exchange (SPDX) 2.x",
+    "spdx3": "System Package Data Exchange (SPDX) 3.x",
+}
+DEFAULT_SBOM_SPEC = "spdx2"
+SUPPORTED_SBOM_SPECS = set(SUPPORTED_SBOM_SPECS_DESC.keys())
+
+SUPPORTED_COMPLIANCE_STANDARDS_DESC = {
+    # "cisasbom2025": "2025 CISA SBOM Minimum Elements",
+    # https://www.cisa.gov/resources-tools/resources/2025-minimum-elements-software-bill-materials-sbom
+    "fsct3-min": "2024 CISA Framing Software Component Transparency (minimum expectation)",
+    "ntia": "2021 NTIA SBOM Minimum Elements",
+}
+DEFAULT_COMPLIANCE_STANDARD = "ntia"
+SUPPORTED_COMPLIANCE_STANDARDS = set(SUPPORTED_COMPLIANCE_STANDARDS_DESC.keys())
+
+SUPPORTED_SPDX_VERSIONS = {(2, 2), (2, 3), (3, 0)}  # (Major, Minor)
+SUPPORTED_SPDX2_VERSION_STRINGS = {
+    f"SPDX-{maj}.{min}" for (maj, min) in SUPPORTED_SPDX_VERSIONS if maj == 2
+}  # e.g. "SPDX-2.2", "SPDX-2.3"
+SUPPORTED_SPDX3_VERSION_STRINGS = {
+    f"{maj}.{min}" for (maj, min) in SUPPORTED_SPDX_VERSIONS if maj == 3
+}  # e.g. "3.0"

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -116,65 +116,33 @@ class FSCT3Checker(BaseChecker):
             ],
         )
 
-    def output_html(self) -> str:
+    def output_html(self, table_elements=None) -> str:
         """Create a HTML of results."""
-        if self.doc:
-            result = (
-                f"<h2>FSCTv3 Minimum Expected Conformance Results</h2>"
-                f"<h3>Conformant: {self.compliant}</h3>"
-                f"<table> <tr> "
-                f"<th>Individual Elements</th> <th>Conformant</th> </tr> "
-                f"<tr> <td>All component names provided</td>"
-                f" <td>{not self.components_without_names}</td> </tr> "
-                f"<tr> <td>All component versions provided</td>"
-                f" <td>{not self.components_without_versions}</td> </tr> "
-                f"<tr> <td>All component identifiers provided</td> "
-                f"<td>{not self.components_without_identifiers}</td> </tr> "
-                f"<tr> <td>All component suppliers provided</td> "
-                f"<td>{not self.components_without_suppliers}</td> "
-                f"<tr> <td>All component concluded license provided</td> "
-                f"<td>{not self.components_without_concluded_licenses}</td> "
-                f"<tr> <td>All component copyright notice provided</td> "
-                f"<td>{not self.components_without_copyright_texts}</td> "
-                f"</tr> <tr> <td>SBOM author name provided</td> "
-                f"<td>{self.doc_author}</td> </tr> "
-                f"<tr> <td>SBOM creation timestamp provided</td> "
-                f"<td>{self.doc_timestamp}</td> </tr> "
-                f"<tr> <td>Dependency relationships provided?</td> "
-                f"<td>{self.dependency_relationships}</td> </tr> "
-                f"</table>"
-            )
-            if self.validation_messages:
-                result += (
-                    "<p>The provided document is not valid according to the SPDX specification. "
-                    "The following errors were found:</p>\n"
-                )
-                result += "<ul>\n"
-                for msg in self.validation_messages:
-                    if msg.validation_message:
-                        result += "<li>\n"
-                        result += "<p><strong>Validation message:</strong></p>\n"
-                        result += f"<p>{msg.validation_message}</p>\n"
-                        if msg.context:
-                            result += "<p><strong>Validation context:</strong></p>\n"
-                            result += "<ul>\n"
-                            result += f"<li>SPDX ID: {msg.context.spdx_id}</li>\n"
-                            result += f"<li>Parent ID: {msg.context.parent_id}</li>\n"
-                            result += (
-                                f"<li>Element type: {msg.context.element_type}</li>\n"
-                            )
-                            result += "</ul>\n"
-                        result += "</li>\n"
-                result += "</ul>\n"
-        else:
-            result = f"""
-            <h2>FSCTv3 Minimum Expected Conformance Results</h2>
-            <h3>Conformant: {self.compliant}</h3>
-            <p>The provided document couldn't be parsed, check for baseline attributes couldn't be performed.</p>
-            <p>The following SPDXParsingError was raised:<p><ul>"""
-            for error in self.parsing_error:
-                result += f"""<li>{error}</li>"""
-
-            result += """</ul>"""
-
-        return result
+        return super().output_html(
+            table_elements=[
+                ("All component names provided", not self.components_without_names),
+                (
+                    "All component versions provided",
+                    not self.components_without_versions,
+                ),
+                (
+                    "All component identifiers provided",
+                    not self.components_without_identifiers,
+                ),
+                (
+                    "All component suppliers provided",
+                    not self.components_without_suppliers,
+                ),
+                (
+                    "All component concluded license provided",
+                    not self.components_without_concluded_licenses,
+                ),
+                (
+                    "All component copyright notice provided",
+                    not self.components_without_copyright_texts,
+                ),
+                ("SBOM author name provided", self.doc_author),
+                ("SBOM creation timestamp provided", self.doc_timestamp),
+                ("Dependency relationships provided", self.dependency_relationships),
+            ],
+        )

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
-
 from .base_checker import BaseChecker
 
 
@@ -73,191 +71,50 @@ class FSCT3Checker(BaseChecker):
             ]
         )
 
-    def print_components_missing_info(self) -> None:
-        """Print detailed info about which components are missing info."""
-        if not self.parsing_error:
-            if all(
-                [
-                    not self.components_without_names,
-                    not self.components_without_versions,
-                    not self.components_without_identifiers,
-                    not self.components_without_suppliers,
-                    not self.components_without_concluded_licenses,
-                    not self.components_without_copyright_texts,
-                ]
-            ):
-                print("No components with missing information.")
-            if self.components_without_names:
-                print(
-                    "Components missing a name: "
-                    f"{', '.join(self.components_without_names)}"
-                )
-                print()
-            if self.components_without_versions:
-                print(
-                    "Components missing a version: "
-                    f"{', '.join(self.components_without_versions)}"
-                )
-                print()
-            if self.components_without_identifiers:
-                print(
-                    "Components missing an identifier: "
-                    f"{', '.join(self.components_without_identifiers)}"
-                )
-                print()
-            if self.components_without_suppliers:
-                print(
-                    "Components missing a supplier: "
-                    f"{', '.join(self.components_without_suppliers)}"
-                )
-                print()
-            if self.components_without_concluded_licenses:
-                print(
-                    "Components missing a license: "
-                    f"{', '.join(self.components_without_concluded_licenses)}"
-                )
-                print()
-            if self.components_without_copyright_texts:
-                print(
-                    "Components missing a copyright notice: "
-                    f"{', '.join(self.components_without_copyright_texts)}"
-                )
-                print()
+    def print_components_missing_info(self, attributes=None) -> None:
+        """Print detailed info about which components have missing info."""
+        super().print_components_missing_info(
+            attributes=[
+                "name",
+                "version",
+                "identifier",
+                "supplier",
+                "concluded_license",
+                "copyright_text",
+            ]
+        )
 
-    def print_table_output(self, verbose: bool = False) -> None:
+    def print_table_output(self, verbose: bool = False, table_elements=None) -> None:
         """Print element-by-element result table."""
-        # pylint: disable=line-too-long
-        if self.parsing_error:
-            print(
-                f"\nIs this SBOM FSCTv3 Minimum Expected conformant? {self.compliant}\n"
-            )
-            print(
-                "The provided document couldn't be parsed, "
-                "check for FSCTv3 Minimum Expected couldn't be performed.\n"
-            )
-            print("The following SPDXParsingError was raised:\n")
-            for error in self.parsing_error:
-                print(error)
-
-        else:
-            print(
-                f"\nIs this SBOM FSCTv3 Minimum Expected conformant? {self.compliant}\n"
-            )
-            print("Individual elements                            | Status")
-            print("-------------------------------------------------------")
-            print(
-                f"All component names provided?                  | {not self.components_without_names}"
-            )
-            print(
-                f"All component versions provided?               | {not self.components_without_versions}"
-            )
-            print(
-                f"All component identifiers provided?            | {not self.components_without_identifiers}"
-            )
-            print(
-                f"All component suppliers provided?              | {not self.components_without_suppliers}"
-            )
-            print(
-                f"All component concluded license provided?      | {not self.components_without_concluded_licenses}"
-            )
-            print(
-                f"All component copyright notice provided?       | {not self.components_without_copyright_texts}"
-            )
-            print(f"SBOM author name provided?                     | {self.doc_author}")
-            print(
-                f"SBOM creation timestamp provided?              | {self.doc_timestamp}"
-            )
-            print(
-                f"Dependency relationships provided?             | {self.dependency_relationships}\n"
-            )
-
-            if self.validation_messages:
-                print(
-                    "The provided document is not valid according to the SPDX specification. "
-                    "The following errors were found:\n"
-                )
-                for msg in self.validation_messages:
-                    if msg.validation_message:
-                        print(msg.validation_message)
-                        if verbose and msg.context:
-                            print(f"- SPDX ID: {msg.context.spdx_id}")
-                            print(f"- Parent ID: {msg.context.parent_id}")
-                            print(f"- Element type: {msg.context.element_type}")
-                        print()
-
-    def output_json(self) -> Dict[str, Any]:
-        """Create a dict of results for outputting to JSON."""
-        # instantiate dict and fields that have > 1 level
-        result: Dict[str, Any] = {}
-
-        result["isConformant"] = self.compliant
-        result["isNtiaConformant"] = self.compliant  # for backward compatibility
-
-        result["complianceStandard"] = self.compliance_standard
-        result["sbomSpec"] = self.sbom_spec
-
-        result["validationMessages"] = []
-        if self.validation_messages:
-            result["validationMessages"] = list(map(str, self.validation_messages))
-
-        result["parsingError"] = self.parsing_error
-
-        result["sbomName"] = self.sbom_name
-        result["componentNames"] = {}
-        result["componentVersions"] = {}
-        result["componentIdentifiers"] = {}
-        result["componentSuppliers"] = {}
-        result["componentConcludedLicenses"] = {}
-        result["componentCopyrightTexts"] = {}
-
-        result["specVersionProvided"] = self.doc_version
-        result["authorNameProvided"] = self.doc_author
-        result["timestampProvided"] = self.doc_timestamp
-        result["dependencyRelationshipsProvided"] = self.dependency_relationships
-
-        result["componentNames"][
-            "nonconformantComponents"
-        ] = self.components_without_names
-        result["componentNames"]["allProvided"] = not self.components_without_names
-
-        result["componentVersions"][
-            "nonconformantComponents"
-        ] = self.components_without_versions
-        result["componentVersions"][
-            "allProvided"
-        ] = not self.components_without_versions
-
-        result["componentIdentifiers"][
-            "nonconformantComponents"
-        ] = self.components_without_identifiers
-        result["componentIdentifiers"][
-            "allProvided"
-        ] = not self.components_without_identifiers
-
-        result["componentSuppliers"][
-            "nonconformantComponents"
-        ] = self.components_without_suppliers
-        result["componentSuppliers"][
-            "allProvided"
-        ] = not self.components_without_suppliers
-
-        result["componentConcludedLicenses"][
-            "nonconformantComponents"
-        ] = self.components_without_concluded_licenses
-        result["componentConcludedLicenses"][
-            "allProvided"
-        ] = not self.components_without_concluded_licenses
-
-        result["componentCopyrightTexts"][
-            "nonconformantComponents"
-        ] = self.components_without_copyright_texts
-        result["componentCopyrightTexts"][
-            "allProvided"
-        ] = not self.components_without_copyright_texts
-
-        result["totalNumberComponents"] = self.get_total_number_components()
-
-        return result
+        super().print_table_output(
+            verbose=verbose,
+            table_elements=[
+                ("All component names provided?", not self.components_without_names),
+                (
+                    "All component versions provided?",
+                    not self.components_without_versions,
+                ),
+                (
+                    "All component identifiers provided?",
+                    not self.components_without_identifiers,
+                ),
+                (
+                    "All component suppliers provided?",
+                    not self.components_without_suppliers,
+                ),
+                (
+                    "All component concluded license provided?",
+                    not self.components_without_concluded_licenses,
+                ),
+                (
+                    "All component copyright notice provided?",
+                    not self.components_without_copyright_texts,
+                ),
+                ("SBOM author name provided?", self.doc_author),
+                ("SBOM creation timestamp provided?", self.doc_timestamp),
+                ("Dependency relationships provided?", self.dependency_relationships),
+            ],
+        )
 
     def output_html(self) -> str:
         """Create a HTML of results."""

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -11,8 +11,8 @@ import logging
 import sys
 from typing import Any, Dict, Optional, Tuple
 
-from .base_checker import SUPPORTED_SBOM_SPECS, SUPPORTED_SPDX_VERSIONS
 from .cli_utils import get_parsed_args, get_spdx_version
+from .constants import SUPPORTED_SBOM_SPECS, SUPPORTED_SPDX_VERSIONS
 from .sbom_checker import SbomChecker
 
 

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Dict
 
 from .base_checker import BaseChecker
 
@@ -77,162 +76,35 @@ class NTIAChecker(BaseChecker):
         )
         return self.check_compliance()
 
-    def print_components_missing_info(self) -> None:
-        """Print detailed info about which components are missing info."""
-        if not self.parsing_error:
-            if all(
-                [
-                    not self.components_without_names,
-                    not self.components_without_versions,
-                    not self.components_without_identifiers,
-                    not self.components_without_suppliers,
-                ]
-            ):
-                print("No components with missing information.")
-            if self.components_without_names:
-                print(
-                    f"Components missing a name: {', '.join(self.components_without_names)}"
-                )
-                print()
-            if self.components_without_versions:
-                print(
-                    f"Components missing a version: {', '.join(self.components_without_versions)}"
-                )
-                print()
-            if self.components_without_identifiers:
-                print(
-                    f"Components missing an identifier: "
-                    f"{', '.join(self.components_without_identifiers)}"
-                )
-                print()
-            if self.components_without_suppliers:
-                print(
-                    f"Components missing a supplier: {', '.join(self.components_without_suppliers)}"
-                )
-                print()
+    def print_components_missing_info(self, attributes=None) -> None:
+        """Print detailed info about which components have missing info."""
+        super().print_components_missing_info(
+            ["name", "version", "identifier", "supplier"]
+        )
 
-    def print_table_output(self, verbose: bool = False) -> None:
+    def print_table_output(self, verbose: bool = False, table_elements=None) -> None:
         """Print element-by-element result table."""
-        # pylint: disable=line-too-long
-        if self.parsing_error:
-            print(f"\nIs this SBOM NTIA minimum element conformant? {self.compliant}\n")
-            print(
-                "The provided document couldn't be parsed, check for ntia minimum elements couldn't be performed.\n"
-            )
-            print("The following SPDXParsingError was raised:\n")
-            for error in self.parsing_error:
-                print(error)
-
-        else:
-            print(f"\nIs this SBOM NTIA minimum element conformant? {self.compliant}\n")
-            print("Individual elements                            | Status")
-            print("-------------------------------------------------------")
-            print(
-                f"All component names provided?                  | {not self.components_without_names}"
-            )
-            print(
-                f"All component versions provided?               | {not self.components_without_versions}"
-            )
-            print(
-                f"All component identifiers provided?            | {not self.components_without_identifiers}"
-            )
-            print(
-                f"All component suppliers provided?              | {not self.components_without_suppliers}"
-            )
-            print(f"SBOM author name provided?                     | {self.doc_author}")
-            print(
-                f"SBOM creation timestamp provided?              | {self.doc_timestamp}"
-            )
-            print(
-                f"Dependency relationships provided?             | {self.dependency_relationships}\n"
-            )
-            if self.validation_messages:
-                print(
-                    "The provided document is not valid according to the SPDX specification. "
-                    "The following errors were found:\n"
-                )
-                for msg in self.validation_messages:
-                    if msg.validation_message:
-                        print(msg.validation_message)
-                        if verbose and msg.context:
-                            print(f"- SPDX ID: {msg.context.spdx_id}")
-                            print(f"- Parent ID: {msg.context.parent_id}")
-                            print(f"- Element type: {msg.context.element_type}")
-                        print()
-
-    def output_json(self) -> Dict[str, Any]:
-        """Create a dict of results for outputting to JSON."""
-        # instantiate dict and fields that have > 1 level
-        result: Dict[str, Any] = {}
-
-        result["isConformant"] = self.compliant
-        result["isNtiaConformant"] = self.compliant  # for backward compatibility
-
-        result["complianceStandard"] = self.compliance_standard
-        result["sbomSpec"] = self.sbom_spec
-
-        result["validationMessages"] = []
-        if self.validation_messages:
-            result["validationMessages"] = list(map(str, self.validation_messages))
-
-        result["parsingError"] = self.parsing_error
-
-        result["sbomName"] = self.sbom_name
-        result["componentNames"] = {}
-        result["componentVersions"] = {}
-        result["componentIdentifiers"] = {}
-        result["componentSuppliers"] = {}
-        result["componentConcludedLicenses"] = {}
-        result["componentCopyrightTexts"] = {}
-
-        result["specVersionProvided"] = self.doc_version
-        result["authorNameProvided"] = self.doc_author
-        result["timestampProvided"] = self.doc_timestamp
-        result["dependencyRelationshipsProvided"] = self.dependency_relationships
-
-        result["componentNames"][
-            "nonconformantComponents"
-        ] = self.components_without_names
-        result["componentNames"]["allProvided"] = not self.components_without_names
-
-        result["componentVersions"][
-            "nonconformantComponents"
-        ] = self.components_without_versions
-        result["componentVersions"][
-            "allProvided"
-        ] = not self.components_without_versions
-
-        result["componentIdentifiers"][
-            "nonconformantComponents"
-        ] = self.components_without_identifiers
-        result["componentIdentifiers"][
-            "allProvided"
-        ] = not self.components_without_identifiers
-
-        result["componentSuppliers"][
-            "nonconformantComponents"
-        ] = self.components_without_suppliers
-        result["componentSuppliers"][
-            "allProvided"
-        ] = not self.components_without_suppliers
-
-        result["componentConcludedLicenses"][
-            "nonconformantComponents"
-        ] = self.components_without_concluded_licenses
-        result["componentConcludedLicenses"][
-            "allProvided"
-        ] = not self.components_without_concluded_licenses
-
-        result["componentCopyrightTexts"][
-            "nonconformantComponents"
-        ] = self.components_without_copyright_texts
-        result["componentCopyrightTexts"][
-            "allProvided"
-        ] = not self.components_without_copyright_texts
-
-        result["totalNumberComponents"] = self.get_total_number_components()
-
-        return result
+        super().print_table_output(
+            verbose=verbose,
+            table_elements=[
+                ("All component names provided?", not self.components_without_names),
+                (
+                    "All component versions provided?",
+                    not self.components_without_versions,
+                ),
+                (
+                    "All component identifiers provided?",
+                    not self.components_without_identifiers,
+                ),
+                (
+                    "All component suppliers provided?",
+                    not self.components_without_suppliers,
+                ),
+                ("SBOM author name provided?", self.doc_author),
+                ("SBOM creation timestamp provided?", self.doc_timestamp),
+                ("Dependency relationships provided?", self.dependency_relationships),
+            ],
+        )
 
     def output_html(self) -> str:
         """Create a HTML of results."""

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -106,62 +106,25 @@ class NTIAChecker(BaseChecker):
             ],
         )
 
-    def output_html(self) -> str:
+    def output_html(self, table_elements=None) -> str:
         """Create a HTML of results."""
-        if self.doc:
-            result = (
-                f" <h2>NTIA Conformance Results</h2> "
-                f"<h3>Conformant: {self.compliant}</h3>"
-                f"<table> <tr> "
-                f"<th>Individual Elements</th> <th>Conformant</th> </tr> "
-                f"<tr> <td>All component names provided</td>"
-                f" <td>{not self.components_without_names}</td> </tr> "
-                f"<tr> <td>All component versions provided</td>"
-                f" <td>{not self.components_without_versions}</td> </tr> "
-                f"<tr> <td>All component identifiers provided</td> "
-                f"<td>{not self.components_without_identifiers}</td> </tr> "
-                f"<tr> <td>All component suppliers provided</td> "
-                f"<td>{not self.components_without_suppliers}</td> "
-                f"</tr> <tr> <td>SBOM author name provided</td> "
-                f"<td>{self.doc_author}</td> </tr> "
-                f"<tr> <td>SBOM creation timestamp provided</td> "
-                f"<td>{self.doc_timestamp}</td> </tr> "
-                f"<tr> <td>Dependency relationships provided?</td> "
-                f"<td>{self.dependency_relationships}</td> </tr> "
-                f"</table>"
-            )
-
-            if self.validation_messages:
-                result += (
-                    "<p>The provided document is not valid according to the SPDX specification. "
-                    "The following errors were found:</p>\n"
-                )
-                result += "<ul>\n"
-                for msg in self.validation_messages:
-                    if msg.validation_message:
-                        result += "<li>\n"
-                        result += "<p><strong>Validation message:</strong></p>\n"
-                        result += f"<p>{msg.validation_message}</p>\n"
-                        if msg.context:
-                            result += "<p><strong>Validation context:</strong></p>\n"
-                            result += "<ul>\n"
-                            result += f"<li>SPDX ID: {msg.context.spdx_id}</li>\n"
-                            result += f"<li>Parent ID: {msg.context.parent_id}</li>\n"
-                            result += (
-                                f"<li>Element type: {msg.context.element_type}</li>\n"
-                            )
-                            result += "</ul>\n"
-                        result += "</li>\n"
-                result += "</ul>\n"
-        else:
-            result = f"""
-            <h2>NTIA Conformance Results</h2>
-            <h3>Conformant: {self.compliant}</h3>
-            <p>The provided document couldn't be parsed, check for NTIA Minimum Elements couldn't be performed.</p>
-            <p>The following SPDXParsingError was raised:<p><ul>"""
-            for error in self.parsing_error:
-                result += f"""<li>{error}</li>"""
-
-            result += """</ul>"""
-
-        return result
+        return super().output_html(
+            table_elements=[
+                ("All component names provided", not self.components_without_names),
+                (
+                    "All component versions provided",
+                    not self.components_without_versions,
+                ),
+                (
+                    "All component identifiers provided",
+                    not self.components_without_identifiers,
+                ),
+                (
+                    "All component suppliers provided",
+                    not self.components_without_suppliers,
+                ),
+                ("SBOM author name provided", self.doc_author),
+                ("SBOM creation timestamp provided", self.doc_timestamp),
+                ("Dependency relationships provided", self.dependency_relationships),
+            ],
+        )

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -3,14 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Report generation functionality."""
+from typing import List
+
+from spdx_tools.spdx.validation.validation_message import ValidationMessage
 
 
-def print_validation_messages(validation_messages, verbose: bool = False) -> None:
+def _safe_attr(obj: object, name: str) -> str:
+    val = getattr(obj, name, None)
+    return str(val) if val not in (None, "") else "N/A"
+
+
+def print_validation_messages(
+    validation_messages: List[ValidationMessage], verbose: bool = False
+) -> None:
     """Helper to print validation messages and optional context details."""
-
-    def _safe_attr(obj: object, name: str) -> str:
-        val = getattr(obj, name, None)
-        return str(val) if val not in (None, "") else "N/A"
 
     for msg in validation_messages:
         if not msg.validation_message:
@@ -22,3 +28,31 @@ def print_validation_messages(validation_messages, verbose: bool = False) -> Non
             print("- Parent ID:", _safe_attr(ctx, "parent_id"))
             print("- Element type:", _safe_attr(ctx, "element_type"))
         print()
+
+
+def get_validation_messages_html(validation_messages: List[ValidationMessage]) -> str:
+    """Helper to generate HTML for validation messages and context details."""
+    if not validation_messages:
+        return ""
+
+    html = "<ul>\n"
+    for msg in validation_messages:
+        if not getattr(msg, "validation_message", None):
+            continue
+        html += "<li>\n"
+        html += "<p><strong>Validation message:</strong></p>\n"
+        html += f"<p>{msg.validation_message}</p>\n"
+        ctx = getattr(msg, "context", None)
+        if ctx:
+            html += "<p><strong>Validation context:</strong></p>\n<ul>\n"
+            spdx_id = getattr(ctx, "spdx_id", "N/A")
+            parent_id = getattr(ctx, "parent_id", "N/A")
+            elem_type = getattr(ctx, "element_type", "N/A")
+            html += f"<li>SPDX ID: {spdx_id}</li>\n"
+            html += f"<li>Parent ID: {parent_id}</li>\n"
+            html += f"<li>Element type: {elem_type}</li>\n"
+            html += "</ul>\n"
+        html += "</li>\n"
+    html += "</ul>"
+
+    return html

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Report generation functionality."""
+
+
+def print_validation_messages(validation_messages, verbose: bool = False) -> None:
+    """Helper to print validation messages and optional context details."""
+
+    def _safe_attr(obj: object, name: str) -> str:
+        val = getattr(obj, name, None)
+        return str(val) if val not in (None, "") else "N/A"
+
+    for msg in validation_messages:
+        if not msg.validation_message:
+            continue
+        print(msg.validation_message)
+        if verbose and getattr(msg, "context", None):
+            ctx = msg.context
+            print("- SPDX ID:", _safe_attr(ctx, "spdx_id"))
+            print("- Parent ID:", _safe_attr(ctx, "parent_id"))
+            print("- Element type:", _safe_attr(ctx, "element_type"))
+        print()

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, final
+from typing import final
 
 from .base_checker import SUPPORTED_SBOM_SPECS, BaseChecker
 
@@ -80,15 +80,6 @@ class SbomChecker(BaseChecker):
         )
 
     def check_compliance(self) -> bool:
-        raise NotImplementedError("This method is not implemented by SbomChecker.")
-
-    def print_components_missing_info(self) -> None:
-        raise NotImplementedError("This method is not implemented by SbomChecker.")
-
-    def print_table_output(self, verbose: bool = False) -> None:
-        raise NotImplementedError("This method is not implemented by SbomChecker.")
-
-    def output_json(self) -> Dict[str, Any]:
         raise NotImplementedError("This method is not implemented by SbomChecker.")
 
     def output_html(self) -> str:

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from typing import final
 
-from .base_checker import SUPPORTED_SBOM_SPECS, BaseChecker
+from .base_checker import BaseChecker
+from .constants import SUPPORTED_SBOM_SPECS
 
 
 @final
@@ -80,7 +81,4 @@ class SbomChecker(BaseChecker):
         )
 
     def check_compliance(self) -> bool:
-        raise NotImplementedError("This method is not implemented by SbomChecker.")
-
-    def output_html(self) -> str:
         raise NotImplementedError("This method is not implemented by SbomChecker.")

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -429,16 +429,18 @@ def test_sbomchecker_output_html():
 
     got = sbom.output_html()
     expected = (
-        " <h2>NTIA Conformance Results</h2> <h3>Conformant: False</h3><table> <tr> "
-        "<th>Individual Elements</th> "
-        "<th>Conformant</th> </tr> "
-        "<tr> <td>All component names provided</td> <td>True</td> </tr> "
-        "<tr> <td>All component versions provided</td> <td>True</td> </tr> "
-        "<tr> <td>All component identifiers provided</td> <td>True</td> </tr> "
-        "<tr> <td>All component suppliers provided</td> <td>False</td> </tr> "
-        "<tr> <td>SBOM author name provided</td> <td>True</td> </tr> "
-        "<tr> <td>SBOM creation timestamp provided</td> <td>True</td> </tr> "
-        "<tr> <td>Dependency relationships provided?</td> <td>True</td> </tr> </table>"
+        "<h2>2021 NTIA SBOM Minimum Elements Conformance Results</h2>\n"
+        "<h3>Conformant: False</h3>\n"
+        "<table>\n"
+        "<tr><th>Individual Elements</th><th>Conformant</th></tr>\n"
+        "<tr><td>All component names provided</td><td>True</td></tr>\n"
+        "<tr><td>All component versions provided</td><td>True</td></tr>\n"
+        "<tr><td>All component identifiers provided</td><td>True</td></tr>\n"
+        "<tr><td>All component suppliers provided</td><td>False</td></tr>\n"
+        "<tr><td>SBOM author name provided</td><td>True</td></tr>\n"
+        "<tr><td>SBOM creation timestamp provided</td><td>True</td></tr>\n"
+        "<tr><td>Dependency relationships provided</td><td>True</td></tr>\n"
+        "</table>"
     )
 
     assert got == expected


### PR DESCRIPTION
- Refactor printout, HTML, and JSON output functions so some code can be shared between different conformance checkers
- BaseChecker will take care of generic output. Customization is possible thru parameters and method overriding.
- This will make it easier to add new conformance checker (for example, #305)