### PR TITLE
Remove pytype from CI, Makefile, and docs

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -43,6 +43,3 @@ jobs:
       - name: pyright type check
         run: |
           pyright ntia_conformance_checker
-      - name: pytype type check
-        run: |
-          pytype ntia_conformance_checker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,6 @@ pip install -e ".[dev,docs,test]"
 pip install spdx-tools tzdata
 ```
 
-Note: `pytype` does not support Windows and will fail during install —
-this is expected and can be ignored. All other tools will install correctly.
-
 Or, if you're on a Unix-like system, you can use `make`:
 
 ```sh
@@ -132,8 +129,7 @@ Here's the process to make changes to the codebase:
 
    Static type analysis is recommended to catch potential bugs and improve code
    quality. We use several type checkers ([`mypy`][mypy], [`pyrefly`][pyrefly],
-   [`pyright`][pyright], and [`pytype`][pytype]) to get different perspectives
-   on the code.
+   and [`pyright`][pyright]) to get different perspectives on the code.
 
    Run all type checkers:
 
@@ -148,16 +144,13 @@ Here's the process to make changes to the codebase:
    pyright ntia_conformance_checker/
    ```
 
-   Note: `pytype` does not support Windows and can be skipped.
-
-   If you are certain that a line is correct but the type checker is not able
+   If you are certain that a line is correct, but the type checker is not able
    to verify it, you may choose to add a `# type: ignore` comment with
    additional explanation at the end of the line to suppress the error.
 
    [mypy]: https://mypy-lang.org/
    [pyrefly]: https://pyrefly.org/
    [pyright]: https://github.com/microsoft/pyright
-   [pytype]: https://github.com/google/pytype
 
 8. Format your changes with [`black`][black] and sort import with
     [`isort`][isort]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,14 +145,14 @@ Here's the process to make changes to the codebase:
    ```
 
    If you are certain that a line is correct, but the type checker is not able
-   to verify it, you may choose to add a `# type: ignore` comment with
-   additional explanation at the end of the line to suppress the error.
+   to verify it, you may choose to add a relevant `# type: ignore[..]` comment
+   with additional explanation to suppress the error.
 
    [mypy]: https://mypy-lang.org/
    [pyrefly]: https://pyrefly.org/
    [pyright]: https://github.com/microsoft/pyright
 
-8. Format your changes with [`black`][black] and sort import with
+9. Format your changes with [`black`][black] and sort import with
     [`isort`][isort]:
 
    ```sh
@@ -169,21 +169,21 @@ Here's the process to make changes to the codebase:
    [black]: https://github.com/psf/black
    [isort]: https://pycqa.github.io/isort/
 
-9. Push the branch to your fork on GitHub:
+10. Push the branch to your fork on GitHub:
 
    ```sh
    git push origin fix-or-improve-something
    ```
 
-10. Make a pull request on GitHub.
-11. Continue making more changes and commits on the branch,
+11. Make a pull request on GitHub.
+12. Continue making more changes and commits on the branch,
     with `git commit --signoff` and `git push`.
-12. When done, write a comment on the PR asking for a code review.
-13. Some other developer will review your changes and accept your PR.
+13. When done, write a comment on the PR asking for a code review.
+14. Some other developer will review your changes and accept your PR.
     The merge should be done with `rebase`, if possible, or with `squash`.
-14. The temporary branch on GitHub should be deleted (there is a button for
+15. The temporary branch on GitHub should be deleted (there is a button for
     deleting it).
-15. Delete the local branch as well:
+16. Delete the local branch as well:
 
     ```sh
     git checkout master

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ type:
 	mypy ntia_conformance_checker || true
 	pyrefly check ntia_conformance_checker
 	pyright ntia_conformance_checker
-	pytype ntia_conformance_checker
 
 # Unit tests
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,16 +56,15 @@ dependencies = ["spdx-python-model==0.0.4", "spdx-tools>=0.8.5"]
 
 [project.optional-dependencies]
 dev = [
-    "black>=25.12.0",
+    "black>=26.3.1",
     "mypy>=1.19.1",
-    "pylint>=4.0.4",
-    "pyrefly>=0.46.0",
-    "pyright>=1.1.407",
-    "pytype>=2024.10.11",
+    "pylint>=4.0.5",
+    "pyrefly>=0.58.0",
+    "pyright>=1.1.408",
     "ruff>=0.14.9",
 ]
 docs = ["Sphinx>=9.0.4"]
-test = ["coverage>=7.13.0", "pytest>=9.0.2"]
+test = ["coverage>=7.13.5", "pytest>=9.0.2"]
 
 [project.scripts]
 # Both "ntia-checker" and "sbomcheck" are identical.


### PR DESCRIPTION
Drop the official use of pytype. Remove mention of pytype from CONTRIBUTING.md

Update type checkers and test runners.

To fix #360 