### PR TITLE
Remove sphinx_rtd_theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 SPDX contributors
+# SPDX-FileCopyrightText: 2024-2025 SPDX contributors
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,13 +13,12 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import List
 
 # Path setup
 sys.path.insert(0, os.path.abspath(".."))
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path: List[str] = ["_templates"]
+templates_path: list[str] = ["_templates"]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -32,7 +31,7 @@ project_copyright = "2022-%Y SPDX contributors"  # pylint: disable=C0103
 author = "SPDX contributors"  # pylint: disable=C0103
 
 # The theme to use for HTML and HTML Help pages.
-html_theme = "sphinx_rtd_theme"  # pylint: disable=C0103
+# html_theme = "sphinx_rtd_theme"  # pylint: disable=C0103
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -46,4 +45,4 @@ extensions = [
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = []
+exclude_patterns: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "pytype>=2024.10.11",
     "ruff>=0.14.9",
 ]
-docs = ["Sphinx>=9.0.4", "sphinx-rtd-theme>=3.0.2"]
+docs = ["Sphinx>=9.0.4"]
 test = ["beartype>=0.22.9", "coverage>=7.13.0", "pytest>=9.0.2"]
 
 [project.scripts]


### PR DESCRIPTION
sphinx_rtd_theme does not support Sphinx 9, causing apidoc workflow to fail.

Remove to use default theme.