### PR TITLE
Fix validation message order at command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
+## [4.1.2] - 2025-11-19
+
+Note: Python 3.9 support will be dropped in the next major release.
+This is likely the final version supporting it.
+
+### Fixed
+
+- Fix validation message order at command line ([#327][])
+
+[#327]: https://github.com/spdx/ntia-conformance-checker/pull/327
+
 ## [4.1.1] - 2025-11-18
 
 This version primarily focused on improving the HTML output.
@@ -181,6 +192,7 @@ Thanks to @goneall, @licquia, and @kestewart for mentoring @linynjosh.
 [#1]: https://github.com/spdx/ntia-conformance-checker/pull/1
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/
 [semver]: https://semver.org/spec/v2.0.0.html
+[4.1.2]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.2
 [4.1.1]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.1
 [4.1.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.0
 [4.0.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.0.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -49,5 +49,5 @@ keywords:
   - NTIA
   - CISA
 license: Apache-2.0
-version: 4.1.1
-date-released: '2025-11-18'
+version: 4.1.2
+date-released: '2025-11-19'

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -164,11 +164,11 @@ def report_text(
 
     if rc.validation_messages:
         report.append(
-            "\nThe document is not valid according to the SBOM "
+            "The document is not valid according to the SBOM "
             f'specification ("{rc.sbom_spec}"). '
             "The following violations were found:\n"
         )
-        print_validation_messages(rc.validation_messages, verbose)
+        report.append(get_validation_messages_text(rc.validation_messages, verbose))
 
     return "\n".join(report)
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -81,7 +81,7 @@ def validate_spdx3_data(
         if not isinstance(root_element, (spdx3.Bom, spdx3.software_Sbom)):
             error_msg = (
                 "The root element must be of type Bom or software_Sbom. "
-                f"Found: r{type(root_element)}"
+                f"Found: {type(root_element)!r}"
             )
             root_element_id = getattr(root_element, "spdxId", None)
             context = ValidationContext(parent_id=doc_id, spdx_id=root_element_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ntia_conformance_checker"
-version = "4.1.1"
+version = "4.1.2"
 authors = [
     { name = "Josh Lin", email = "linynjosh@gmail.com" },
     { name = "John Speed Meyers", email = "johnmeyersster@gmail.com" },


### PR DESCRIPTION
The validation messages should be printed after the text "The following violations were found:".

Test by

```shell
sbomcheck tests/data/spdx3/has_no_sbom.json
```

Currently, it printed like this, noted the line "The root element must be.."

> ERROR: SpdxDocument not found or invalid.
> The root element must be of type Bom or software_Sbom. Found: r<class 'spdx_python_model.bindings.v3_0_1.software_Package'>
>
> 2021 NTIA SBOM Minimum Elements Conformance Results
>
> ...
>
> The document is not valid according to the SBOM specification ("spdx3"). The following violations were found:

It should print like this:

> ERROR: SpdxDocument not found or invalid.
> 2021 NTIA SBOM Minimum Elements Conformance Results
> 
> ...
> The document is not valid according to the SBOM specification ("spdx3"). The following violations were found:
>
> The root element must be of type Bom or software_Sbom. Found: <class 'spdx_python_model.bindings.v3_0_1.software_Package'>



