### PR TITLE
Update spdx-tools to 0.8.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
         cache: "pip"
     - name: Install dependencies
       run: |
-        pip install pip==25.3
-        pip install build==1.3.0
+        pip install pip==26.0.1
+        pip install build==1.4.0
     - name: Build package
       run: |
         python -m build

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install pylint>=4.0.4
+        pip install pylint>=4.0.5
         pip install .[test]
     - name: Analysing the code with Pylint
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        pip install build==1.3.0
+        pip install build==1.4.0
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ keywords = [
     "software component transparency",
     "supply chain security",
 ]
-dependencies = ["spdx-python-model==0.0.4", "spdx-tools==0.8.3"]
+dependencies = ["spdx-python-model==0.0.4", "spdx-tools>=0.8.5"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
To resolve #355 

spdx-tools 0.8.5 will allow the support of Python 3.14

Both spdx-tools and ntia-conformance-checker now requires Python >= 3.10