### PR TITLE
Update spdx-python-model to > 0.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ keywords = [
     "software component transparency",
     "supply chain security",
 ]
-dependencies = ["spdx-python-model==0.0.4", "spdx-tools>=0.8.5"]
+dependencies = ["spdx-python-model>=0.0.5,<1.0.0", "spdx-tools>=0.8.5,<1.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/spdx/ntia-conformance-checker"
@@ -65,12 +65,12 @@ dev = [
     "black>=26.3.1",
     "mypy>=1.20.0",
     "pylint>=4.0.5",
-    "pyrefly>=0.58.0",
+    "pyrefly>=0.60.2",
     "pyright>=1.1.408",
-    "ruff>=0.14.9",
+    "ruff>=0.15.10",
 ]
 docs = ["Sphinx>=8.1.3"]
-test = ["coverage>=7.13.5", "pytest>=9.0.2"]
+test = ["coverage>=7.13.5", "pytest>=9.0.3"]
 
 [project.scripts]
 # Both "ntia-checker" and "sbomcheck" are identical.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ keywords = [
     "software component transparency",
     "supply chain security",
 ]
-dependencies = ["spdx-python-model>=0.0.5,<1.0.0", "spdx-tools>=0.8.5,<1.0.0"]
+dependencies = ["spdx-python-model>0.0.5,<1.0.0", "spdx-tools>=0.8.5,<1.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/spdx/ntia-conformance-checker"


### PR DESCRIPTION
- Update spdx-python-model to >= 0.0.5.
  - 0.0.5 comes with improved typing https://github.com/spdx/spdx-python-model/releases/tag/v0.0.5 
- Update other dependencies.

Keep minimum supported Python version at 3.10.