### PR TITLE
Add cooldown settings for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
I suggest adding a cooldown period to the dependabot updates. See this blog post for why: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns