### PR TITLE
Simplify get_components_without_* API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 - BREAKING CHANGE: Drop support for Python 3.9
 - BREAKING CHANGE: All `get_components_without_*` functions now return a
   unified `list[tuple[str, str]]` where each tuple is
-  `(component_name, spdx_id)`.
+  `(component_name, spdx_id)` ([#341]).
   Consumers should extract the preferred value (name or SPDX ID) as needed.
   For example:
 
@@ -53,6 +53,7 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
 [#331]: https://github.com/spdx/ntia-conformance-checker/pull/331
 [#339]: https://github.com/spdx/ntia-conformance-checker/pull/339
+[#341]: https://github.com/spdx/ntia-conformance-checker/pull/341
 [PEP 585]: https://peps.python.org/pep-0585/
 [PEP 604]: https://peps.python.org/pep-0604/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
-## [5.0.0] - 2025-12-18
+## [5.0.0] - 2025-12-20
 
 ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
 ### Changed
 
-- BREAKING CHANGE: Drop support for Python 3.9
+- Drop support for Python 3.9
 - BREAKING CHANGE: All `get_components_without_*` functions now return a
   unified `list[tuple[str, str]]` where each tuple is
   `(component_name, spdx_id)` ([#341]).
@@ -35,8 +35,8 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
 ### Fixed
 
-- Fix validation messages that did not properly serialize in JSON output
-  ([#331])
+- BREAKING CHANGE: Fix validation messages that did not properly serialize
+  in JSON output ([#331])
 
   The JSON output for validation messages now follows this structure:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ and this project adheres to [Semantic Versioning][semver].
 
 ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
+### Changed
+
+- BREAKING CHANGE: Drop support for Python 3.9
+- BREAKING CHANGE: All `get_components_without_*` functions now return a
+  unified `list[tuple[str, str]]` where each tuple is
+  `(component_name, spdx_id)`.
+  Consumers should extract the preferred value (name or SPDX ID) as needed.
+  For example:
+
+  ```python
+  # returns list[tuple[str, str]]
+  components = sbom_checker.get_components_without_versions()
+  names = [name for name, _ in components]
+  ```
+
+- Use type hinting generics for standard collections ([PEP 585])
+  and use `X | Y` for union types ([PEP 604]) ([#339])
+
 ### Fixed
 
 - Fix validation messages that did not properly serialize in JSON output
@@ -32,9 +50,6 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
     }
   ]
   ```
-
-- Use type hinting generics for standard collections ([PEP 585])
-  and use `X | Y` for union types ([PEP 604]) ([#339])
 
 [#331]: https://github.com/spdx/ntia-conformance-checker/pull/331
 [#339]: https://github.com/spdx/ntia-conformance-checker/pull/339

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 - BREAKING CHANGE: All `get_components_without_*` functions now return a
   unified `list[tuple[str, str]]` where each tuple is
   `(component_name, spdx_id)` ([#341]).
+
   Consumers should extract the preferred value (name or SPDX ID) as needed.
   For example:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,8 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
   For example:
 
   ```python
-  # returns list[tuple[str, str]]
-  components = sbom_checker.get_components_without_versions()
-  names = [name for name, _ in components]
+  components = sbom_checker.get_components_without_versions()  # list[tuple[str, str]]
+  names = [name for name, _ in components]  # list[str]
   ```
 
 - Use type hinting generics for standard collections ([PEP 585])

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -50,4 +50,4 @@ keywords:
   - CISA
 license: Apache-2.0
 version: 5.0.0
-date-released: '2025-12-18'
+date-released: '2025-12-20'

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -30,7 +30,7 @@ class ReportContext:
     compliance_standard: str = ""
     compliant: bool = False
     requirement_results: list[tuple[str, bool]] | None = None
-    components_without_info: list[tuple[str, list[str]]] | None = None
+    components_without_info: list[tuple[str, list[tuple[str, str]]]] | None = None
     validation_messages: list[ValidationMessage] | None = None
     parsing_error: list[str] | None = None
 
@@ -255,11 +255,11 @@ def report_html(
         report.append("<table class='conformance-res-tab'>")
         report.append("<thead><tr><th>Requirement</th><th>Conformant</th></tr></thead>")
         report.append("<tbody>")
-        for component_name, val in rc.requirement_results:
+        for info_name, val in rc.requirement_results:
             report.append(
                 "<tr>"
                 "<td class='conformance-res-tab-r'>"
-                f"{component_name}</td>"
+                f"{info_name}</td>"
                 "<td class='conformance-res-tab-v'>"
                 f"{val}</td>"
                 "</tr>"
@@ -278,10 +278,13 @@ def report_html(
             "</p>"
         )
         report.append("<ul class='conformance-mis-list'>")
-        for component_name, components in rc.components_without_info:
+        for info_name, components in rc.components_without_info:
+            component_names = [
+                name if name not in (None, "") else id for name, id in components
+            ]
             report.append(
-                f"<li>{component_name} ({len(components)}): "
-                f"{', '.join(components)}</li>"
+                f"<li>{info_name} ({len(components)}): "
+                f"{', '.join(component_names)}</li>"
             )
         report.append("</ul>")
         report.append("</div>")

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -19,7 +19,11 @@ from ntia_conformance_checker import FSCT3Checker, NTIAChecker
 from ntia_conformance_checker.base_checker import validate_spdx3_data
 
 
-def _component_names_from_tuples(tuples_list: list[tuple[str, str]]) -> list[str]:
+def _component_names(tuples_list: list[tuple[str, str]]) -> list[str]:
+    """
+    Extract first element from list of tuples,
+    or second if first is None or empty.
+    """
     return [
         t[0] if t and t[0] not in (None, "") else (t[1] if t else "")
         for t in tuples_list
@@ -201,7 +205,7 @@ def test_sbomchecker_missing_component_version(test_file):
     assert sbom.dependency_relationships
     assert not sbom.components_without_names
     TestCase().assertCountEqual(
-        _component_names_from_tuples(sbom.components_without_versions), ["glibc"]
+        _component_names(sbom.components_without_versions), ["glibc"]
     )
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
@@ -226,7 +230,7 @@ def test_sbomchecker_missing_supplier_name(test_file):
     assert not sbom.components_without_names
     assert not sbom.components_without_versions
     TestCase().assertCountEqual(
-        _component_names_from_tuples(sbom.components_without_suppliers),
+        _component_names(sbom.components_without_suppliers),
         ["glibc", "Jena", "Saxon"],
     )
     assert not sbom.components_without_identifiers
@@ -268,7 +272,7 @@ def test_sbomchecker_tern_photon_example():
     )
     sbom = sbom_checker.SbomChecker(test_file)
     assert sbom.doc_author
-    assert _component_names_from_tuples(sbom.components_without_versions) == [
+    assert _component_names(sbom.components_without_versions) == [
         "5e94941e3961b26645fbfdc71a59d439537b98417546bfdab35fa074f121eb15",
         "bash",
     ]
@@ -286,7 +290,7 @@ def test_sbomchecker_bom_alpine_example():
     # currently checking only one component with a missing version
     assert (
         "sha256:850d4aa2c32a30db71a7e54dab7c605f74a4aeabf9418ccd9273b2480fcb6c04"
-        in _component_names_from_tuples(sbom.components_without_versions)
+        in _component_names(sbom.components_without_versions)
     )
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -18,6 +18,14 @@ import ntia_conformance_checker.sbom_checker as sbom_checker
 from ntia_conformance_checker import FSCT3Checker, NTIAChecker
 from ntia_conformance_checker.base_checker import validate_spdx3_data
 
+
+def _component_names_from_tuples(tuples_list: list[tuple[str, str]]) -> list[str]:
+    return [
+        t[0] if t and t[0] not in (None, "") else (t[1] if t else "")
+        for t in tuples_list
+    ]
+
+
 ### Test no element missing
 
 dirname = os.path.join(os.path.dirname(__file__), "data", "no_elements_missing")
@@ -192,7 +200,9 @@ def test_sbomchecker_missing_component_version(test_file):
     assert sbom.doc_timestamp
     assert sbom.dependency_relationships
     assert not sbom.components_without_names
-    TestCase().assertCountEqual(sbom.components_without_versions, ["glibc"])
+    TestCase().assertCountEqual(
+        _component_names_from_tuples(sbom.components_without_versions), ["glibc"]
+    )
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert not sbom.compliant
@@ -216,7 +226,8 @@ def test_sbomchecker_missing_supplier_name(test_file):
     assert not sbom.components_without_names
     assert not sbom.components_without_versions
     TestCase().assertCountEqual(
-        sbom.components_without_suppliers, ["glibc", "Jena", "Saxon"]
+        _component_names_from_tuples(sbom.components_without_suppliers),
+        ["glibc", "Jena", "Saxon"],
     )
     assert not sbom.components_without_identifiers
     assert not sbom.compliant
@@ -257,7 +268,7 @@ def test_sbomchecker_tern_photon_example():
     )
     sbom = sbom_checker.SbomChecker(test_file)
     assert sbom.doc_author
-    assert sbom.components_without_versions == [
+    assert _component_names_from_tuples(sbom.components_without_versions) == [
         "5e94941e3961b26645fbfdc71a59d439537b98417546bfdab35fa074f121eb15",
         "bash",
     ]
@@ -275,7 +286,7 @@ def test_sbomchecker_bom_alpine_example():
     # currently checking only one component with a missing version
     assert (
         "sha256:850d4aa2c32a30db71a7e54dab7c605f74a4aeabf9418ccd9273b2480fcb6c04"
-        in sbom.components_without_versions
+        in _component_names_from_tuples(sbom.components_without_versions)
     )
 
 
@@ -540,17 +551,13 @@ def test_components_without_functions():
     )
     sbom = sbom_checker.SbomChecker(filepath)
     components = sbom.get_components_without_names()
-    assert components == ["SPDXRef-Package1"]
+    assert components == [("", "SPDXRef-Package1")]
     components = sbom.get_components_without_versions()
-    assert components == ["glibc-no-version-1", "glibc-no-version-2"]
-    components = sbom.get_components_without_versions(return_tuples=True)
     assert components == [
         ("glibc-no-version-1", "SPDXRef-Package2"),
         ("glibc-no-version-2", "SPDXRef-Package3"),
     ]
     components = sbom.get_components_without_suppliers()
-    assert components == ["glibc-no-supplier"]
-    components = sbom.get_components_without_suppliers(return_tuples=True)
     assert components == [("glibc-no-supplier", "SPDXRef-Package4")]
     # Not sure how to test this.
     # If any package misses the SPDXID the whole file seems to be invalid.


### PR DESCRIPTION
`get_components_without_*` methods previously able to return either list or list of tuples.
It made the code complex and also requires casting afterward to have type checkers run smoothly.

- This PR will make `get_components_without_*` methods to have only one unified return type (`list[tuple[str, str]]`). Users can do simple filter to get only what they need.
- Add attribute availability check for SPDX 2
- Use list comprehension to make the code more focus on the return logic
- In case that name is not available, use SPDX ID instead when list components without required info

This will fix pylint warnings of `too-many-branches` and `too-many-return-statements`.

This is a breaking change and will go to v5.0.0 (major version update).