### PR TITLE
Deprecate parsing_error and ntia_minimum_elements_compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
-## [5.0.0] - 2026-03-13
+## [5.0.0] - 2026-03-14
 
 ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
@@ -32,7 +32,9 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
 - Use type hinting generics for standard collections ([PEP 585])
   and use `X | Y` for union types ([PEP 604]) ([#339])
-- Update spdx-tools to 0.8.5 ([#356])
+
+### Deprecated
+
 - Deprecate `BaseChecker.parsing_error`,
   replacing it with `BaseChecker.parsing_errors` ([#357])
 
@@ -57,7 +59,6 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 [#331]: https://github.com/spdx/ntia-conformance-checker/pull/331
 [#339]: https://github.com/spdx/ntia-conformance-checker/pull/339
 [#341]: https://github.com/spdx/ntia-conformance-checker/pull/341
-[#356]: https://github.com/spdx/ntia-conformance-checker/pull/356
 [#357]: https://github.com/spdx/ntia-conformance-checker/pull/357
 [PEP 585]: https://peps.python.org/pep-0585/
 [PEP 604]: https://peps.python.org/pep-0604/
@@ -191,8 +192,13 @@ issue [#214][] for more details.
 
 ### Added
 
-- Add FSCTv3 checker fo Baseline Attributes in 2024 CISA Framing Software
+- Add FSCTv3 checker for Baseline Attributes in 2024 CISA Framing Software
   Component Transparency ([#224], [#226])
+
+### Deprecated
+
+- Deprecate `BaseChecker.ntia_minimum_elements_compliant`,
+  replacing it with `BaseChecker.compliant` ([#214])
 
 [new-sbomchecker]: https://docs.google.com/document/d/1pueRxlxoM9n1eG9g6AihjLvybEBTd77m22mRYBQltpg/edit?usp=sharing
 [#214]: https://github.com/spdx/ntia-conformance-checker/issues/214

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog]
 and this project adheres to [Semantic Versioning][semver].
 
-## [5.0.0] - 2025-12-20
+## [5.0.0] - 2026-03-13
 
 ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
@@ -32,6 +32,9 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 
 - Use type hinting generics for standard collections ([PEP 585])
   and use `X | Y` for union types ([PEP 604]) ([#339])
+- Update spdx-tools to 0.8.5 ([#356])
+- Deprecate `BaseChecker.parsing_error`,
+  replacing it with `BaseChecker.parsing_errors` ([#357])
 
 ### Fixed
 
@@ -54,6 +57,8 @@ ntia-conformance-checker 5.0.0 requires Python 3.10 or newer.
 [#331]: https://github.com/spdx/ntia-conformance-checker/pull/331
 [#339]: https://github.com/spdx/ntia-conformance-checker/pull/339
 [#341]: https://github.com/spdx/ntia-conformance-checker/pull/341
+[#356]: https://github.com/spdx/ntia-conformance-checker/pull/356
+[#357]: https://github.com/spdx/ntia-conformance-checker/pull/357
 [PEP 585]: https://peps.python.org/pep-0585/
 [PEP 604]: https://peps.python.org/pep-0604/
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -50,4 +50,4 @@ keywords:
   - CISA
 license: Apache-2.0
 version: 5.0.0
-date-released: '2026-03-13'
+date-released: '2026-03-14'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -50,4 +50,4 @@ keywords:
   - CISA
 license: Apache-2.0
 version: 5.0.0
-date-released: '2025-12-20'
+date-released: '2026-03-13'

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -89,7 +89,7 @@ class BaseChecker(ABC):
     __spdx3_doc: spdx3.SpdxDocument | None = None  # cached SPDX 3 document
 
     _parsing_errors: list[str] = []
-    validation_messages: list[ValidationMessage] = []
+    _validation_messages: list[ValidationMessage] = []
 
     sbom_name: str = ""
     # Lists of components missing required information.
@@ -117,6 +117,11 @@ class BaseChecker(ABC):
             stacklevel=2,
         )
         return self.compliant
+
+    @property
+    def validation_messages(self) -> list[ValidationMessage]:
+        """Validation messages from SPDX document validation."""
+        return self._validation_messages
 
     @property
     def parsing_errors(self) -> list[str]:
@@ -163,7 +168,7 @@ class BaseChecker(ABC):
         # Make sure the logs are instance variables and not class variables
         # to avoid shared state between instances.
         self._parsing_errors = []
-        self.validation_messages = []
+        self._validation_messages = []
 
         match sbom_spec:
             case "spdx2":
@@ -174,11 +179,11 @@ class BaseChecker(ABC):
                     logging.error("Failed to parse the SPDX 3 file.")
                 else:
                     self.doc = object_set
-                    _doc, _validation_messages = validate_spdx3_data(object_set)
-                    if not _doc or _validation_messages:
+                    _doc, _val_msgs = validate_spdx3_data(object_set)
+                    if not _doc or _val_msgs:
                         logging.error("SpdxDocument not found or invalid.")
                     self.__spdx3_doc = _doc  # cache the extracted SpdxDocument
-                    self.validation_messages.extend(_validation_messages)
+                    self._validation_messages.extend(_val_msgs)
             case _:
                 # We can add a heuristic to detect the spec from the file content here,
                 # in case sbom_spec is not provided or invalid.
@@ -188,7 +193,7 @@ class BaseChecker(ABC):
             if validate:
                 if sbom_spec == "spdx2":
                     self.doc = cast("Document", self.doc)
-                    self.validation_messages = validate_full_spdx_document(self.doc)
+                    self._validation_messages = validate_full_spdx_document(self.doc)
                 else:
                     pass
 
@@ -802,7 +807,7 @@ class BaseChecker(ABC):
             compliant=getattr(self, "compliant", False),
             requirement_results=getattr(self, "table_elements", []),
             components_without_info=getattr(self, "all_components_without_info", []),
-            validation_messages=getattr(self, "validation_messages", []),
+            validation_messages=self._validation_messages,
             parsing_errors=self._parsing_errors,
         )
 
@@ -821,7 +826,7 @@ class BaseChecker(ABC):
             compliant=getattr(self, "compliant", False),
             requirement_results=getattr(self, "table_elements", []),
             components_without_info=getattr(self, "all_components_without_info", []),
-            validation_messages=getattr(self, "validation_messages", []),
+            validation_messages=self._validation_messages,
             parsing_errors=self._parsing_errors,
         )
 
@@ -841,7 +846,7 @@ class BaseChecker(ABC):
             "complianceStandard": getattr(self, "compliance_standard", ""),
             "sbomSpec": getattr(self, "sbom_spec", ""),
             "validationMessages": get_validation_messages_json(
-                getattr(self, "validation_messages", [])
+                self._validation_messages
             ),
             "parsingError": self._parsing_errors,
             "sbomName": getattr(self, "sbom_name", ""),

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, cast
 
@@ -87,7 +88,7 @@ class BaseChecker(ABC):
     doc: Document | spdx3.SHACLObjectSet | None = None
     __spdx3_doc: spdx3.SpdxDocument | None = None  # cached SPDX 3 document
 
-    parsing_error: list[str] = []
+    _parsing_errors: list[str] = []
     validation_messages: list[ValidationMessage] = []
 
     sbom_name: str = ""
@@ -107,8 +108,30 @@ class BaseChecker(ABC):
 
     compliant: bool = False  # Is SBOM compliant with the chosen standard?
 
-    # An alias of "compliant", for backward compatibility
-    ntia_minimum_elements_compliant: bool = compliant
+    @property
+    def ntia_minimum_elements_compliant(self) -> bool:
+        """Deprecated: use ``compliant`` instead."""
+        warnings.warn(
+            "ntia_minimum_elements_compliant is deprecated; use compliant instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.compliant
+
+    @property
+    def parsing_errors(self) -> list[str]:
+        """Parsing errors encountered during file parsing."""
+        return self._parsing_errors
+
+    @property
+    def parsing_error(self) -> list[str]:
+        """Deprecated: use ``parsing_errors`` instead."""
+        warnings.warn(
+            "parsing_error is deprecated; use parsing_errors instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._parsing_errors
 
     @abstractmethod
     def check_compliance(self) -> bool:
@@ -139,7 +162,7 @@ class BaseChecker(ABC):
 
         # Make sure the logs are instance variables and not class variables
         # to avoid shared state between instances.
-        self.parsing_error = []
+        self._parsing_errors = []
         self.validation_messages = []
 
         match sbom_spec:
@@ -697,7 +720,7 @@ class BaseChecker(ABC):
         try:
             doc = parse_anything.parse_file(self.file)
         except SPDXParsingError as err:
-            self.parsing_error.extend(err.get_messages())
+            self._parsing_errors.extend(err.get_messages())
             return None
         except Exception as err:  # pylint: disable=broad-except
             # Catch any other errors, including BeartypeCallHintParamViolation
@@ -706,7 +729,7 @@ class BaseChecker(ABC):
             # which throws exceptions when encountering missing required fields
             # (e.g., missing author, timestamp, or identifiers).
             logging.debug("Error parsing file: %s", err)
-            self.parsing_error.append(
+            self._parsing_errors.append(
                 f"Error parsing file: {type(err).__name__}: {str(err)}"
             )
             return None
@@ -734,7 +757,7 @@ class BaseChecker(ABC):
                 spdx3.JSONLDDeserializer().read(f, object_set)
         except (OSError, json.JSONDecodeError) as err:
             logging.warning("SPDX3 deserialization failed: %s", err)
-            self.parsing_error.append(str(err))
+            self._parsing_errors.append(str(err))
             return None
 
         return object_set
@@ -750,7 +773,7 @@ class BaseChecker(ABC):
             None
         """
         # If parsing failed, skip
-        if self.parsing_error:
+        if self._parsing_errors:
             return
 
         if not self.all_components_without_info:
@@ -780,7 +803,7 @@ class BaseChecker(ABC):
             requirement_results=getattr(self, "table_elements", []),
             components_without_info=getattr(self, "all_components_without_info", []),
             validation_messages=getattr(self, "validation_messages", []),
-            parsing_error=getattr(self, "parsing_error", []),
+            parsing_errors=self._parsing_errors,
         )
 
         print(report_text(report_context, verbose))
@@ -799,7 +822,7 @@ class BaseChecker(ABC):
             requirement_results=getattr(self, "table_elements", []),
             components_without_info=getattr(self, "all_components_without_info", []),
             validation_messages=getattr(self, "validation_messages", []),
-            parsing_error=getattr(self, "parsing_error", []),
+            parsing_errors=self._parsing_errors,
         )
 
         return report_html(report_context, verbose=True)
@@ -820,7 +843,7 @@ class BaseChecker(ABC):
             "validationMessages": get_validation_messages_json(
                 getattr(self, "validation_messages", [])
             ),
-            "parsingError": getattr(self, "parsing_error", []),
+            "parsingError": self._parsing_errors,
             "sbomName": getattr(self, "sbom_name", ""),
             "specVersionProvided": getattr(self, "doc_version", False),
             "authorNameProvided": getattr(self, "doc_author", False),

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -119,11 +119,6 @@ class BaseChecker(ABC):
         return self.compliant
 
     @property
-    def validation_messages(self) -> list[ValidationMessage]:
-        """Validation messages from SPDX document validation."""
-        return self._validation_messages
-
-    @property
     def parsing_errors(self) -> list[str]:
         """Parsing errors encountered during file parsing."""
         return self._parsing_errors
@@ -137,6 +132,11 @@ class BaseChecker(ABC):
             stacklevel=2,
         )
         return self._parsing_errors
+
+    @property
+    def validation_messages(self) -> list[ValidationMessage]:
+        """Validation messages from SPDX document validation."""
+        return self._validation_messages
 
     @abstractmethod
     def check_compliance(self) -> bool:

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from spdx_tools.spdx.validation.validation_message import ValidationMessage
 
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes,too-many-public-methods
 class BaseChecker(ABC):
     """Base class for all compliance/conformance checkers.
 

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -59,8 +59,6 @@ class FSCT3Checker(BaseChecker):
 
         if self.doc:
             self.compliant = self.check_compliance()
-            # for backward compatibility
-            self.ntia_minimum_elements_compliant = self.compliant
 
         self.table_elements = [
             ("All component names provided?", not self.components_without_names),

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -39,8 +39,8 @@ def main() -> None:
         sbom_spec=detected_sbom_spec,
     )
 
-    logging.debug("Parsing: %s", "OK" if not sbom.parsing_error else "Failed")
-    if not sbom.parsing_error:
+    logging.debug("Parsing: %s", "OK" if not sbom.parsing_errors else "Failed")
+    if not sbom.parsing_errors:
         if args.skip_validation:
             logging.debug("Validation: skipped")
         else:

--- a/ntia_conformance_checker/ntia_checker.py
+++ b/ntia_conformance_checker/ntia_checker.py
@@ -46,8 +46,6 @@ class NTIAChecker(BaseChecker):
 
         if self.doc:
             self.compliant = self.check_compliance()
-            # for backward compatibility
-            self.ntia_minimum_elements_compliant = self.compliant
 
         self.table_elements = [
             ("All component names provided?", not self.components_without_names),

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -32,7 +32,7 @@ class ReportContext:
     requirement_results: list[tuple[str, bool]] | None = None
     components_without_info: list[tuple[str, list[tuple[str, str]]]] | None = None
     validation_messages: list[ValidationMessage] | None = None
-    parsing_error: list[str] | None = None
+    parsing_errors: list[str] | None = None
 
 
 def _safe_attr(obj: object, name: str) -> str:
@@ -163,11 +163,11 @@ def report_text(
     report: list[str] = []
 
     # Parsing error
-    if rc.parsing_error:
+    if rc.parsing_errors:
         report.append("The document couldn't be parsed; check couldn't be performed.\n")
-        if rc.parsing_error:
+        if rc.parsing_errors:
             report.append("The following parsing error(s) were raised:\n")
-            for error in rc.parsing_error:
+            for error in rc.parsing_errors:
                 report.append(error)
         return "\n".join(report)
 
@@ -216,7 +216,7 @@ def report_html(
     report: list[str] = []
 
     # Parsing error
-    if rc.parsing_error:
+    if rc.parsing_errors:
         report.append("<div class='conformance-err'>")
         report.append(
             "<p class='conformance-err-label'>"
@@ -225,7 +225,7 @@ def report_html(
             "</p>"
         )
         report.append("<ul class='conformance-err-list'>")
-        for err in rc.parsing_error:
+        for err in rc.parsing_errors:
             report.append(f"<li>{err}</li>")
         report.append("</ul>")
         report.append("</div>")

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -7,6 +7,7 @@
 # pylint: disable=missing-function-docstring,import-error,consider-using-from-import
 
 import os
+import warnings
 from pathlib import Path
 from unittest import TestCase
 
@@ -49,7 +50,6 @@ def test_sbomchecker_ntia_no_errors(test_file):
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert sbom.compliant
-    assert sbom.ntia_minimum_elements_compliant
 
 
 @pytest.mark.parametrize("test_file", test_files)
@@ -81,7 +81,6 @@ def test_ntiachecker_no_errors(test_file):
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert sbom.compliant
-    assert sbom.ntia_minimum_elements_compliant
 
 
 @pytest.mark.parametrize("test_file", test_files)
@@ -114,7 +113,7 @@ def test_sbomchecker_missing_author_name(test_file):
     the document does not contain a creator."""
     sbom_check = sbom_checker.SbomChecker(test_file)
 
-    assert not sbom_check.ntia_minimum_elements_compliant
+    assert not sbom_check.compliant
     assert sbom_check.parsing_errors
 
 
@@ -130,7 +129,7 @@ def test_sbomchecker_missing_timestamp(test_file):
     the document does not contain a created date."""
     sbom_check = sbom_checker.SbomChecker(test_file)
 
-    assert not sbom_check.ntia_minimum_elements_compliant
+    assert not sbom_check.compliant
     assert sbom_check.parsing_errors
 
 
@@ -173,7 +172,6 @@ def test_sbomchecker_missing_dependency_relationships(test_file):
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert not sbom.compliant
-    assert not sbom.ntia_minimum_elements_compliant
 
 
 ### Test missing component version
@@ -199,7 +197,6 @@ def test_sbomchecker_missing_component_version(test_file):
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert not sbom.compliant
-    assert not sbom.ntia_minimum_elements_compliant
 
 
 ### Test missing supplier name
@@ -224,7 +221,6 @@ def test_sbomchecker_missing_supplier_name(test_file):
     )
     assert not sbom.components_without_identifiers
     assert not sbom.compliant
-    assert not sbom.ntia_minimum_elements_compliant
 
 
 ### Test missing unique identifiers
@@ -243,7 +239,6 @@ def test_sbomchecker_missing_unique_identifiers(test_file):
     sbom_check = sbom_checker.SbomChecker(test_file)
 
     assert not sbom_check.compliant
-    assert not sbom_check.ntia_minimum_elements_compliant
     assert sbom_check.parsing_errors
 
 
@@ -289,7 +284,6 @@ def test_sbomchecker_chainguard_example():
     )
     sbom = sbom_checker.SbomChecker(test_file)
     assert sbom.compliant
-    assert sbom.ntia_minimum_elements_compliant
 
 
 def test_sbomchecker_alpine_no_package_supplier_name_example():
@@ -552,3 +546,29 @@ def test_components_without_functions():
     # If any package misses the SPDXID the whole file seems to be invalid.
     # components = sbom.get_components_without_identifiers()
     # assert components == ["glibc-no-identifier"]
+
+
+def test_deprecation_ntia_minimum_elements_compliant():
+    """Test that accessing the deprecated property
+    `ntia_minimum_elements_compliant`
+    raises a DeprecationWarning."""
+    sbom = sbom_checker.SbomChecker(test_files[0])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = sbom.ntia_minimum_elements_compliant
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "ntia_minimum_elements_compliant" in str(caught[0].message)
+
+
+def test_deprecation_parsing_error():
+    """Test that accessing the deprecated property
+    `parsing_error`
+    raises a DeprecationWarning."""
+    sbom = sbom_checker.SbomChecker(test_files[0])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = sbom.parsing_error
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "parsing_error" in str(caught[0].message)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -115,7 +115,7 @@ def test_sbomchecker_missing_author_name(test_file):
     sbom_check = sbom_checker.SbomChecker(test_file)
 
     assert not sbom_check.ntia_minimum_elements_compliant
-    assert sbom_check.parsing_error
+    assert sbom_check.parsing_errors
 
 
 ### Test missing timestamp
@@ -131,7 +131,7 @@ def test_sbomchecker_missing_timestamp(test_file):
     sbom_check = sbom_checker.SbomChecker(test_file)
 
     assert not sbom_check.ntia_minimum_elements_compliant
-    assert sbom_check.parsing_error
+    assert sbom_check.parsing_errors
 
 
 ### Test missing concluded licenses
@@ -244,7 +244,7 @@ def test_sbomchecker_missing_unique_identifiers(test_file):
 
     assert not sbom_check.compliant
     assert not sbom_check.ntia_minimum_elements_compliant
-    assert sbom_check.parsing_error
+    assert sbom_check.parsing_errors
 
 
 ### Test SBOM example from various sources
@@ -337,7 +337,7 @@ def test_sbomchecker_spdx3_no_elements_missing():
     assert sbom.doc is not None
     assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
     print(sbom.sbom_name)
-    assert len(sbom.parsing_error) == 0
+    assert len(sbom.parsing_errors) == 0
     assert len(sbom.validation_messages) == 0
     assert sbom.sbom_name is not None
     assert len(sbom.components_without_names) == 0


### PR DESCRIPTION
## Background

- The `parsing_error: list[str]` naming is not consistent with other properties than are list. For example, `validation_messages` and `components_without_names`.
- `ntia_minimum_elements_compliant` is deprecated since 3.1.0 but the deprecation mechanism is flaky and rely on disciplined get/set in different locations.

## What this PR does?

- Deprecate `parsing_error` and replace with `parsing_errors` (plural form for list), using `@property` which allow to define getter/setter methods of a property and prevent direct property manipulation
- Use `@property` to properly deprecate `ntia_minimum_elements_compliant`

This will not introduce a breaking change.

Users will be warned and suggested with new property names.

Changelog is updated with these deprecation info.