### PR TITLE
Use type hinting generics for collections and X | Y for union

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.13", "3.12", "3.11", "3.10"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9"]
+        python-version: ["3.13", "3.12", "3.11", "3.10"]
 
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
@@ -33,7 +33,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install pylint==3.3.9
+        pip install pylint>=4.0.4
         pip install .[test]
     - name: Analysing the code with Pylint
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         pip install build==1.3.0

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,11 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Setup Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
-## [5.0.0] - 2025-12-17
+## [5.0.0] - 2025-12-18
 
 ntia-conformance-checker 5.0.0 requires Python 3.12 or newer.
+
+Update code to use type hinting generics for standard collections ([PEP 585])
+and use `X | Y` for union types ([PEP 604]).
 
 ### Fixed
 
@@ -33,7 +36,11 @@ ntia-conformance-checker 5.0.0 requires Python 3.12 or newer.
   ]
   ```
 
+- The type hints have been updated to use generics (PEP 585) in standard collections and union types as X | Y (PEP 604).
+
 [#331]: https://github.com/spdx/ntia-conformance-checker/pull/331
+[PEP 585]: https://peps.python.org/pep-0585/
+[PEP 604]: https://peps.python.org/pep-0604/
 
 ## [4.1.2] - 2025-11-19
 
@@ -138,8 +145,6 @@ This is likely the final version supporting it.
 [#288]: https://github.com/spdx/ntia-conformance-checker/pull/288
 [#272]: https://github.com/spdx/ntia-conformance-checker/pull/272
 [#281]: https://github.com/spdx/ntia-conformance-checker/pull/281
-[PEP 585]: https://peps.python.org/pep-0585/
-[PEP 604]: https://peps.python.org/pep-0604/
 
 ## [3.2.0] - 2025-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [5.0.0] - 2025-12-18
 
-ntia-conformance-checker 5.0.0 requires Python 3.12 or newer.
+ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
 Update code to use type hinting generics for standard collections ([PEP 585])
 and use `X | Y` for union types ([PEP 604]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ and this project adheres to [Semantic Versioning][semver].
 
 ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
-Update code to use type hinting generics for standard collections ([PEP 585])
-and use `X | Y` for union types ([PEP 604]).
-
 ### Fixed
 
 - Fix validation messages that did not properly serialize in JSON output
@@ -36,9 +33,11 @@ and use `X | Y` for union types ([PEP 604]).
   ]
   ```
 
-- The type hints have been updated to use generics (PEP 585) in standard collections and union types as X | Y (PEP 604).
+- Use type hinting generics for standard collections ([PEP 585])
+  and use `X | Y` for union types ([PEP 604]) ([#339])
 
 [#331]: https://github.com/spdx/ntia-conformance-checker/pull/331
+[#339]: https://github.com/spdx/ntia-conformance-checker/pull/339
 [PEP 585]: https://peps.python.org/pep-0585/
 [PEP 604]: https://peps.python.org/pep-0604/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
-## [4.1.3] - 2025-11-30
+## [5.0.0] - 2025-12-17
 
-Note: Python 3.9 support will be dropped in the next major release.
-This is likely the final version supporting it.
+ntia-conformance-checker 5.0.0 requires Python 3.12 or newer.
 
 ### Fixed
 
@@ -275,7 +274,7 @@ Thanks to @goneall, @licquia, and @kestewart for mentoring @linynjosh.
 [#1]: https://github.com/spdx/ntia-conformance-checker/pull/1
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[4.1.3]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.3
+[5.0.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v5.0.0
 [4.1.2]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.2
 [4.1.1]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.1
 [4.1.0]: https://github.com/spdx/ntia-conformance-checker/releases/tag/v4.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -50,4 +50,4 @@ keywords:
   - CISA
 license: Apache-2.0
 version: 5.0.0
-date-released: '2025-12-17'
+date-released: '2025-12-18'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -49,5 +49,5 @@ keywords:
   - NTIA
   - CISA
 license: Apache-2.0
-version: 4.1.3
-date-released: '2025-11-30'
+version: 5.0.0
+date-released: '2025-12-17'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Mappings:
 
 ## Installation
 
-This tool requires Python 3.9+.
+This tool requires Python 3.12 or newer.
 Its dependencies may require a more recent version of Python.
 
 *Installation Method #1*:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Mappings:
 
 ## Installation
 
-This tool requires Python 3.12 or newer.
+This tool requires Python 3.10 or newer.
 Its dependencies may require a more recent version of Python.
 
 *Installation Method #1*:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 5.x   | :white_check_mark: |
 | 4.x   | :white_check_mark: |
-| 3.x   | :white_check_mark: |
+| 3.x   | :x: |
 | 2.x   | :x: |
 | 1.x   | :x: |
 | 0.x   | :x: |

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -140,25 +140,24 @@ class BaseChecker(ABC):
         self.parsing_error = []
         self.validation_messages = []
 
-        # SPDX 2
-        if sbom_spec == "spdx2":
-            self.doc = self.parse_file()
-        # SPDX 3
-        elif sbom_spec == "spdx3":
-            object_set = self.parse_spdx3_file()
-            if not object_set:
-                logging.error("Failed to parse the SPDX 3 file.")
-            else:
-                self.doc = object_set
-                _doc, _validation_messages = validate_spdx3_data(object_set)
-                if not _doc or _validation_messages:
-                    logging.error("SpdxDocument not found or invalid.")
-                self.__spdx3_doc = _doc  # cache the extracted SpdxDocument
-                self.validation_messages.extend(_validation_messages)
-        else:
-            # We can add a heuristic to detect the spec from the file content here,
-            # in case sbom_spec is not provided or invalid.
-            raise ValueError(f"Unsupported SBOM specification: {sbom_spec}")
+        match sbom_spec:
+            case "spdx2":
+                self.doc = self.parse_file()
+            case "spdx3":
+                object_set = self.parse_spdx3_file()
+                if not object_set:
+                    logging.error("Failed to parse the SPDX 3 file.")
+                else:
+                    self.doc = object_set
+                    _doc, _validation_messages = validate_spdx3_data(object_set)
+                    if not _doc or _validation_messages:
+                        logging.error("SpdxDocument not found or invalid.")
+                    self.__spdx3_doc = _doc  # cache the extracted SpdxDocument
+                    self.validation_messages.extend(_validation_messages)
+            case _:
+                # We can add a heuristic to detect the spec from the file content here,
+                # in case sbom_spec is not provided or invalid.
+                raise ValueError(f"Unsupported SBOM specification: {sbom_spec}")
 
         if self.doc:
             if validate:

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -51,7 +51,7 @@ class BaseChecker(ABC):
     """
 
     # Minimum elements/baseline attributes required by a compliance standard
-    MIN_ELEMENTS: List[str] = []
+    MIN_ELEMENTS: list[str] = []
 
     # Mapping of components without information
     # SBOM component name: (list containing components missing the info, label)
@@ -83,19 +83,20 @@ class BaseChecker(ABC):
     # For SPDX 3, we have to use SHACLObjectSet instead of SpdxDocument,
     # because we need access to relationships and other elements that are not
     # accessible from SpdxDocument.
-    doc: Union[Document, spdx3.SHACLObjectSet, None] = None
-    __spdx3_doc: Optional[spdx3.SpdxDocument] = None  # cached SPDX 3 document
 
-    parsing_error: List[str] = []
-    validation_messages: List[ValidationMessage] = []
+    doc: Document | spdx3.SHACLObjectSet | None = None
+    __spdx3_doc: spdx3.SpdxDocument | None = None  # cached SPDX 3 document
+
+    parsing_error: list[str] = []
+    validation_messages: list[ValidationMessage] = []
 
     sbom_name: str = ""
-    components_without_names: List[str] = []
-    components_without_versions: List[str] = []
-    components_without_suppliers: List[str] = []
-    components_without_identifiers: List[str] = []
-    components_without_concluded_licenses: List[str] = []
-    components_without_copyright_texts: List[str] = []
+    components_without_names: list[str] = []
+    components_without_versions: list[str] = []
+    components_without_suppliers: list[str] = []
+    components_without_identifiers: list[str] = []
+    components_without_concluded_licenses: list[str] = []
+    components_without_copyright_texts: list[str] = []
 
     doc_version: bool = False  # Has SPDX document version?
     doc_author: bool = False  # Has SPDX document author?
@@ -191,11 +192,11 @@ class BaseChecker(ABC):
                 "List[str]", self.get_components_without_copyright_texts()
             )
 
-            self.all_components_without_info: List[Tuple[str, List[str]]] = (
+            self.all_components_without_info: list[tuple[str, list[str]]] = (
                 self._get_all_components_without_info()
             )
 
-        self.table_elements: List[Tuple[str, bool]] = []
+        self.table_elements: list[tuple[str, bool]] = []
 
     def check_doc_version(self) -> bool:
         """Check if the document's specification version exists."""
@@ -308,12 +309,12 @@ class BaseChecker(ABC):
 
         return False
 
-    def get_doc_spec_version(self) -> Optional[str]:
+    def get_doc_spec_version(self) -> str | None:
         """Retrieve the document's specification version."""
         if not self.doc:
             return None
 
-        doc_spec_version: Optional[str] = None
+        doc_spec_version: str | None = None
 
         # SPDX 2
         if self.sbom_spec == "spdx2":
@@ -778,7 +779,7 @@ class BaseChecker(ABC):
 
         return 0
 
-    def parse_file(self) -> Optional[Document]:
+    def parse_file(self) -> Document | None:
         """
         Parse SPDX 2 SBOM document.
 
@@ -802,7 +803,7 @@ class BaseChecker(ABC):
 
         return cast("Document", doc)
 
-    def parse_spdx3_file(self) -> Optional[spdx3.SHACLObjectSet]:
+    def parse_spdx3_file(self) -> spdx3.SHACLObjectSet | None:
         """
         Parse SPDX 3 SBOM document.
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
 from spdx_tools.spdx.model.relationship import RelationshipType
@@ -177,19 +177,19 @@ class BaseChecker(ABC):
 
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = cast(
-                "List[str]", self.get_components_without_versions()
-            )  # with return_tuples=False, always get List[str]
+                "list[str]", self.get_components_without_versions()
+            )  # with return_tuples=False, always get list[str]
             self.components_without_suppliers = cast(
-                "List[str]", self.get_components_without_suppliers()
+                "list[str]", self.get_components_without_suppliers()
             )
             self.components_without_identifiers = (
                 self.get_components_without_identifiers()
             )
             self.components_without_concluded_licenses = cast(
-                "List[str]", self.get_components_without_concluded_licenses()
+                "list[str]", self.get_components_without_concluded_licenses()
             )
             self.components_without_copyright_texts = cast(
-                "List[str]", self.get_components_without_copyright_texts()
+                "list[str]", self.get_components_without_copyright_texts()
             )
 
             self.all_components_without_info: list[tuple[str, list[str]]] = (
@@ -359,7 +359,7 @@ class BaseChecker(ABC):
     # pylint: disable=too-many-return-statements
     def get_components_without_concluded_licenses(
         self, return_tuples: bool = False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve names and/or SPDX IDs of components without concluded licenses.
 
@@ -369,7 +369,7 @@ class BaseChecker(ABC):
                                   If False, return a list of component names.
 
         Returns:
-            Union[List[str], List[Tuple[str, str]]]: A list of component names
+            list[str] | list[tuple[str, str]]: A list of component names
             or a list of tuples with component names and SPDX IDs.
         """
         # Note: concluded license is mandatory in SPDX-2.2 and SPDX-2.3
@@ -383,7 +383,7 @@ class BaseChecker(ABC):
                 return []
 
             if return_tuples:
-                components_name_id: List[Tuple[str, str]] = []
+                components_name_id: list[tuple[str, str]] = []
                 for package in self.doc.packages:
                     no_license = (
                         package.license_concluded is None
@@ -397,7 +397,7 @@ class BaseChecker(ABC):
                         components_name_id.append((package.name, package.spdx_id))
                 return components_name_id
 
-            components_name: List[str] = []
+            components_name: list[str] = []
             for package in self.doc.packages:
                 no_license = (
                     package.license_concluded is None
@@ -415,7 +415,7 @@ class BaseChecker(ABC):
         if self.sbom_spec == "spdx3":
             self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
-            has_concluded_license_ids: Set[str] = {
+            has_concluded_license_ids: set[str] = {
                 from_id
                 for from_id, to_id in iter_relationships_by_type(
                     self.doc, "hasConcludedLicense"
@@ -453,7 +453,7 @@ class BaseChecker(ABC):
     # pylint: disable=too-many-return-statements
     def get_components_without_copyright_texts(
         self, return_tuples: bool = False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve names and/or SPDX IDs of components without copyright texts.
 
@@ -463,7 +463,7 @@ class BaseChecker(ABC):
                                   If False, return a list of component names.
 
         Returns:
-            Union[List[str], List[Tuple[str, str]]]: A list of component names
+            list[str] | list[tuple[str, str]]: A list of component names
             or a list of tuples with component names and SPDX IDs.
         """
         if not self.doc:
@@ -476,7 +476,7 @@ class BaseChecker(ABC):
                 return []
 
             if return_tuples:
-                components_name_id: List[Tuple[str, str]] = []
+                components_name_id: list[tuple[str, str]] = []
                 for package in self.doc.packages:
                     no_license = (
                         package.copyright_text is None
@@ -490,7 +490,7 @@ class BaseChecker(ABC):
                         components_name_id.append((package.name, package.spdx_id))
                 return components_name_id
 
-            components_name: List[str] = []
+            components_name: list[str] = []
             for package in self.doc.packages:
                 no_license = (
                     package.copyright_text is None
@@ -533,7 +533,7 @@ class BaseChecker(ABC):
 
         return []
 
-    def get_components_without_identifiers(self) -> List[str]:
+    def get_components_without_identifiers(self) -> list[str]:
         """
         Retrieve name of components without identifiers.
 
@@ -543,7 +543,7 @@ class BaseChecker(ABC):
         if any element is missing an identifier.
 
         Returns:
-            List[str]: A list of component names.
+            list[str]: A list of component names.
         """
         if not self.doc:
             return []
@@ -571,12 +571,12 @@ class BaseChecker(ABC):
 
         return []
 
-    def get_components_without_names(self) -> List[str]:
+    def get_components_without_names(self) -> list[str]:
         """
         Retrieve SPDX ID of components without names.
 
         Returns:
-            List[str]: A list of component SPDX IDs.
+            list[str]: A list of component SPDX IDs.
         """
         if not self.doc:
             return []
@@ -586,7 +586,7 @@ class BaseChecker(ABC):
             self.doc = cast("Document", self.doc)
             if not self.doc.packages:
                 return []
-            components_without_names: List[str] = []
+            components_without_names: list[str] = []
             for package in self.doc.packages:
                 if not package.name:
                     components_without_names.append(package.spdx_id)
@@ -610,7 +610,7 @@ class BaseChecker(ABC):
     # pylint: disable=too-many-return-statements
     def get_components_without_suppliers(
         self, return_tuples: bool = False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve names and/or SPDX IDs of components without suppliers.
 
@@ -620,7 +620,7 @@ class BaseChecker(ABC):
                                   If False, return a list of component names.
 
         Returns:
-            Union[List[str], List[Tuple[str, str]]]: A list of component names
+            list[str] | list[tuple[str, str]]: A list of component names
             or a list of tuples with component names and SPDX IDs.
         """
         if not self.doc:
@@ -633,7 +633,7 @@ class BaseChecker(ABC):
                 return []
 
             if return_tuples:
-                components_name_id: List[Tuple[str, str]] = []
+                components_name_id: list[tuple[str, str]] = []
                 for package in self.doc.packages:
                     no_supplier = package.supplier is None or isinstance(
                         package.supplier, SpdxNoAssertion
@@ -642,7 +642,7 @@ class BaseChecker(ABC):
                         components_name_id.append((package.name, package.spdx_id))
                 return components_name_id
 
-            components_name: List[str] = []
+            components_name: list[str] = []
             for package in self.doc.packages:
                 no_supplier = package.supplier is None or isinstance(
                     package.supplier, SpdxNoAssertion
@@ -676,7 +676,7 @@ class BaseChecker(ABC):
 
     def get_components_without_versions(
         self, return_tuples: bool = False
-    ) -> Union[List[str], List[Tuple[str, str]]]:
+    ) -> list[str] | list[tuple[str, str]]:
         """
         Retrieve name and/or SPDX ID of components without versions.
 
@@ -686,7 +686,7 @@ class BaseChecker(ABC):
                                   If False, return a list of component names.
 
         Returns:
-            Union[List[str], List[Tuple[str, str]]]: A list of component names
+            list[str] | list[tuple[str, str]]: A list of component names
             or a list of tuples with component names and SPDX IDs.
         """
         if not self.doc:
@@ -699,13 +699,13 @@ class BaseChecker(ABC):
                 return []
 
             if return_tuples:
-                components_name_id: List[Tuple[str, str]] = []
+                components_name_id: list[tuple[str, str]] = []
                 for package in self.doc.packages:
                     if not package.version:
                         components_name_id.append((package.name, package.spdx_id))
                 return components_name_id
 
-            components_name: List[str] = []
+            components_name: list[str] = []
             for package in self.doc.packages:
                 if not package.version:
                     components_name.append(package.name)
@@ -734,7 +734,7 @@ class BaseChecker(ABC):
 
         return []
 
-    def _get_all_components_without_info(self) -> List[Tuple[str, List[str]]]:
+    def _get_all_components_without_info(self) -> list[tuple[str, list[str]]]:
         """Get a list of components missing information for each minimum component."""
 
         # If all lists are empty, return an empty list
@@ -744,7 +744,7 @@ class BaseChecker(ABC):
         ):
             return []
 
-        res: List[Tuple[str, List[str]]] = []
+        res: list[tuple[str, list[str]]] = []
         for component_name in self.MIN_ELEMENTS:
             if component_name in self._COMPONENTS_WITHOUT_INFO:
                 list_name, _ = self._COMPONENTS_WITHOUT_INFO[component_name]
@@ -774,7 +774,7 @@ class BaseChecker(ABC):
         # SPDX 3
         if self.sbom_spec == "spdx3":
             self.doc = cast("spdx3.SHACLObjectSet", self.doc)
-            objects: Set[spdx3.SHACLObject] = getattr(self.doc, "objects", set())
+            objects: set[spdx3.SHACLObject] = getattr(self.doc, "objects", set())
             return len(objects)
 
         return 0
@@ -784,8 +784,7 @@ class BaseChecker(ABC):
         Parse SPDX 2 SBOM document.
 
         Returns:
-            Optional[Document]: An SPDX 2 SBOM document if successful,
-            otherwise None.
+            Document | None: An SPDX 2 SBOM document if successful, otherwise None.
         """
         if not self.file or str(self.file).strip() == "":
             logging.error("No file path provided.")
@@ -808,8 +807,7 @@ class BaseChecker(ABC):
         Parse SPDX 3 SBOM document.
 
         Returns:
-            Optional[spdx3.SHACLObjectSet]: An SHACLObjectSet if successful,
-            otherwise None.
+            spdx3.SHACLObjectSet | None: An SHACLObjectSet if successful, otherwise None.
         """
         if not self.file or str(self.file).strip() == "":
             logging.error("No file path provided.")
@@ -892,13 +890,13 @@ class BaseChecker(ABC):
 
         return report_html(report_context, verbose=True)
 
-    def output_json(self) -> Dict[str, Any]:
+    def output_json(self) -> dict[str, Any]:
         """
         Create a JSON-serializable result dict.
 
         Subclasses may override to provide custom fields.
         """
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "isConformant": getattr(self, "compliant", False),
             "isNtiaConformant": getattr(
                 self, "compliant", False

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -266,10 +266,11 @@ def get_sbom_spec(file: str, sbom_spec: str) -> str:
             )
             return ""
 
-        if spdx_version[0] == 3:
-            detected_sbom_spec = "spdx3"
-        elif spdx_version[0] == 2:
-            detected_sbom_spec = "spdx2"
+        match spdx_version[0]:
+            case 3:
+                detected_sbom_spec = "spdx3"
+            case 2:
+                detected_sbom_spec = "spdx2"
 
     return detected_sbom_spec
 
@@ -278,39 +279,42 @@ def print_output(
     sbom: BaseChecker, *, output_type: str, output_file: str, verbose: bool
 ) -> None:
     """Print or save the output report."""
-    if output_type == "print":
-        sbom.print_table_output(verbose=verbose)
-        if verbose:
-            sbom.print_components_missing_info()
-    elif output_type == "json":
-        result_dict: dict[str, Any] = sbom.output_json()
-        if output_file:
-            with open(output_file, "w", encoding="utf-8") as outfile:
-                json.dump(result_dict, outfile)
-        else:
-            print(json.dumps(result_dict, indent=2))
-    elif output_type == "html":
-        html_output = sbom.output_html()
-        if output_file:
-            try:
+    match output_type:
+        case "print":
+            sbom.print_table_output(verbose=verbose)
+            if verbose:
+                sbom.print_components_missing_info()
+
+        case "json":
+            result_dict: dict[str, Any] = sbom.output_json()
+            if output_file:
                 with open(output_file, "w", encoding="utf-8") as outfile:
-                    # Put a simple HTML wrapper around the HTML report snippet
-                    outfile.write(
-                        "<!DOCTYPE html>\n"
-                        "<html>\n"
-                        "<head>\n"
-                        "  <title>SBOM Conformance Report</title>\n"
-                        '  <meta charset="utf-8" />\n'
-                        "</head>\n"
-                        "<body>\n"
-                        "<h1>SBOM Conformance Report</h1>\n"
-                    )
-                    outfile.write(f"<p>Filename: {sbom.file}</p>\n")
-                    outfile.write(html_output)
-                    outfile.write("\n</body>\n</html>\n")
-            except OSError as exc:
-                logging.error("Could not write HTML output file: %s", exc)
-        else:
-            print(html_output)
+                    json.dump(result_dict, outfile)
+            else:
+                print(json.dumps(result_dict, indent=2))
+
+        case "html":
+            html_output = sbom.output_html()
+            if output_file:
+                try:
+                    with open(output_file, "w", encoding="utf-8") as outfile:
+                        # Put a simple HTML wrapper around the HTML report snippet
+                        outfile.write(
+                            "<!DOCTYPE html>\n"
+                            "<html>\n"
+                            "<head>\n"
+                            "  <title>SBOM Conformance Report</title>\n"
+                            "  <meta charset=\"utf-8\" />\n"
+                            "</head>\n"
+                            "<body>\n"
+                            "<h1>SBOM Conformance Report</h1>\n"
+                        )
+                        outfile.write(f"<p>Filename: {sbom.file}</p>\n")
+                        outfile.write(html_output)
+                        outfile.write("\n</body>\n</html>\n")
+                except OSError as exc:
+                    logging.error("Could not write HTML output file: %s", exc)
+            else:
+                print(html_output)
 
     # do nothing if output_type is "quiet" or unrecognized

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -151,7 +151,7 @@ def get_parsed_args() -> argparse.Namespace:
     return args
 
 
-def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> Optional[Tuple[int, int]]:
+def get_spdx_version(file: str, sbom_spec: str = "spdx2") -> tuple[int, int] | None:
     """
     Detect the SPDX version of the SBOM file.
 
@@ -247,7 +247,7 @@ def get_sbom_spec(file: str, sbom_spec: str) -> str:
         return ""
 
     if sbom_spec.startswith("spdx"):
-        spdx_version: Optional[Tuple[int, int]] = get_spdx_version(
+        spdx_version: tuple[int, int] | None = get_spdx_version(
             file, sbom_spec=sbom_spec
         )
         if not spdx_version:

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -304,7 +304,7 @@ def print_output(
                             "<html>\n"
                             "<head>\n"
                             "  <title>SBOM Conformance Report</title>\n"
-                            "  <meta charset=\"utf-8\" />\n"
+                            '  <meta charset="utf-8" />\n'
                             "</head>\n"
                             "<body>\n"
                             "<h1>SBOM Conformance Report</h1>\n"

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -12,7 +12,7 @@ import logging
 import re
 import sys
 from importlib.metadata import version
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.parse_anything import parse_file as parse_spdx2_file
@@ -283,7 +283,7 @@ def print_output(
         if verbose:
             sbom.print_components_missing_info()
     elif output_type == "json":
-        result_dict: Dict[str, Any] = sbom.output_json()
+        result_dict: dict[str, Any] = sbom.output_json()
         if output_file:
             with open(output_file, "w", encoding="utf-8") as outfile:
                 json.dump(result_dict, outfile)

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -11,7 +11,7 @@ Some of the code here was originally in the BaseChecker class.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 from .constants import (
     SUPPORTED_COMPLIANCE_STANDARDS,
@@ -29,10 +29,10 @@ class ReportContext:
     sbom_spec: str = ""
     compliance_standard: str = ""
     compliant: bool = False
-    requirement_results: Optional[List[Tuple[str, bool]]] = None
-    components_without_info: Optional[List[Tuple[str, List[str]]]] = None
-    validation_messages: Optional[List[ValidationMessage]] = None
-    parsing_error: Optional[List[str]] = None
+    requirement_results: list[tuple[str, bool]] | None = None
+    components_without_info: list[tuple[str, list[str]]] | None = None
+    validation_messages: list[ValidationMessage] | None = None
+    parsing_error: list[str] | None = None
 
 
 def _safe_attr(obj: object, name: str) -> str:
@@ -41,7 +41,7 @@ def _safe_attr(obj: object, name: str) -> str:
 
 
 def print_validation_messages(
-    validation_messages: List[ValidationMessage], verbose: bool = False
+    validation_messages: list[ValidationMessage], verbose: bool = False
 ) -> None:
     """Prints validation messages and optional context details.
 
@@ -56,7 +56,7 @@ def print_validation_messages(
 
 
 def get_validation_messages_text(
-    validation_messages: List[ValidationMessage], verbose: bool = False
+    validation_messages: list[ValidationMessage], verbose: bool = False
 ) -> str:
     """Generates validation messages and optional context details.
 
@@ -67,7 +67,7 @@ def get_validation_messages_text(
     Returns:
         str: Plain-text representation of the validation messages.
     """
-    report: List[str] = []
+    report: list[str] = []
 
     for msg in validation_messages:
         if not msg.validation_message:
@@ -84,7 +84,7 @@ def get_validation_messages_text(
 
 
 def get_validation_messages_html(
-    validation_messages: List[ValidationMessage], verbose: bool = False
+    validation_messages: list[ValidationMessage], verbose: bool = False
 ) -> str:
     """Generates HTML for validation messages and context details.
 
@@ -121,8 +121,8 @@ def get_validation_messages_html(
 
 
 def get_validation_messages_json(
-    validation_messages: List[ValidationMessage],
-) -> List[Dict[str, str]]:
+    validation_messages: list[ValidationMessage],
+) -> list[dict[str, str]]:
     """Generates JSON-serializable list for validation messages and context details.
 
     Args:
@@ -131,7 +131,7 @@ def get_validation_messages_json(
     Returns:
         List[Dict[str, str]]: JSON-serializable representation of the validation messages.
     """
-    json_output: List[Dict[str, str]] = []
+    json_output: list[dict[str, str]] = []
 
     for msg in validation_messages:
         if not getattr(msg, "validation_message", None):
@@ -160,7 +160,7 @@ def report_text(
     Returns:
         str: Plain-text representation of the results.
     """
-    report: List[str] = []
+    report: list[str] = []
 
     # Parsing error
     if rc.parsing_error:

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -46,7 +46,7 @@ def print_validation_messages(
     """Prints validation messages and optional context details.
 
     Args:
-        validation_messages (List[ValidationMessage]): List of validation messages.
+        validation_messages (list[ValidationMessage]): List of validation messages.
         verbose (bool): If True, include detailed validation context.
 
     Returns:
@@ -61,7 +61,7 @@ def get_validation_messages_text(
     """Generates validation messages and optional context details.
 
     Args:
-        validation_messages (List[ValidationMessage]): List of validation messages.
+        validation_messages (list[ValidationMessage]): List of validation messages.
         verbose (bool): If True, include detailed validation context.
 
     Returns:
@@ -89,7 +89,7 @@ def get_validation_messages_html(
     """Generates HTML for validation messages and context details.
 
     Args:
-        validation_messages (List[ValidationMessage]): List of validation messages.
+        validation_messages (list[ValidationMessage]): List of validation messages.
         verbose (bool): If True, include detailed validation context.
 
     Returns:
@@ -126,10 +126,10 @@ def get_validation_messages_json(
     """Generates JSON-serializable list for validation messages and context details.
 
     Args:
-        validation_messages (List[ValidationMessage]): List of validation messages.
+        validation_messages (list[ValidationMessage]): List of validation messages.
 
     Returns:
-        List[Dict[str, str]]: JSON-serializable representation of the validation messages.
+        list[dict[str, str]]: JSON-serializable representation of the validation messages.
     """
     json_output: list[dict[str, str]] = []
 
@@ -213,7 +213,7 @@ def report_html(
     Returns:
         str: HTML representation of the results.
     """
-    report: List[str] = []
+    report: list[str] = []
 
     # Parsing error
     if rc.parsing_error:

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Optional, Set, Tuple, Type, cast
+from typing import Any, Iterator, Optional, Set, Type, cast
 
 from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
 from spdx_tools.spdx.validation.validation_message import (
@@ -17,7 +17,7 @@ from spdx_tools.spdx.validation.validation_message import (
 
 def validate_spdx3_data(
     object_set: spdx3.SHACLObjectSet,
-) -> Tuple[Optional[spdx3.SpdxDocument], List[ValidationMessage]]:
+) -> tuple[spdx3.SpdxDocument | None, list[ValidationMessage]]:
     """
     Validate an SHACLObjectSet if it contains a valid SpdxDocument.
 
@@ -43,10 +43,10 @@ def validate_spdx3_data(
     # which is originally meant for SPDX 2, to report validation errors for
     # SPDX 3 as well, so the print/HTML/JSON output functions can be reused.
 
-    doc: Optional[spdx3.SpdxDocument] = None
-    validation_messages: List[ValidationMessage] = []
+    doc: spdx3.SpdxDocument | None = None
+    validation_messages: list[ValidationMessage] = []
 
-    spdx_documents: List[spdx3.SpdxDocument] = [
+    spdx_documents: list[spdx3.SpdxDocument] = [
         cast("spdx3.SpdxDocument", obj)
         for obj in object_set.foreach_type("SpdxDocument")
     ]
@@ -91,8 +91,8 @@ def validate_spdx3_data(
 
 
 def get_boms_from_spdx_document(
-    spdx_doc: Optional[spdx3.SpdxDocument],
-) -> Optional[List[spdx3.Bom]]:
+    spdx_doc: spdx3.SpdxDocument | None,
+) -> list[spdx3.Bom] | None:
     """
     Retrieve the BOMs that are rootElements of an SPDX 3 SpdxDocument.
 
@@ -105,7 +105,7 @@ def get_boms_from_spdx_document(
     if not spdx_doc:
         return None
 
-    root_elements: List[spdx3.Bom] = getattr(spdx_doc, "rootElement", [])
+    root_elements: list[spdx3.Bom] = getattr(spdx_doc, "rootElement", [])
     if not root_elements:
         return None
 
@@ -113,8 +113,8 @@ def get_boms_from_spdx_document(
 
 
 def get_packages_from_bom(
-    bom: Optional[spdx3.Bom],
-) -> Optional[List[spdx3.software_Package]]:
+    bom: spdx3.Bom | None,
+) -> list[spdx3.software_Package] | None:
     """
     Retrieve the /Software/Packages that are rootElements of an SPDX 3 BOM.
 
@@ -127,7 +127,7 @@ def get_packages_from_bom(
     if not bom:
         return None
 
-    root_elements: List[spdx3.software_Package] = getattr(bom, "rootElement", [])
+    root_elements: list[spdx3.software_Package] = getattr(bom, "rootElement", [])
     if not root_elements or len(root_elements) != 1:
         return None
 
@@ -138,7 +138,7 @@ def iter_objects_with_property(
     object_set: spdx3.SHACLObjectSet,
     typ: Type[spdx3.SHACLObject] = spdx3.Artifact,
     property_name: str = "spdxId",
-) -> Iterator[Tuple[str, str, Any]]:
+) -> Iterator[tuple[str, str, Any]]:
     """
     Yield (name, spdxId, property) for each SPDX 3 object.
 
@@ -162,7 +162,7 @@ def iter_objects_with_property(
 def iter_relationships_by_type(
     object_set: spdx3.SHACLObjectSet,
     rel_type: str,
-) -> Iterator[Tuple[str, str]]:
+) -> Iterator[tuple[str, str]]:
     """
     Yield (from_id, to_id) for each relationship of the specified relationship type.
     """
@@ -172,8 +172,8 @@ def iter_relationships_by_type(
         # Remove the IRI prefix of entry name before compare
         if not _rel_type or _rel_type.split("/")[-1] != rel_type:
             continue
-        from_: Optional[spdx3.Element] = getattr(obj, "from_", None)
-        to: Optional[spdx3.Element] = getattr(obj, "to", None)
+        from_: spdx3.Element | None = getattr(obj, "from_", None)
+        to: spdx3.Element | None = getattr(obj, "to", None)
         if not from_ or not to:
             continue
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterator, Optional, Set, Type, cast
+from collections.abc import Iterator
+from typing import Any, cast
 
 from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
 from spdx_tools.spdx.validation.validation_message import (
@@ -35,8 +36,8 @@ def validate_spdx3_data(
         object_set (spdx3.SHACLObjectSet): The SHACLObjectSet containing
                                             the SPDX 3 document.
     Returns:
-        Optional[spdx3.SpdxDocument]: An SpdxDocument if found, otherwise None.
-        List[ValidationMessage]: A list of validation messages. Empty if no errors.
+        spdx3.SpdxDocument | None: An SpdxDocument if found, otherwise None.
+        list[ValidationMessage]: A list of validation messages. Empty if no errors.
 
     """
     # Note that we use spdx_tools.spdx.validation.validation_message,
@@ -100,7 +101,7 @@ def get_boms_from_spdx_document(
         spdx_doc (spdx3.SpdxDocument): The SPDX 3 SpdxDocument.
 
     Returns:
-        Optional[List[spdx3.Bom]]: The Boms if found, otherwise None.
+        list[spdx3.Bom] | None: The Boms if found, otherwise None.
     """
     if not spdx_doc:
         return None
@@ -122,7 +123,7 @@ def get_packages_from_bom(
         spdx_doc (spdx3.Bom): The SPDX 3 Bom.
 
     Returns:
-        Optional[List[spdx3.software_Package]]: The packages if found, otherwise None.
+        list[spdx3.software_Package] | None: The packages if found, otherwise None.
     """
     if not bom:
         return None
@@ -136,7 +137,7 @@ def get_packages_from_bom(
 
 def iter_objects_with_property(
     object_set: spdx3.SHACLObjectSet,
-    typ: Type[spdx3.SHACLObject] = spdx3.Artifact,
+    typ: type[spdx3.SHACLObject] = spdx3.Artifact,
     property_name: str = "spdxId",
 ) -> Iterator[tuple[str, str, Any]]:
     """
@@ -144,11 +145,11 @@ def iter_objects_with_property(
 
     Args:
         object_set (spdx3.SHACLObjectSet): The SHACLObjectSet to iterate over.
-        typ (Type[spdx3.SHACLObject]): The type of SPDX3 object
+        typ (type[spdx3.SHACLObject]): The type of SPDX3 object
         property_name (str): The property name to retrieve.
 
     Yields:
-        Iterator[Tuple[str, str, Any]]: A tuple containing the name,
+        Iterator[tuple[str, str, Any]]: A tuple containing the name,
         SPDX ID, and the specified property of the object.
     """
 
@@ -183,9 +184,9 @@ def iter_relationships_by_type(
         yield from_id, to_id
 
 
-def get_all_packages(object_set: spdx3.SHACLObjectSet) -> Set[spdx3.software_Package]:
+def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Package]:
     """Retrieve all /Software/Package objects from an SHACLObjectSet."""
-    packages: Set[spdx3.software_Package] = {
+    packages: set[spdx3.software_Package] = {
         cast("spdx3.software_Package", obj)
         for obj in object_set.foreach_type("software_Package")
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ readme = "README.md"
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -35,7 +37,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 urls = { Homepage = "https://github.com/spdx/ntia-conformance-checker" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = [
     "spdx",
     "sbom",
@@ -62,15 +64,8 @@ dev = [
     "pytype>=2024.10.11",
     "ruff>=0.14.9",
 ]
-docs = [
-    "Sphinx>=9.0.4",
-    "sphinx-rtd-theme>=3.0.2",
-]
-test = [
-    "beartype>=0.22.9",
-    "coverage>=7.13.0",
-    "pytest>=9.0.2",
-]
+docs = ["Sphinx>=9.0.4", "sphinx-rtd-theme>=3.0.2"]
+test = ["beartype>=0.22.9", "coverage>=7.13.0", "pytest>=9.0.2"]
 
 [project.scripts]
 # Both "ntia-checker" and "sbomcheck" are identical.
@@ -83,7 +78,7 @@ sbomcheck = "ntia_conformance_checker.main:main"
 [tool.ruff]
 line-length = 88 # Same as black
 indent-width = 4 # Same as black
-target-version = "py39"
+target-version = "py310"
 exclude = [
     "build",
     "dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ntia_conformance_checker"
-version = "4.1.3"
+version = "5.0.0"
 authors = [
     { name = "Josh Lin", email = "linynjosh@gmail.com" },
     { name = "John Speed Meyers", email = "johnmeyersster@gmail.com" },
@@ -27,17 +27,15 @@ readme = "README.md"
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Systems Administration",
 ]
 urls = { Homepage = "https://github.com/spdx/ntia-conformance-checker" }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 keywords = [
     "spdx",
     "sbom",
@@ -56,22 +54,22 @@ dependencies = ["spdx-python-model==0.0.3", "spdx-tools==0.8.3"]
 
 [project.optional-dependencies]
 dev = [
-    "black>=25.9.0",
-    "mypy>=1.18.2",
-    "pylint>=3.3.9", # 3.3.9 is the last version supporting Python 3.9
-    "pyrefly>=0.42.0",
+    "black>=25.12.0",
+    "mypy>=1.19.1",
+    "pylint>=4.0.4",
+    "pyrefly>=0.46.0",
     "pyright>=1.1.407",
-    "pytype>=2024.9.13", # 2024.9.13 is the last version supporting Python 3.9
-    "ruff>=0.14.5",
+    "pytype>=2024.10.11",
+    "ruff>=0.14.9",
 ]
 docs = [
-    "sphinx>=7.4.7", # 7.4.7 is the last version supporting Python 3.9
+    "Sphinx>=9.0.4",
     "sphinx-rtd-theme>=3.0.2",
 ]
 test = [
-    "beartype==0.21.0", # 0.21.0 is the last version supporting Python 3.9
-    "coverage==7.10.7", # 7.10.7 is the last version supporting Python 3.9
-    "pytest==8.4.2", # 8.4.2 is the last version supporting Python 3.9
+    "beartype>=0.22.9",
+    "coverage>=7.13.0",
+    "pytest>=9.0.2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ keywords = [
     "software component transparency",
     "supply chain security",
 ]
-dependencies = ["spdx-python-model==0.0.3", "spdx-tools==0.8.3"]
+dependencies = ["spdx-python-model==0.0.4", "spdx-tools==0.8.3"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
- Update code
  - Use type hinting generics for standard collections ([PEP 585] / Python 3.9) and use union types as X | Y ([PEP 604] / Python 3.10).
  - Use match-case instead of if-elses ([PEP 635] / Python 3.10)
- Update dependencies for Python 3.10

[PEP 585]: https://peps.python.org/pep-0585/
[PEP 604]: https://peps.python.org/pep-0604/
[PEP 635]: https://peps.python.org/pep-0635/
