### PR TITLE
Fix FSCT3Checker failed to report components without required info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [4.1.1] - 2025-11-18
 
+This version primarily focused on improving the HTML output.
+
+The HTML output is now organized into four distinct div blocks,
+each with a specific CSS class for easy styling and targeting:
+
+- Errors (parsing, etc.): `<div class="conformance-err">`
+- Conformance results: `<div class="conformance-res">`
+- Components missing required information: `<div class="conformance-mis">`
+- Detailed validation information: `<div class="conformance-val">`
+
+Note: Python 3.9 support will be dropped in the next major release.
+This is likely the final version supporting it.
+
 ### Fixed
 
 - Fix FSCT3Checker that do not report components without required information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
-## [4.1.1] - 2025-11-17
+## [4.1.1] - 2025-11-18
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 - Fix FSCT3Checker that do not report components without required information
+  ([#326][])
+
+[#326]: https://github.com/spdx/ntia-conformance-checker/pull/326
 
 ## [4.1.0] - 2025-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
+## [4.1.1] - 2025-11-17
+
+### Fixed
+
+- Fix FSCT3Checker that do not report components without required information
+
 ## [4.1.0] - 2025-11-17
 
 This version primarily focused on improving the HTML output.
@@ -159,6 +165,7 @@ Thanks to @goneall, @licquia, and @kestewart for mentoring @linynjosh.
 [#1]: https://github.com/spdx/ntia-conformance-checker/pull/1
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/
 [semver]: https://semver.org/spec/v2.0.0.html
+[4.1.1]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.1
 [4.1.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.0
 [4.0.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.0.0
 [3.2.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v3.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -50,4 +50,4 @@ keywords:
   - CISA
 license: Apache-2.0
 version: 4.1.1
-date-released: '2025-11-17'
+date-released: '2025-11-18'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -49,5 +49,5 @@ keywords:
   - NTIA
   - CISA
 license: Apache-2.0
-version: 4.1.0
+version: 4.1.1
 date-released: '2025-11-17'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This tool determines whether a [SPDX](https://spdx.dev/) software bill of
 materials (SBOM) document contains informational items as required by a
 certain specification.
 
+A web-based version of the tool is available (no installation needed) at:
+<https://tools.spdx.org/app/ntia_checker/>
+
 ## Conformance
 
 Currently, the supported specifications are:
@@ -77,7 +80,7 @@ if you work with multiple Python versions.
 it lets you keep a project's dependencies in a single environment
 or create separate environments for testing with different Python versions.
 
-## CLI Usage
+## CLI usage
 
 ```text
 usage: sbomcheck [OPTIONS] FILE
@@ -143,7 +146,7 @@ Use `-h` for help:
 sbomcheck -h
 ```
 
-## Usage as a Library
+## Usage as a library
 
 `ntia-conformance-checker` can also be imported as a library. For example:
 
@@ -164,12 +167,22 @@ Specific properties and methods for a particular specification can be found
 at the checker for that specification. For example, `NTIAChecker` class
 at [`ntia_checker.py`](ntia_conformance_checker/ntia_checker.py).
 
-## Online Usage
+## Online usage
 
 With the SPDX Online Tool, you can check the SBOM conformance without the need
 to install the Python package.
 
 Go to this page: <https://tools.spdx.org/app/ntia_checker/>.
+
+## HTML output
+
+The HTML output is organized into four distinct div blocks,
+each with a specific CSS class for easy styling and targeting:
+
+- Errors (parsing, etc.): `<div class="conformance-err">`
+- Conformance results: `<div class="conformance-res">`
+- Components missing required information: `<div class="conformance-mis">`
+- Detailed validation information: `<div class="conformance-val">`
 
 ## History
 

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -25,7 +25,7 @@ class FSCT3Checker(BaseChecker):
         https://www.cisa.gov/resources-tools/resources/framing-software-component-transparency-2024
     """
 
-    MIN_COMPONENTS = [
+    MIN_ELEMENTS = [
         "name",
         "version",
         "identifier",

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -46,7 +46,6 @@ class NTIAChecker(BaseChecker):
 
         if self.doc:
             self.compliant = self.check_compliance()
-
             # for backward compatibility
             self.ntia_minimum_elements_compliant = self.compliant
 

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -242,6 +242,7 @@ def report_html(
 
     # Components without required information
     if rc.components_without_info:
+        report.append("<div class='conformance-missing'>")
         report.append(
             "<p class='conformance-missing-label'>"
             "Missing required information in these components:"
@@ -254,22 +255,21 @@ def report_html(
                 f"{', '.join(components)}</li>"
             )
         report.append("</ul>")
+        report.append("</div>")
 
     # Validation messages
     if rc.validation_messages:
-        report.append(
-            "<p class='conformance-val'>"
-            "The document is not valid according to the SBOM specification"
-            f' ("{rc.sbom_spec}").'
-            "</p>"
-        )
+        report.append("<div class='conformance-val'>")
         report.append(
             "<p class='conformance-val-label'>"
+            "The document is not valid according to the SBOM specification"
+            f' ("{rc.sbom_spec}").<br />'
             "The following violations were found:"
             "</p>"
         )
         report.append(
             get_validation_messages_html(rc.validation_messages, verbose=verbose)
         )
+        report.append("</div>")
 
     return "\n".join(report)

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -190,33 +190,33 @@ def report_html(
 
     # Parsing error
     if rc.parsing_error:
+        report.append("<div class='conformance-err'>")
         report.append(
-            "<p class='conformance-err'>"
-            "The document couldn't be parsed; check couldn't be performed."
+            "<p class='conformance-err-label'>"
+            "The document couldn't be parsed; check couldn't be performed.<br />"
+            "The following parsing errors were raised:"
             "</p>"
         )
-        if rc.parsing_error:
-            report.append(
-                "<p class='conformance-err-details-label'>"
-                "The following parsing errors were raised:"
-                "</p>"
-            )
-            report.append("<ul class='conformance-err-details'>")
-            for err in rc.parsing_error:
-                report.append(f"<li>{err}</li>")
-            report.append("</ul>")
+        report.append("<ul class='conformance-err-list'>")
+        for err in rc.parsing_error:
+            report.append(f"<li>{err}</li>")
+        report.append("</ul>")
+        report.append("</div>")
         return "\n".join(report)
 
     # Unsupported compliance standard
     if rc.compliance_standard not in SUPPORTED_COMPLIANCE_STANDARDS:
         report.append(
-            "<p class='conformance-err'>"
+            "<div class='conformance-err'>"
+            "<p class='conformance-err-label'>"
             f"Unsupported compliance standard {rc.compliance_standard!r}"
             "</p>"
+            "</div>"
         )
         return "\n".join(report)
 
     # Compliance results
+    report.append("<div class='conformance-res'>")
     report.append(
         "<h2 class='conformance-res-title'>"
         f"{SUPPORTED_COMPLIANCE_STANDARDS_DESC[rc.compliance_standard]}"
@@ -240,15 +240,17 @@ def report_html(
         report.append("</tbody>")
         report.append("</table>")
 
+    report.append("</div>") # End of conformance-res
+
     # Components without required information
     if rc.components_without_info:
-        report.append("<div class='conformance-missing'>")
+        report.append("<div class='conformance-mis'>")
         report.append(
-            "<p class='conformance-missing-label'>"
+            "<p class='conformance-mis-label'>"
             "Missing required information in these components:"
             "</p>"
         )
-        report.append("<ul class='conformance-missing-list'>")
+        report.append("<ul class='conformance-mis-list'>")
         for component_name, components in rc.components_without_info:
             report.append(
                 f"<li>{component_name} ({len(components)}): "

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -240,7 +240,7 @@ def report_html(
         report.append("</tbody>")
         report.append("</table>")
 
-    report.append("</div>") # End of conformance-res
+    report.append("</div>")  # End of conformance-res
 
     # Components without required information
     if rc.components_without_info:

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -81,7 +81,7 @@ def validate_spdx3_data(
         if not isinstance(root_element, (spdx3.Bom, spdx3.software_Sbom)):
             error_msg = (
                 "The root element must be of type Bom or software_Sbom. "
-                f"Found: {type(root_element)}"
+                f"Found: r{type(root_element)}"
             )
             root_element_id = getattr(root_element, "spdxId", None)
             context = ValidationContext(parent_id=doc_id, spdx_id=root_element_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ntia_conformance_checker"
-version = "4.1.0"
+version = "4.1.1"
 authors = [
     { name = "Josh Lin", email = "linynjosh@gmail.com" },
     { name = "John Speed Meyers", email = "johnmeyersster@gmail.com" },

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -466,6 +466,7 @@ def test_sbomchecker_output_html():
 
     assert got == expected
 
+
 def test_sbomchecker_fsct3_output_html():
     filepath = os.path.join(
         os.path.dirname(__file__), "data", "other_tests", "SPDXSBOMExample.spdx.yml"
@@ -516,6 +517,7 @@ def test_sbomchecker_fsct3_output_html():
     )
 
     assert got == expected
+
 
 def test_components_without_functions():
     filepath = os.path.join(

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -453,11 +453,13 @@ def test_sbomchecker_output_html():
         "<td class='conformance-res-tab-v'>True</td></tr>\n"
         "</tbody>\n"
         "</table>\n"
+        "<div class='conformance-missing'>\n"
         "<p class='conformance-missing-label'>"
         "Missing required information in these components:</p>\n"
         "<ul class='conformance-missing-list'>\n"
         "<li>supplier (3): xyz, curl, openssl</li>\n"
-        "</ul>"
+        "</ul>\n"
+        "</div>"
     )
 
     assert got == expected

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 SPDX contributors
+# SPDX-FileCopyrightText: 2024-2025 SPDX contributors
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
@@ -429,6 +429,7 @@ def test_sbomchecker_output_html():
 
     got = sbom.output_html()
     expected = (
+        "<div class='conformance-res'>\n"
         "<h2 class='conformance-res-title'>"
         "2021 NTIA SBOM Minimum Elements Conformance Results"
         "</h2>\n"
@@ -453,10 +454,11 @@ def test_sbomchecker_output_html():
         "<td class='conformance-res-tab-v'>True</td></tr>\n"
         "</tbody>\n"
         "</table>\n"
-        "<div class='conformance-missing'>\n"
-        "<p class='conformance-missing-label'>"
+        "</div>\n"
+        "<div class='conformance-mis'>\n"
+        "<p class='conformance-mis-label'>"
         "Missing required information in these components:</p>\n"
-        "<ul class='conformance-missing-list'>\n"
+        "<ul class='conformance-mis-list'>\n"
         "<li>supplier (3): xyz, curl, openssl</li>\n"
         "</ul>\n"
         "</div>"
@@ -464,6 +466,56 @@ def test_sbomchecker_output_html():
 
     assert got == expected
 
+def test_sbomchecker_fsct3_output_html():
+    filepath = os.path.join(
+        os.path.dirname(__file__), "data", "other_tests", "SPDXSBOMExample.spdx.yml"
+    )
+    sbom = sbom_checker.SbomChecker(filepath, compliance="fsct3-min")
+
+    got = sbom.output_html()
+    expected = (
+        "<div class='conformance-res'>\n"
+        "<h2 class='conformance-res-title'>"
+        "2024 CISA Framing Software Component Transparency"
+        " (minimum expectation) Conformance Results"
+        "</h2>\n"
+        "<h3 class='conformance-res-status'>Conformant: False</h3>\n"
+        "<table class='conformance-res-tab'>\n"
+        "<thead><tr><th>Requirement</th>"
+        "<th>Conformant</th></tr></thead>\n"
+        "<tbody>\n"
+        "<tr><td class='conformance-res-tab-r'>All component names provided?</td>"
+        "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>All component versions provided?</td>"
+        "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>All component identifiers provided?</td>"
+        "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>All component suppliers provided?</td>"
+        "<td class='conformance-res-tab-v'>False</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>All component concluded license provided?</td>"
+        "<td class='conformance-res-tab-v'>False</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>All component copyright notice provided?</td>"
+        "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>SBOM author name provided?</td>"
+        "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>SBOM creation timestamp provided?</td>"
+        "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>Dependency relationships provided?</td>"
+        "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "</tbody>\n"
+        "</table>\n"
+        "</div>\n"
+        "<div class='conformance-mis'>\n"
+        "<p class='conformance-mis-label'>"
+        "Missing required information in these components:</p>\n"
+        "<ul class='conformance-mis-list'>\n"
+        "<li>supplier (3): xyz, curl, openssl</li>\n"
+        "<li>concluded_license (3): xyz, curl, openssl</li>\n"
+        "</ul>\n"
+        "</div>"
+    )
+
+    assert got == expected
 
 def test_components_without_functions():
     filepath = os.path.join(


### PR DESCRIPTION
Hotfix: The FSCT3Checker failed to report components lacking required information because the constant listing the minimum required elements was incorrectly named.

Correction: Renamed constant from `MIN_COMPONENTS` to the correct name, `MIN_ELEMENTS`.