### PR TITLE
Add py.typed type hint marker

### DIFF
--- a/ntia_conformance_checker/py.typed
+++ b/ntia_conformance_checker/py.typed
@@ -1,0 +1,1 @@
+# PEP 561: Type hints marker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,6 @@ fixable = ["ALL"]
 
 [tool.setuptools]
 packages = ["ntia_conformance_checker"]
+
+[tool.setuptools.package-data]
+ntia_conformance_checker = ["py.typed"]  # Signal type hinting support


### PR DESCRIPTION
To indicates that this package supports typing.

This will silent linter warning of "import-untyped" when importing ntia_conformance_checker.

More about py.typed marker
https://peps.python.org/pep-0561/