### PR TITLE
Fix Sphinx version to support Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "pyright>=1.1.408",
     "ruff>=0.14.9",
 ]
-docs = ["Sphinx>=9.0.4"]
+docs = ["Sphinx>=8.1.3"]
 test = ["coverage>=7.13.5", "pytest>=9.0.2"]
 
 [project.scripts]


### PR DESCRIPTION
Sphinx 9 is not available for Python 3.10, so we downgrade it to Sphinx 8 to make the pip install ".[dev,docs,test]" in example work for every supported Python version.