### PR TITLE
Remove coverage dependency for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ docs = [
 ]
 test = [
     "beartype==0.21.0", # 0.21.0 is the last version supporting Python 3.9
-    "coverage==7.10.7", # 7.10.7 is the last version supporting Python 3.9
     "pytest==8.4.2"
 ]
 


### PR DESCRIPTION
Remove `coverage` version for Python 3.9.

I don't think `coverage` is needed. But maybe I'm missing something?