### PR TITLE
Write HTML output to file with --output-file option

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -821,19 +821,20 @@ class BaseChecker(ABC):
             attributes = list(self._COMPONENTS_MISSING.keys())
 
         if all(
-            not getattr(self, components_without_info, None)
-            for components_without_info, _ in self._COMPONENTS_MISSING.values()
+            not getattr(self, list_name, [])
+            for list_name, _ in self._COMPONENTS_MISSING.values()
         ):
             print("No components with missing information.")
             return
 
         for info in attributes:
             if info in self._COMPONENTS_MISSING:
-                components_without_infos, label = self._COMPONENTS_MISSING[info]
-                if components_without_infos:
+                list_name, label = self._COMPONENTS_MISSING[info]
+                components_without_info = getattr(self, list_name, [])
+                if components_without_info:
                     print(
-                        f"{label} ({len(components_without_infos)}): "
-                        f"{', '.join(components_without_infos)}"
+                        f"{label} ({len(components_without_info)}): "
+                        f"{', '.join(components_without_info)}"
                     )
             else:
                 print(f"Unknown attribute: {info!r}\n")

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -291,6 +291,26 @@ def print_output(
             print(json.dumps(result_dict, indent=2))
     elif output_type == "html":
         html_output = sbom.output_html()
-        print(html_output)
+        if output_file:
+            try:
+                with open(output_file, "w", encoding="utf-8") as outfile:
+                    # Put a simple HTML wrapper around the HTML report snippet
+                    outfile.write(
+                        "<!DOCTYPE html>\n"
+                        "<html>\n"
+                        "<head>\n"
+                        "  <title>SBOM Conformance Report</title>\n"
+                        '  <meta charset="utf-8" />\n'
+                        "</head>\n"
+                        "<body>\n"
+                        "<h1>SBOM Conformance Report</h1>\n"
+                    )
+                    outfile.write(f"<p>Filename: {sbom.file}</p>\n")
+                    outfile.write(html_output)
+                    outfile.write("\n</body>\n</html>\n")
+            except OSError as exc:
+                logging.error("Could not write HTML output file: %s", exc)
+        else:
+            print(html_output)
 
     # do nothing if output_type is "quiet" or unrecognized

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -156,9 +156,12 @@ def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> Optional[Tuple[int,
 
     Args:
         file (str): The name of the file to be checked.
+        sbom_spec (str): The SBOM specification hint, the function will try to
+                         use the appropriate parser first.
 
     Returns:
-        Tuple[int, int]: The SPDX major.minor version of the SBOM. E.g. (2, 3) for version 2.3.
+        Tuple[int, int]: The SPDX major.minor version of the SBOM.
+                         E.g. (2, 3) for version 2.3.
     """
     if file.lower().endswith(".xls") or file.lower().endswith(".xlsx"):
         logging.debug("Detect SPDX version: Excel file format is not supported")

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -6,74 +6,11 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
-from typing import Any, Dict, Optional, Tuple
 
-from .cli_utils import get_parsed_args, get_spdx_version
-from .constants import SUPPORTED_SBOM_SPECS, SUPPORTED_SPDX_VERSIONS
-from .sbom_checker import BaseChecker, SbomChecker
-
-
-def _detect_sbom_spec(file: str, sbom_spec: str) -> str:
-    detected_sbom_spec: str = ""
-
-    if sbom_spec not in SUPPORTED_SBOM_SPECS:
-        logging.error(
-            "Unsupported SBOM specification: %s. Supported: %s",
-            sbom_spec,
-            ", ".join(sorted(SUPPORTED_SBOM_SPECS)),
-        )
-        return ""
-
-    if sbom_spec.startswith("spdx"):
-        spdx_version: Optional[Tuple[int, int]] = get_spdx_version(
-            file, sbom_spec=sbom_spec
-        )
-        if not spdx_version:
-            logging.error("Could not determine SPDX version from SBOM.")
-            return ""
-        logging.debug("Detected SPDX version: %d.%d", spdx_version[0], spdx_version[1])
-
-        if spdx_version not in SUPPORTED_SPDX_VERSIONS:
-            logging.error(
-                "Unsupported SPDX version: %d.%d. Supported: %s",
-                spdx_version[0],
-                spdx_version[1],
-                ", ".join(
-                    f"{maj}.{min}" for maj, min in sorted(SUPPORTED_SPDX_VERSIONS)
-                ),
-            )
-            return ""
-
-        if spdx_version[0] == 3:
-            detected_sbom_spec = "spdx3"
-        elif spdx_version[0] == 2:
-            detected_sbom_spec = "spdx2"
-
-    return detected_sbom_spec
-
-
-def _print_output(
-    sbom: BaseChecker, *, output_type: str, output_file: str, verbose: bool
-) -> None:
-    if output_type == "print":
-        sbom.print_table_output(verbose=verbose)
-        if verbose:
-            sbom.print_components_missing_info()
-    elif output_type == "json":
-        result_dict: Dict[str, Any] = sbom.output_json()
-        if output_file:
-            with open(output_file, "w", encoding="utf-8") as outfile:
-                json.dump(result_dict, outfile)
-        else:
-            print(json.dumps(result_dict, indent=2))
-    elif output_type == "html":
-        html_output = sbom.output_html()
-        print(html_output)
-
-    # do nothing if output_type is "quiet" or unrecognized
+from .cli_utils import get_parsed_args, get_sbom_spec, print_output
+from .sbom_checker import SbomChecker
 
 
 def main() -> None:
@@ -91,7 +28,7 @@ def main() -> None:
         "SPDX validation: %s", "enabled" if not args.skip_validation else "disabled"
     )
 
-    detected_sbom_spec = _detect_sbom_spec(file=args.file, sbom_spec=args.sbom_spec)
+    detected_sbom_spec = get_sbom_spec(file=args.file, sbom_spec=args.sbom_spec)
     if not detected_sbom_spec:
         sys.exit(1)
 
@@ -112,7 +49,7 @@ def main() -> None:
             )
         logging.debug("SBOM name: %s", sbom.sbom_name)
 
-    _print_output(
+    print_output(
         sbom,
         output_type=args.output,
         output_file=args.output_file,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ from typing import List, Tuple
 import pytest
 from beartype.roar import BeartypeCallHintParamViolation
 
-from ntia_conformance_checker.main import get_spdx_version
+from ntia_conformance_checker.cli_utils import get_sbom_spec, get_spdx_version
 
 spdx2_2_dir = Path(__file__).parent / "data" / "missing_component_name"
 spdx2_3_dir = Path(__file__).parent / "data" / "missing_timestamp"
@@ -28,7 +28,8 @@ detect_version_test: List[Tuple[Path, Tuple[int, ...]]] = [
     (spdx2_3_dir / "SPDXTagExample-v2.3.spdx", (2, 3)),
     (spdx2_3_dir / "SPDXXMLExample-v2.3.spdx.xml", (2, 3)),
     (spdx2_3_dir / "SPDXYAMLExample-v2.3.spdx.yaml", (2, 3)),
-    (spdx3_0_dir / "dataset-example01.json", (3, 0)),
+    (spdx3_0_dir / "no_elements_missing.json", (3, 0)),
+    (spdx3_0_dir / "has_sbom.json", (3, 0)),
 ]
 
 
@@ -39,6 +40,33 @@ def test_detect_spdx_version():
             assert (
                 version == expected_version
             ), f"Expected {expected_version}, got {version} for {file_path}"
+        except BeartypeCallHintParamViolation:
+            pytest.xfail(
+                "Beartype type violation (assigning None) due to missing field in SPDX document"
+            )
+
+
+detect_sbom_spec_test: List[Tuple[Path, str]] = [
+    (spdx2_2_dir / "SPDXJsonExample.json", "spdx2"),
+    (spdx2_2_dir / "SPDXXmlExample.xml", "spdx2"),
+    (spdx2_2_dir / "SPDXYamlExample.yaml", "spdx2"),
+    (spdx2_3_dir / "SPDXJSONExample-v2.3.spdx.json", "spdx2"),
+    (spdx2_3_dir / "SPDXRdfExample-v2.3.spdx.rdf.xml", "spdx2"),
+    (spdx2_3_dir / "SPDXTagExample-v2.3.spdx", "spdx2"),
+    (spdx2_3_dir / "SPDXXMLExample-v2.3.spdx.xml", "spdx2"),
+    (spdx2_3_dir / "SPDXYAMLExample-v2.3.spdx.yaml", "spdx2"),
+    (spdx3_0_dir / "no_elements_missing.json", "spdx3"),
+    (spdx3_0_dir / "has_sbom.json", "spdx3"),
+]
+
+
+def test_detect_sbom_spec():
+    for file_path, expected_sbom_spec in detect_sbom_spec_test:
+        try:
+            sbom_spec = get_sbom_spec(str(file_path), sbom_spec=expected_sbom_spec)
+            assert (
+                sbom_spec == expected_sbom_spec
+            ), f"Expected {expected_sbom_spec}, got {sbom_spec} for {file_path}"
         except BeartypeCallHintParamViolation:
             pytest.xfail(
                 "Beartype type violation (assigning None) due to missing field in SPDX document"


### PR DESCRIPTION
Currently `--output-file` option only works with JSON output. Make it works with HTML output as well.

Also
- Simplify the main function by moving SBOM spec detection and output printing to cli_utils.py.
- Add test for SBOM spec detection function.
- Fix bug when printing components missing info.