### PR TITLE
Refactor exception handling to remove beartype direct dependency

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -699,6 +699,17 @@ class BaseChecker(ABC):
         except SPDXParsingError as err:
             self.parsing_error.extend(err.get_messages())
             return None
+        except Exception as err:  # pylint: disable=broad-except
+            # Catch any other errors, including BeartypeCallHintParamViolation
+            # from the spdx-tools library when parsing invalid SPDX files.
+            # The spdx-tools library uses beartype for runtime type checking,
+            # which throws exceptions when encountering missing required fields
+            # (e.g., missing author, timestamp, or identifiers).
+            logging.debug("Error parsing file: %s", err)
+            self.parsing_error.append(
+                f"Error parsing file: {type(err).__name__}: {str(err)}"
+            )
+            return None
 
         return cast("Document", doc)
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -100,10 +100,10 @@ def get_boms_from_spdx_document(
     Retrieve the BOMs that are rootElements of an SPDX 3 SpdxDocument.
 
     Args:
-        spdx_doc (spdx3.SpdxDocument): The SPDX 3 SpdxDocument.
+        spdx_doc (spdx3.SpdxDocument | None): The SPDX 3 SpdxDocument.
 
     Returns:
-        list[spdx3.Bom] | None: The Boms if found, otherwise None.
+        list[spdx3.Bom] | None: A list of BOMs if found, otherwise None.
     """
     if not spdx_doc:
         return None
@@ -122,10 +122,10 @@ def get_packages_from_bom(
     Retrieve the /Software/Packages that are rootElements of an SPDX 3 BOM.
 
     Args:
-        spdx_doc (spdx3.Bom): The SPDX 3 Bom.
+        bom (spdx3.Bom | None): The SPDX 3 Bom.
 
     Returns:
-        list[spdx3.software_Package] | None: The packages if found, otherwise None.
+        list[spdx3.software_Package] | None: A list of packages if found, otherwise None.
     """
     if not bom:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
     "ruff>=0.14.9",
 ]
 docs = ["Sphinx>=9.0.4"]
-test = ["beartype>=0.22.9", "coverage>=7.13.0", "pytest>=9.0.2"]
+test = ["coverage>=7.13.0", "pytest>=9.0.2"]
 
 [project.scripts]
 # Both "ntia-checker" and "sbomcheck" are identical.

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from unittest import TestCase
 
 import pytest
-from beartype.roar import BeartypeCallHintParamViolation
 from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
 
 import ntia_conformance_checker.sbom_checker as sbom_checker
@@ -113,15 +112,10 @@ test_files_missing_author_name = [
 def test_sbomchecker_missing_author_name(test_file):
     """The parser from spdx-tools will raise an SPDXParsingError if
     the document does not contain a creator."""
-    try:
-        sbom_check = sbom_checker.SbomChecker(test_file)
+    sbom_check = sbom_checker.SbomChecker(test_file)
 
-        assert not sbom_check.ntia_minimum_elements_compliant
-        assert sbom_check.parsing_error
-    except BeartypeCallHintParamViolation:
-        pytest.xfail(
-            "Beartype type violation (assigning None) due to missing author field"
-        )
+    assert not sbom_check.ntia_minimum_elements_compliant
+    assert sbom_check.parsing_error
 
 
 ### Test missing timestamp
@@ -134,15 +128,10 @@ test_files_missing_timestamp = [os.path.join(dirname, fn) for fn in os.listdir(d
 def test_sbomchecker_missing_timestamp(test_file):
     """The parser from spdx-tools will raise an SPDXParsingError if
     the document does not contain a created date."""
-    try:
-        sbom_check = sbom_checker.SbomChecker(test_file)
+    sbom_check = sbom_checker.SbomChecker(test_file)
 
-        assert not sbom_check.ntia_minimum_elements_compliant
-        assert sbom_check.parsing_error
-    except BeartypeCallHintParamViolation:
-        pytest.xfail(
-            "Beartype type violation (assigning None) due to missing timestamp field"
-        )
+    assert not sbom_check.ntia_minimum_elements_compliant
+    assert sbom_check.parsing_error
 
 
 ### Test missing concluded licenses
@@ -250,16 +239,12 @@ test_files_missing_unique_identifiers = [
 def test_sbomchecker_missing_unique_identifiers(test_file):
     """The parser from spdx-tools will raise an SPDXParsingError if
     the document contains an element without SPDXID."""
-    try:
-        sbom_check = sbom_checker.SbomChecker(test_file)
 
-        assert not sbom_check.compliant
-        assert not sbom_check.ntia_minimum_elements_compliant
-        assert sbom_check.parsing_error
-    except BeartypeCallHintParamViolation:
-        pytest.xfail(
-            "Beartype type violation (assigning None) due to missing unique identifier field"
-        )
+    sbom_check = sbom_checker.SbomChecker(test_file)
+
+    assert not sbom_check.compliant
+    assert not sbom_check.ntia_minimum_elements_compliant
+    assert sbom_check.parsing_error
 
 
 ### Test SBOM example from various sources

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,9 +9,6 @@
 from pathlib import Path
 from typing import List, Tuple
 
-import pytest
-from beartype.roar import BeartypeCallHintParamViolation
-
 from ntia_conformance_checker.cli_utils import get_sbom_spec, get_spdx_version
 
 spdx2_2_dir = Path(__file__).parent / "data" / "missing_component_name"
@@ -35,15 +32,10 @@ detect_version_test: List[Tuple[Path, Tuple[int, ...]]] = [
 
 def test_detect_spdx_version():
     for file_path, expected_version in detect_version_test:
-        try:
-            version = get_spdx_version(str(file_path))
-            assert (
-                version == expected_version
-            ), f"Expected {expected_version}, got {version} for {file_path}"
-        except BeartypeCallHintParamViolation:
-            pytest.xfail(
-                "Beartype type violation (assigning None) due to missing field in SPDX document"
-            )
+        version = get_spdx_version(str(file_path))
+        assert (
+            version == expected_version
+        ), f"Expected {expected_version}, got {version} for {file_path}"
 
 
 detect_sbom_spec_test: List[Tuple[Path, str]] = [
@@ -62,12 +54,7 @@ detect_sbom_spec_test: List[Tuple[Path, str]] = [
 
 def test_detect_sbom_spec():
     for file_path, expected_sbom_spec in detect_sbom_spec_test:
-        try:
-            sbom_spec = get_sbom_spec(str(file_path), sbom_spec=expected_sbom_spec)
-            assert (
-                sbom_spec == expected_sbom_spec
-            ), f"Expected {expected_sbom_spec}, got {sbom_spec} for {file_path}"
-        except BeartypeCallHintParamViolation:
-            pytest.xfail(
-                "Beartype type violation (assigning None) due to missing field in SPDX document"
-            )
+        sbom_spec = get_sbom_spec(str(file_path), sbom_spec=expected_sbom_spec)
+        assert (
+            sbom_spec == expected_sbom_spec
+        ), f"Expected {expected_sbom_spec}, got {sbom_spec} for {file_path}"


### PR DESCRIPTION
beartype will be installed through spdx-tools anyway, but now we don't have to manage the version requirement by ourselves - let the spdx-tools manage what it see fits (reduce chance of version conflicts).

Also fix few inconsistent docstrings.

Tested locally, all passed.