### PR TITLE
Fix verbosity option bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Fixed
+
+- Fix verbosity bug
+
 ## [4.0.0] - 2025-09-05
 
 ### Added
@@ -93,6 +99,7 @@ Thanks to @goneall, @licquia, and @kestewart for mentoring @linynjosh.
 [#1]: https://github.com/spdx/ntia-conformance-checker/pull/1
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/
 [semver]: https://semver.org/spec/v2.0.0.html
+[unreleased]: https://github.com/spdx/ntia-conformance-checker/compare/v4.0.0...main
 [4.0.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.0.0
 [3.2.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v3.2.0
 [3.1.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
-- Fix verbosity bug
+- Fix verbosity bug ([#308][])
+
+[#308]: https://github.com/spdx/ntia-conformance-checker/pull/308
 
 ## [4.0.0] - 2025-09-05
 

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -173,7 +173,10 @@ def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> Optional[Tuple[int,
             logging.debug("Detect SPDX version: spdx_tools parser failed: %s", exc)
             doc = None
         except (ValueError, TypeError, OSError) as exc:
-            logging.debug("Detect SPDX version: Unexpected error while parsing with spdx_tools: %s", exc)
+            logging.debug(
+                "Detect SPDX version: Unexpected error while parsing with spdx_tools: %s",
+                exc,
+            )
             doc = None
 
     # If parsing was successful, return the version tuple. e.g. (2, 3) for 2.3.

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -145,15 +145,6 @@ def get_parsed_args() -> argparse.Namespace:
         parser.print_help()
         sys.exit(0)
 
-    logging.basicConfig(
-        level=(
-            logging.CRITICAL
-            if getattr(args, "quiet", "") == "quiet"
-            else (logging.INFO if getattr(args, "verbose", False) else logging.WARNING)
-        ),
-        format="%(levelname)s: %(message)s",
-    )
-
     return args
 
 
@@ -170,7 +161,7 @@ def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> Optional[Tuple[int,
         Tuple[int, int]: The SPDX major.minor version of the SBOM. E.g. (2, 3) for version 2.3.
     """
     if file.lower().endswith(".xls") or file.lower().endswith(".xlsx"):
-        logging.warning("Excel file format is not supported")
+        logging.debug("Detect SPDX version: Excel file format is not supported")
         return None
 
     # Try parsing the file with spdx_tools first
@@ -179,10 +170,10 @@ def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> Optional[Tuple[int,
         try:
             doc = parse_spdx2_file(file)
         except SPDXParsingError as exc:
-            logging.warning("spdx_tools parser failed: %s", exc)
+            logging.debug("Detect SPDX version: spdx_tools parser failed: %s", exc)
             doc = None
         except (ValueError, TypeError, OSError) as exc:
-            logging.warning("Unexpected error while parsing with spdx_tools: %s", exc)
+            logging.debug("Detect SPDX version: Unexpected error while parsing with spdx_tools: %s", exc)
             doc = None
 
     # If parsing was successful, return the version tuple. e.g. (2, 3) for 2.3.
@@ -201,7 +192,7 @@ def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> Optional[Tuple[int,
         with open(file, "r", encoding="utf-8") as f:
             content = f.read()
     except (OSError, UnicodeDecodeError) as exc:
-        logging.warning("Could not read file: %s", exc)
+        logging.debug("Detect SPDX version: Could not read file: %s", exc)
         return None
 
     # Match MAJOR.MINOR.PATCH version

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -63,10 +63,15 @@ def main() -> None:
         sbom_spec=args.sbom_spec,
     )
 
-    logging.info("Parsing: %s", "OK" if not sbom.parsing_error else "Failed")
-    logging.info("Validation: %s", "OK" if not sbom.validation_messages else "Failed")
+    logging.debug("Parsing: %s", "OK" if not sbom.parsing_error else "Failed")
     if not sbom.parsing_error:
-        logging.info("SBOM name: %s", sbom.sbom_name)
+        if args.skip_validation:
+            logging.debug("Validation: skipped")
+        else:
+            logging.debug(
+                "Validation: %s", "OK" if not sbom.validation_messages else "Failed"
+            )
+        logging.debug("SBOM name: %s", sbom.sbom_name)
 
     if args.output == "print":
         sbom.print_table_output(verbose=args.verbose)


### PR DESCRIPTION
With "--output quiet", the expectation is not to print anything except there's an error