### PR TITLE
Update dependencies for Python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         cache: "pip"
     - name: Install dependencies
       run: |
-        pip install pip==25.2
+        pip install pip==25.3
         pip install build==1.3.0
     - name: Build package
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -33,8 +33,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install pylint==3.3.8
-        pip install .[test]
+        pip install pylint==3.3.9
     - name: Analysing the code with Pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install pylint==3.3.9
+        pip install .[test]
     - name: Analysing the code with Pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2024 SPDX contributors
+# SPDX-FileCopyrightText: 2024-2025 SPDX contributors
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=80.9.0", "setuptools-scm[toml]>=9.2.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -56,19 +56,23 @@ dependencies = ["spdx-python-model==0.0.3", "spdx-tools==0.8.3"]
 
 [project.optional-dependencies]
 dev = [
-    "black>=25.1.0",
-    "mypy>=1.17.1",
-    "pylint>=3.3.8",
-    "pyrefly>=0.31.0",
-    "pyright>=1.1.406",
+    "black>=25.9.0",
+    "mypy>=1.18.2",
+    "pylint>=3.3.9", # 3.3.9 is the last version supporting Python 3.9
+    "pyrefly>=0.39.4",
+    "pyright>=1.1.407",
     "pytype>=2024.9.13", # 2024.9.13 is the last version supporting Python 3.9
-    "ruff>=0.12.12",
+    "ruff>=0.14.3",
 ]
 docs = [
     "sphinx>=7.4.7", # 7.4.7 is the last version supporting Python 3.9
     "sphinx-rtd-theme>=3.0.2",
 ]
-test = ["beartype==0.22.2", "coverage==7.10.7", "pytest==8.4.2"]
+test = [
+    "beartype==0.21.0", # 0.21.0 is the last version supporting Python 3.9
+    "coverage==7.10.7", # 7.10.7 is the last version supporting Python 3.9
+    "pytest==8.4.2"
+]
 
 [project.scripts]
 # Both "ntia-checker" and "sbomcheck" are identical.


### PR DESCRIPTION
- Update dependencies to the latest version that supporting Python 3.9
- Downgrade beartype to 0.21.0 (0.22.0 needs Python 3.10 minimum)