### PR TITLE
Add AGENTS.md for AI agents + AI usage policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Agent instructions
+
+## 1. Contribution workflow
+
+- Follow existing code style and repository conventions.
+- Add tests for new behavior and maintain existing tests.
+- Run linters and static analysis (`ruff`, `pylint`, `mypy`) and fix reported
+  issues before committing.
+- Update `CHANGELOG.md` for significant changes, follows Keep a Changelog style
+  <https://keepachangelog.com/en/1.1.0/>, and use Semantic Versioning for
+  releases.
+
+## 2. Code style & formatting
+
+- Follow PEP 8 for Python; use the project's `pyproject.toml` and tooling for
+  exact settings.
+- Use `black` formatting rules configured in the repo; run formatters
+  before committing.
+- Keep functions and modules short and readable; split large functions into
+  smaller units.
+
+## 3. Naming conventions
+
+- US spelling. Concise. Clear. Consistent across submodules.
+- Noun number consistency: Maintain strict intentionality regarding singular
+  vs. plural forms. Use singular names for classes representing a single entity
+  and reserve plural names only for collections or utility modules.
+
+## 3. Typing & static analysis
+
+- Prefer complete type annotations for public APIs (functions, classes,
+  module-level variables).
+- Use `if TYPE_CHECKING:` for heavy or optional imports used only for typing.
+- Minimize use of `Any`. When unavoidable, prefer narrow casts or
+  `# type: ignore[..]` with an inline justification.
+
+Recommended local checks to run during development:
+
+```bash
+ruff check --fix . && mypy ntia_conformance_checker tests && pylint ntia_conformance_checker tests && pytest -q
+```
+
+## 4. Tests & CI
+
+- Add unit tests for new code paths and edge cases; include type-focused tests
+  when relevant.
+- Keep tests deterministic and fast; avoid network I/O unless explicitly
+  testing integration.
+- If a CI failure stems from differing dependency versions, prefer pinning
+  the tool or adding an explanatory comment and raising a PR to align versions.
+
+## 5. Security & secrets
+
+- Never commit secrets, credentials, or tokens. Use environment variables or
+  secrets stores in CI.
+- Validate and sanitize all external inputs. Avoid `eval()` and untrusted
+  deserialization.
+
+## 6. APIs & backward compatibility
+
+- Design public API changes with backward compatibility in mind.
+  Document breaking changes and bump versions accordingly.
+- Use appropriate HTTP return codes and follow OpenAPI for web APIs.
+- Follow Unix philosophy. Command-line output and error messages must be
+  consistent, predictable and parseable.
+
+## 7. Git & commits
+
+- Write clear commit messages that explain the why and what, following
+  conventional commit style where appropriate.
+- Ask before making large cross-package refactors or adding heavy dependencies.
+
+## 8. File headers & licensing
+
+- Include SPDX tags in source files where applicable (see repo examples).
+
+## 9. Boundaries (what to ask about)
+
+- Ask before: large cross-package refactors, adding heavyweight dependencies,
+  or data migrations.
+- Never: commit secrets, edit generated files by hand when a generator exists,
+  or perform destructive git operations without approval.
+
+## 10. Useful references
+
+- SPDX project code repository: <https://github.com/spdx/>
+- Packaging metadata guidelines: <https://packaging.python.org/>
+- SBOM-Everywhere: <https://sbom-catalog.openssf.org/>
+- 2025 Minimum Elements for SBOM (draft):
+  <https://www.cisa.gov/resources-tools/resources/2025-minimum-elements-software-bill-materials-sbom>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## 1. Contribution workflow
 
 - Follow existing code style and repository conventions.
+- Complete docstring.
 - Add tests for new behavior and maintain existing tests.
 - Run linters and static analysis (`ruff`, `pylint`, `mypy`) and fix reported
   issues before committing.
@@ -18,6 +19,8 @@
   before committing.
 - Keep functions and modules short and readable; split large functions into
   smaller units.
+- Use "Sentence case" for headings in documentation.
+  Be strict on Markdown formatting.
 
 ## 3. Naming conventions
 
@@ -26,7 +29,7 @@
   vs. plural forms. Use singular names for classes representing a single entity
   and reserve plural names only for collections or utility modules.
 
-## 3. Typing & static analysis
+## 4. Typing & static analysis
 
 - Prefer complete type annotations for public APIs (functions, classes,
   module-level variables).
@@ -40,7 +43,7 @@ Recommended local checks to run during development:
 ruff check --fix . && mypy ntia_conformance_checker tests && pylint ntia_conformance_checker tests && pytest -q
 ```
 
-## 4. Tests & CI
+## 5. Tests & CI
 
 - Add unit tests for new code paths and edge cases; include type-focused tests
   when relevant.
@@ -49,14 +52,14 @@ ruff check --fix . && mypy ntia_conformance_checker tests && pylint ntia_conform
 - If a CI failure stems from differing dependency versions, prefer pinning
   the tool or adding an explanatory comment and raising a PR to align versions.
 
-## 5. Security & secrets
+## 6. Security & secrets
 
 - Never commit secrets, credentials, or tokens. Use environment variables or
   secrets stores in CI.
 - Validate and sanitize all external inputs. Avoid `eval()` and untrusted
   deserialization.
 
-## 6. APIs & backward compatibility
+## 7. APIs & backward compatibility
 
 - Design public API changes with backward compatibility in mind.
   Document breaking changes and bump versions accordingly.
@@ -64,24 +67,24 @@ ruff check --fix . && mypy ntia_conformance_checker tests && pylint ntia_conform
 - Follow Unix philosophy. Command-line output and error messages must be
   consistent, predictable and parseable.
 
-## 7. Git & commits
+## 8. Git & commits
 
 - Write clear commit messages that explain the why and what, following
   conventional commit style where appropriate.
 - Ask before making large cross-package refactors or adding heavy dependencies.
 
-## 8. File headers & licensing
+## 9. File headers & licensing
 
 - Include SPDX tags in source files where applicable (see repo examples).
 
-## 9. Boundaries (what to ask about)
+## 10. Boundaries (what to ask about)
 
 - Ask before: large cross-package refactors, adding heavyweight dependencies,
   or data migrations.
 - Never: commit secrets, edit generated files by hand when a generator exists,
   or perform destructive git operations without approval.
 
-## 10. Useful references
+## 11. Useful references
 
 - SPDX project code repository: <https://github.com/spdx/>
 - Packaging metadata guidelines: <https://packaging.python.org/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,3 +245,55 @@ make html
 ```
 
 [sphinx]: https://www.sphinx-doc.org/
+
+## AI usage policy
+
+### General AI tool policy
+
+AI tools (e.g., LLMs, code assistants, and proofreaders) are permitted as
+assistive supplements, not replacements for human judgment.
+
+- **Code review:**
+  AI tools may act as a preliminary "peer reviewer" to catch syntax or style
+  issues, similar to a non-AI code analysis tool.
+  However, a human must perform the final review, validate logic,
+  and take full responsibility for all decisions.
+- **Automation:**
+  AI is acceptable for offloading repetitive, well-understood, and
+  time-consuming boilerplate tasks.
+- **Verification:**
+  All AI-generated suggestions must be manually verified for security,
+  performance, and project alignment.
+
+### Special policy for Google Summer of Code (GSoC)
+
+GSoC is a mentorship and learning program.
+Over-reliance on AI undermines the educational goals and the evaluation of the
+contributor's growth.
+
+- **Writing & proposals:**
+  - Prohibited: Generating full proposals, final reports, PR descriptions,
+    or substantial parts of those.
+  - Permitted: Spell-checking, grammar correction, and feedback on structural
+    coherence.
+  - Requirement: PR descriptions must be written by the contributor to
+    demonstrate a deep understanding of what was changed and why.
+  - Note: Your English skills will not be graded; mentors care about your code
+    and understanding.
+- **Code generation:**
+  - Prohibited: Using AI to write entire modules or significant logic blocks.
+  - Rationale: The goal of GSoC is your development as a contributor within
+    a community. Writing your own code and code comments is essential for
+    learning. Furthermore, LLMs often provide inaccurate results for SPDX 3.x,
+    as the lack of public datasets for these new standards leads to frequent
+    technical hallucinations.
+- **Transparency:**
+  - Contributors must disclose if AI was used significantly in any part of
+    their workflow.
+  - Unattributed AI-generated code may be considered a violation of integrity,
+    which may result in a failing project evaluation.
+
+All GSoC contributors must adhere to the official
+[Guidance for GSoC Contributors using AI tooling in GSoC 2026][gsoc-ai-guidance].
+
+[gsoc-ai-guidance]: https://developers.google.com/open-source/gsoc/resources/ai_guidance#1_always_validate_and_fully_understand_the_code


### PR DESCRIPTION
- AGENTS.md: Some instructions for AI agents. Also symlink it to copilot-instructions.md, so GitHub Copilot can pick it up.
- AI usage policy section in CONTRIBUTING.md, including policy for GSoC contributions

Fix #361 