### PR TITLE
Aligned SpdxDocument's rootElement validation with SPDX 3

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -180,6 +180,7 @@ class BaseChecker(ABC):
         # to avoid shared state between instances.
         self._parsing_errors = []
         self._validation_messages = []
+        self._conformance_messages = []
 
         match sbom_spec:
             case "spdx2":

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -77,9 +77,6 @@ class BaseChecker(ABC):
     compliance_standard: str = ""  # fsct3-min, ntia
     sbom_spec: str = ""  # spdx2, spdx3
 
-    # These are detectable by spdx-tools, so not needed for now.
-    # file_format: str = ""  # json, rdf-xml, tag-value, yaml, xml
-
     file: str = ""
     # For SPDX 3, we have to use SHACLObjectSet instead of SpdxDocument,
     # because we need access to relationships and other elements that are not
@@ -104,7 +101,7 @@ class BaseChecker(ABC):
     doc_version: bool = False  # Has SPDX document version?
     doc_author: bool = False  # Has SPDX document author?
     doc_timestamp: bool = False  # Has SPDX document creation timestamp?
-    dependency_relationships: bool = False  # Has DESCRIBES relationship?
+    dependency_relationships: bool = False  # Has package dependency relationship?
 
     compliant: bool = False  # Is SBOM compliant with the chosen standard?
 
@@ -161,7 +158,6 @@ class BaseChecker(ABC):
         """
         self.compliance_standard = compliance
         self.sbom_spec = sbom_spec
-        # self.file_format = ""
 
         self.file = file
 
@@ -190,12 +186,9 @@ class BaseChecker(ABC):
                 raise ValueError(f"Unsupported SBOM specification: {sbom_spec}")
 
         if self.doc:
-            if validate:
-                if sbom_spec == "spdx2":
-                    self.doc = cast("Document", self.doc)
-                    self._validation_messages = validate_full_spdx_document(self.doc)
-                else:
-                    pass
+            if validate and sbom_spec == "spdx2":
+                self.doc = cast("Document", self.doc)
+                self._validation_messages = validate_full_spdx_document(self.doc)
 
             self.sbom_name = self.get_sbom_name()
 
@@ -261,7 +254,12 @@ class BaseChecker(ABC):
         return False
 
     def check_dependency_relationships(self) -> bool:
-        """Check if the SPDX document DESCRIBES at least one package."""
+        """Check if the SBOM document describes at least one package.
+
+        For SPDX 2 this checks for a DESCRIBES relationship; for SPDX 3 it
+        checks that a BOM/SBOM element lists at least one package in its
+        ``rootElement``.
+        """
         if not self.doc:
             return False
 
@@ -290,12 +288,17 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            # If a BOM/an SBOM's rootElement is a /Software/Package (or its subclass),
+            # We will assume here that the SpdxDocument's rootElement is
+            # BOM/SBOM. If it's not, it should fail the validation step.
+            #
+            # If a BOM/an SBOM's rootElement is a /Software/Package
+            # (or its subclass),
             # it is considered to have a dependency relationship.
             #
             # Note that if there is neither /Software/Package(s) nor /Core/Bom,
-            # a DESCRIBES relationship is not needed; however, this method may still
-            # return False, since it is factually considered as "no relationship".
+            # a DESCRIBES relationship is not needed;
+            # however, this method may still return False,
+            # since it is factually considered as "no relationship".
 
             # There is a BOM/SBOM and an /Software/Package,
             # check if there is at least one package listed in any BOM/SBOM

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -19,6 +19,10 @@ from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 from spdx_tools.spdx.parser import parse_anything
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.validation.validation_message import (
+    ValidationContext,
+    ValidationMessage,
+)
 
 from .constants import DEFAULT_SBOM_SPEC
 from .report import (
@@ -37,7 +41,6 @@ from .spdx3_utils import (
 
 if TYPE_CHECKING:
     from spdx_tools.spdx.model.document import Document
-    from spdx_tools.spdx.validation.validation_message import ValidationMessage
 
 
 # pylint: disable=too-many-instance-attributes,too-many-public-methods
@@ -81,15 +84,16 @@ class BaseChecker(ABC):
     # file_format: str = ""  # json, rdf-xml, tag-value, yaml, xml
 
     file: str = ""
+
     # For SPDX 3, we have to use SHACLObjectSet instead of SpdxDocument,
     # because we need access to relationships and other elements that are not
     # accessible from SpdxDocument.
-
     doc: Document | spdx3.SHACLObjectSet | None = None
     __spdx3_doc: spdx3.SpdxDocument | None = None  # cached SPDX 3 document
 
     _parsing_errors: list[str] = []
     _validation_messages: list[ValidationMessage] = []
+    _conformance_messages: list[ValidationMessage] = []
 
     sbom_name: str = ""
     # Lists of components missing required information.
@@ -138,6 +142,11 @@ class BaseChecker(ABC):
         """Validation messages from SPDX document validation."""
         return self._validation_messages
 
+    @property
+    def conformance_messages(self) -> list[ValidationMessage]:
+        """Conformance messages from compliance/conformance checks."""
+        return self._conformance_messages
+
     @abstractmethod
     def check_compliance(self) -> bool:
         """Abstract method to check compliance/conformance."""
@@ -179,10 +188,9 @@ class BaseChecker(ABC):
                     logging.error("Failed to parse the SPDX 3 file.")
                 else:
                     self.doc = object_set
-                    _doc, _val_msgs = validate_spdx3_data(object_set)
-                    if not _doc or _val_msgs:
+                    self.__spdx3_doc, _val_msgs = validate_spdx3_data(object_set)
+                    if not self.__spdx3_doc or _val_msgs:
                         logging.error("SpdxDocument not found or invalid.")
-                    self.__spdx3_doc = _doc  # cache the extracted SpdxDocument
                     self._validation_messages.extend(_val_msgs)
             case _:
                 # We can add a heuristic to detect the spec from the file content here,
@@ -195,6 +203,7 @@ class BaseChecker(ABC):
                 self._validation_messages = validate_full_spdx_document(self.doc)
 
             self.sbom_name = self.get_sbom_name()
+            self.sbom_types = self.get_sbom_types()
 
             self.doc_version = self.check_doc_version()
             self.doc_author = self.check_author()
@@ -388,6 +397,48 @@ class BaseChecker(ABC):
             name = getattr(self.__spdx3_doc, "name", "")
 
         return name
+
+    def get_sbom_types(self) -> list[str]:
+        """Get SBOM types from the rootElement of the SpdxDocument.
+
+        CISA Framing Software Component Transparency (2024) listed
+        "SBOM type" as one of baseline attributes, see Table 1 (p. 22) in:
+        https://www.cisa.gov/resources-tools/resources/framing-software-component-transparency-2024
+
+        In SPDX 3, SBOM type is only available in /Software/Sbom class.
+        """
+        # SBOM type is only available in SPDX 3
+        if not self.doc or self.sbom_spec != "spdx3":
+            return []
+
+        root_elements: list[spdx3.SHACLObject] = getattr(
+            self.__spdx3_doc, "rootElement", []
+        )
+        if not root_elements:
+            return []
+
+        sbom_types: list[str] = []
+
+        # Assuming only one rootElement per document
+        root_elem = root_elements[0]
+        if not isinstance(root_elem, spdx3.software_Sbom):
+            doc_id = getattr(self.__spdx3_doc, "spdxId", None)
+            root_elem_id = getattr(root_elem, "spdxId", None)
+            error_msg = (
+                "The rootElement of the SpdxDocument must be of "
+                "type /Software/Sbom. CISA baseline attributes require "
+                "an SBOM type field, available only in /Software/Sbom. "
+                f"Found: {type(root_elem).__name__!r}"
+            )
+            context = ValidationContext(parent_id=doc_id, spdx_id=root_elem_id)
+            self._conformance_messages.append(ValidationMessage(error_msg, context))
+            return []
+
+        sbom_types = [
+            type_.strip() for type_ in getattr(root_elem, "software_sbomType", [])
+        ]
+
+        return sbom_types
 
     def get_components_without_concluded_licenses(self) -> list[tuple[str, str]]:
         """
@@ -864,6 +915,9 @@ class BaseChecker(ABC):
             "sbomSpec": getattr(self, "sbom_spec", ""),
             "validationMessages": get_validation_messages_json(
                 self._validation_messages
+            ),
+            "conformanceMessages": get_validation_messages_json(
+                self._conformance_messages
             ),
             "parsingError": self._parsing_errors,
             "sbomName": getattr(self, "sbom_name", ""),

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -77,6 +77,9 @@ class BaseChecker(ABC):
     compliance_standard: str = ""  # fsct3-min, ntia
     sbom_spec: str = ""  # spdx2, spdx3
 
+    # These are detectable by spdx-tools, so not needed for now.
+    # file_format: str = ""  # json, rdf-xml, tag-value, yaml, xml
+
     file: str = ""
     # For SPDX 3, we have to use SHACLObjectSet instead of SpdxDocument,
     # because we need access to relationships and other elements that are not
@@ -158,6 +161,7 @@ class BaseChecker(ABC):
         """
         self.compliance_standard = compliance
         self.sbom_spec = sbom_spec
+        # self.file_format = ""
 
         self.file = file
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -108,7 +108,7 @@ class BaseChecker(ABC):
     doc_version: bool = False  # Has SPDX document version?
     doc_author: bool = False  # Has SPDX document author?
     doc_timestamp: bool = False  # Has SPDX document creation timestamp?
-    dependency_relationships: bool = False  # Has DESCRIBE relationship?
+    dependency_relationships: bool = False  # Has DESCRIBES relationship?
     # See https://github.com/spdx/ntia-conformance-checker/issues/392
     # for discussion on dependency relationships and DESCRIBES.
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -108,7 +108,9 @@ class BaseChecker(ABC):
     doc_version: bool = False  # Has SPDX document version?
     doc_author: bool = False  # Has SPDX document author?
     doc_timestamp: bool = False  # Has SPDX document creation timestamp?
-    dependency_relationships: bool = False  # Has package dependency relationship?
+    dependency_relationships: bool = False  # Has DESCRIBE relationship?
+    # See https://github.com/spdx/ntia-conformance-checker/issues/392
+    # for discussion on dependency relationships and DESCRIBES.
 
     compliant: bool = False  # Is SBOM compliant with the chosen standard?
 
@@ -270,7 +272,7 @@ class BaseChecker(ABC):
         """Check if the SBOM document describes at least one package.
 
         For SPDX 2 this checks for a DESCRIBES relationship; for SPDX 3 it
-        checks that a BOM/SBOM element lists at least one package in its
+        checks that a /Software/Sbom element lists at least one package in its
         ``rootElement``.
         """
         if not self.doc:
@@ -302,16 +304,19 @@ class BaseChecker(ABC):
         # SPDX 3
         if self.sbom_spec == "spdx3":
             # We will assume here that the SpdxDocument's rootElement is
-            # BOM/SBOM. If it's not, it should fail the validation step.
+            # either /Core/Bom or /Software/Sbom.
             #
-            # If a BOM/an SBOM's rootElement is a /Software/Package
+            # If the's rootElement is a /Software/Package
             # (or its subclass),
-            # it is considered to have a dependency relationship.
+            # it is considered to have a DESCRIBES relationship.
             #
             # Note that if there is neither /Software/Package(s) nor /Core/Bom,
             # a DESCRIBES relationship is not needed;
             # however, this method may still return False,
             # since it is factually considered as "no relationship".
+            #
+            # See https://github.com/spdx/ntia-conformance-checker/issues/392
+            # for discussion on dependency relationships and DESCRIBES.
 
             # There is a BOM/SBOM and an /Software/Package,
             # check if there is at least one package listed in any BOM/SBOM

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -882,6 +882,7 @@ class BaseChecker(ABC):
             requirement_results=getattr(self, "table_elements", []),
             components_without_info=getattr(self, "all_components_without_info", []),
             validation_messages=self._validation_messages,
+            conformance_messages=self._conformance_messages,
             parsing_errors=self._parsing_errors,
         )
 
@@ -901,6 +902,7 @@ class BaseChecker(ABC):
             requirement_results=getattr(self, "table_elements", []),
             components_without_info=getattr(self, "all_components_without_info", []),
             validation_messages=self._validation_messages,
+            conformance_messages=self._conformance_messages,
             parsing_errors=self._parsing_errors,
         )
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -206,7 +206,7 @@ class BaseChecker(ABC):
                 self._validation_messages = validate_full_spdx_document(self.doc)
 
             self.sbom_name = self.get_sbom_name()
-            self.sbom_types = self.get_sbom_types()
+            self.sbom_gen_context = self.get_sbom_types()
 
             self.doc_version = self.check_doc_version()
             self.doc_author = self.check_author()
@@ -431,9 +431,9 @@ class BaseChecker(ABC):
             doc_id = getattr(self.__spdx3_doc, "spdxId", None)
             root_elem_id = getattr(root_elem, "spdxId", None)
             error_msg = (
-                "The rootElement of the SpdxDocument must be of "
-                "type /Software/Sbom. CISA baseline attributes require "
-                "an SBOM type field, available only in /Software/Sbom. "
+                "To have SBOM type (SBOM generation context) information, "
+                "the rootElement of the SpdxDocument shall be of type "
+                "/Software/Sbom."
                 f"Found: {type(root_elem).__name__!r}"
             )
             context = ValidationContext(parent_id=doc_id, spdx_id=root_elem_id)

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -84,6 +84,7 @@ class FSCT3Checker(BaseChecker):
             ),
             ("SBOM author name provided?", self.doc_author),
             ("SBOM creation timestamp provided?", self.doc_timestamp),
+            ("SBOM type provided?", bool(self.sbom_types)),
             ("Dependency relationships provided?", self.dependency_relationships),
         ]
 
@@ -94,6 +95,7 @@ class FSCT3Checker(BaseChecker):
                 self.doc_author,
                 self.doc_timestamp,
                 self.dependency_relationships,
+                bool(self.sbom_types),
                 not self.components_without_names,
                 not self.components_without_versions,
                 not self.components_without_identifiers,

--- a/ntia_conformance_checker/fsct_checker.py
+++ b/ntia_conformance_checker/fsct_checker.py
@@ -84,7 +84,10 @@ class FSCT3Checker(BaseChecker):
             ),
             ("SBOM author name provided?", self.doc_author),
             ("SBOM creation timestamp provided?", self.doc_timestamp),
-            ("SBOM type provided?", bool(self.sbom_types)),
+            (
+                "SBOM generation context (SBOM type) provided?",
+                bool(self.sbom_gen_context),
+            ),
             ("Dependency relationships provided?", self.dependency_relationships),
         ]
 
@@ -95,7 +98,7 @@ class FSCT3Checker(BaseChecker):
                 self.doc_author,
                 self.doc_timestamp,
                 self.dependency_relationships,
-                bool(self.sbom_types),
+                bool(self.sbom_gen_context),
                 not self.components_without_names,
                 not self.components_without_versions,
                 not self.components_without_identifiers,

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -32,6 +32,7 @@ class ReportContext:
     requirement_results: list[tuple[str, bool]] | None = None
     components_without_info: list[tuple[str, list[tuple[str, str]]]] | None = None
     validation_messages: list[ValidationMessage] | None = None
+    conformance_messages: list[ValidationMessage] | None = None
     parsing_errors: list[str] | None = None
 
 
@@ -197,6 +198,10 @@ def report_text(
         )
         report.append(get_validation_messages_text(rc.validation_messages, verbose))
 
+    if rc.conformance_messages:
+        report.append("The following conformance issues were found:\n")
+        report.append(get_validation_messages_text(rc.conformance_messages, verbose))
+
     return "\n".join(report)
 
 
@@ -301,6 +306,19 @@ def report_html(
         )
         report.append(
             get_validation_messages_html(rc.validation_messages, verbose=verbose)
+        )
+        report.append("</div>")
+
+    # Conformance messages
+    if rc.conformance_messages:
+        report.append("<div class='conformance-msg'>")
+        report.append(
+            "<p class='conformance-msg-label'>"
+            "The following conformance issues were found:"
+            "</p>"
+        )
+        report.append(
+            get_validation_messages_html(rc.conformance_messages, verbose=verbose)
         )
         report.append("</div>")
 

--- a/ntia_conformance_checker/report.py
+++ b/ntia_conformance_checker/report.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from spdx_tools.spdx.validation.validation_message import ValidationMessage
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class ReportContext:
     """Context for generating conformance reports."""

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -25,14 +25,9 @@ def validate_spdx3_data(
     Validate an SHACLObjectSet if it contains a valid SpdxDocument.
 
     The SPDX 3.0 specification states that "Any instance of serialization of
-    SPDX data MUST NOT contain more than one SpdxDocument element definition."
+    SPDX data shall not contain more than one SpdxDocument element definition."
 
-    See: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/SpdxDocument/
-
-    For the purpose of BOM/SBOM application, it also requires that the
-    SpdxDocument should have a Bom or Software/Sbom as its rootElement.
-
-    See: https://github.com/spdx/ntia-conformance-checker/issues/268
+    See: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/SpdxDocument/
 
     Args:
         object_set (spdx3.SHACLObjectSet): The SHACLObjectSet containing
@@ -54,6 +49,9 @@ def validate_spdx3_data(
         for obj in object_set.foreach_type("SpdxDocument")
     ]
 
+    # == SPDX 3 JSON serialization constraint =====
+
+    # Collections of SPDX 3 Elements shall be inside SpdxDocument
     if not spdx_documents:
         error_msg = (
             "No SpdxDocument object found in the SPDX 3 JSON file. "
@@ -65,42 +63,56 @@ def validate_spdx3_data(
     if len(spdx_documents) != 1:
         error_msg = (
             "Multiple SpdxDocument objects found in the SPDX 3 JSON file. "
-            "Allows exactly one. "
-            "Ref: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/SpdxDocument/"
+            "Allows no more than one. "
+            "Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/SpdxDocument/"
         )
         validation_messages.append(ValidationMessage(error_msg, ValidationContext()))
         return (doc, validation_messages)
 
+    # == ElementCollection constraint =====
+    # SpdxDocument is an ElementCollection.
+
     doc = spdx_documents[0]
     doc_id = getattr(doc, "spdxId", None)
-    root_element = getattr(doc, "rootElement", None)
+    elements: list[Any] = getattr(doc, "element", []) or []
+    root_elements: list[Any] = getattr(doc, "rootElement", []) or []
 
-    # ElementCollection (superclass of SpdxDocument) constraints:
-    # - If the ElementCollection has at least 1 element,
-    #   it shall also have at least 1 rootElement.
-    # - The element shall not be of type SpdxDocument.
-    # - The rootElement shall not be of type SpdxDocument.
+    # ElementCollection constraint: if there is at least one element,
+    # there shall also be at least one rootElement.
     # Ref: https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ElementCollection/
-    if not root_element:
-        error_msg = "No rootElement found in the SpdxDocument. Expected exactly one."
-        context = ValidationContext(parent_id=doc_id)
-        validation_messages.append(ValidationMessage(error_msg, context))
-    elif len(root_element) != 1:
-        error_msg = "Multiple root elements found in SpdxDocument. Allows exactly one."
-        context = ValidationContext(parent_id=doc_id)
-        validation_messages.append(ValidationMessage(error_msg, context))
-    else:
-        root_element = root_element[0]
-        # This is not SPDX 3 spec.
-        # But NTIA Minimum Elements requires an SBOM type and
-        # SBOM type is only available in software_Sbom.
-        if not isinstance(root_element, (spdx3.Bom, spdx3.software_Sbom)):
+    if elements and not root_elements:
+        error_msg = (
+            "The SpdxDocument has elements but no rootElement. "
+            "An SpdxDocument with at least one element shall also have "
+            "at least one rootElement. "
+            "Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/"
+        )
+        validation_messages.append(
+            ValidationMessage(error_msg, ValidationContext(parent_id=doc_id))
+        )
+
+    # ElementCollection constraint: element items shall not be of type SpdxDocument.
+    # Ref: https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ElementCollection/
+    for elem in elements:
+        if isinstance(elem, spdx3.SpdxDocument):
+            elem_id = getattr(elem, "spdxId", None)
             error_msg = (
-                "The root element must be of type Bom or software_Sbom. "
-                f"Found: {type(root_element)!r}"
+                "An SpdxDocument element shall not be of type SpdxDocument. "
+                "Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/"
             )
-            root_element_id = getattr(root_element, "spdxId", None)
-            context = ValidationContext(parent_id=doc_id, spdx_id=root_element_id)
+            context = ValidationContext(parent_id=doc_id, spdx_id=elem_id)
+            validation_messages.append(ValidationMessage(error_msg, context))
+
+    # ElementCollection constraint: rootElement items shall not be of type SpdxDocument.
+    # Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/
+    for root_elem in root_elements:
+        if isinstance(root_elem, spdx3.SpdxDocument):
+            root_elem_id = getattr(root_elem, "spdxId", None)
+            error_msg = (
+                "An SpdxDocument rootElement shall not be of type SpdxDocument. "
+                "Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/"
+            )
+            context = ValidationContext(parent_id=doc_id, spdx_id=root_elem_id)
             validation_messages.append(ValidationMessage(error_msg, context))
 
     return (doc, validation_messages)

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -63,7 +63,11 @@ def validate_spdx3_data(
         return (doc, validation_messages)
 
     if len(spdx_documents) != 1:
-        error_msg = "Multiple SpdxDocument objects found. Allows exactly one."
+        error_msg = (
+            "Multiple SpdxDocument objects found in the SPDX 3 JSON file. "
+            "Allows exactly one. "
+            "Ref: https://spdx.github.io/spdx-spec/v3.0/model/Core/Classes/SpdxDocument/"
+        )
         validation_messages.append(ValidationMessage(error_msg, ValidationContext()))
         return (doc, validation_messages)
 
@@ -71,6 +75,12 @@ def validate_spdx3_data(
     doc_id = getattr(doc, "spdxId", None)
     root_element = getattr(doc, "rootElement", None)
 
+    # ElementCollection (superclass of SpdxDocument) constraints:
+    # - If the ElementCollection has at least 1 element,
+    #   it shall also have at least 1 rootElement.
+    # - The element shall not be of type SpdxDocument.
+    # - The rootElement shall not be of type SpdxDocument.
+    # Ref: https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ElementCollection/
     if not root_element:
         error_msg = "No rootElement found in the SpdxDocument. Expected exactly one."
         context = ValidationContext(parent_id=doc_id)
@@ -81,6 +91,9 @@ def validate_spdx3_data(
         validation_messages.append(ValidationMessage(error_msg, context))
     else:
         root_element = root_element[0]
+        # This is not SPDX 3 spec.
+        # But NTIA Minimum Elements requires an SBOM type and
+        # SBOM type is only available in software_Sbom.
         if not isinstance(root_element, (spdx3.Bom, spdx3.software_Sbom)):
             error_msg = (
                 "The root element must be of type Bom or software_Sbom. "

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -79,7 +79,7 @@ def validate_spdx3_data(
 
     # ElementCollection constraint: if there is at least one element,
     # there shall also be at least one rootElement.
-    # Ref: https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ElementCollection/
+    # Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/
     if elements and not root_elements:
         error_msg = (
             "The SpdxDocument has elements but no rootElement. "
@@ -92,7 +92,7 @@ def validate_spdx3_data(
         )
 
     # ElementCollection constraint: element items shall not be of type SpdxDocument.
-    # Ref: https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ElementCollection/
+    # Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/
     for elem in elements:
         if isinstance(elem, spdx3.SpdxDocument):
             elem_id = getattr(elem, "spdxId", None)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -44,6 +44,7 @@ def test_sbomchecker_ntia_no_errors(test_file: str) -> None:
     assert sbom.doc_version
     assert sbom.doc_author
     assert sbom.doc_timestamp
+    assert not sbom.sbom_gen_context  # SPDX 2 does not have SBOM type
     assert sbom.dependency_relationships
     assert not sbom.components_without_names
     assert not sbom.components_without_versions
@@ -59,15 +60,13 @@ def test_sbomchecker_fsct3_no_errors(test_file: str) -> None:
     assert sbom.doc_version
     assert sbom.doc_author
     assert sbom.doc_timestamp
+    assert not sbom.sbom_gen_context  # SPDX 2 does not have SBOM type
     assert sbom.dependency_relationships
     assert not sbom.components_without_names
     assert not sbom.components_without_versions
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert not sbom.components_without_concluded_licenses
-    assert not sbom.compliant
-    # sbom.compliant will always be False because SPDX 2 do not have SBOM type,
-    # which is one of FSCTv3 baseline attributes.
 
 
 @pytest.mark.parametrize("test_file", test_files)
@@ -92,15 +91,13 @@ def test_fsct3checker_no_errors(test_file: str) -> None:
     assert sbom.doc_version
     assert sbom.doc_author
     assert sbom.doc_timestamp
+    assert not sbom.sbom_gen_context  # SPDX 2 does not have SBOM type
     assert sbom.dependency_relationships
     assert not sbom.components_without_names
     assert not sbom.components_without_versions
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert not sbom.components_without_concluded_licenses
-    assert not sbom.compliant
-    # sbom.compliant will always be False because SPDX 2 do not have SBOM type,
-    # which is one of FSCTv3 baseline attributes.
 
 
 ### Test missing author name
@@ -312,6 +309,7 @@ def test_sbomchecker_spdx3_general() -> None:
     assert sbom.doc is not None
     assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
     assert sbom.sbom_name == "hello"
+    assert not sbom.sbom_gen_context  # No SBOM -> No SBOM generation context
     spdx3_spdx_document, validation_messages = validate_spdx3_data(sbom.doc)
     # The file is spec-valid SPDX 3; no SPDX 3 spec errors expected.
     assert len(validation_messages) == 0
@@ -348,6 +346,7 @@ def test_sbomchecker_spdx3_no_elements_missing() -> None:
     assert sbom.doc_version
     assert sbom.doc_author
     assert sbom.doc_timestamp
+    assert sbom.sbom_gen_context
     assert sbom.compliant
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -309,9 +309,12 @@ def test_sbomchecker_spdx3_general() -> None:
     assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
     assert sbom.sbom_name == "hello"
     spdx3_spdx_document, validation_messages = validate_spdx3_data(sbom.doc)
-    assert (
-        len(validation_messages) >= 1
-    )  # There should be a message about missing /Core/Bom.
+    # The file is spec-valid SPDX 3; no SPDX 3 spec errors expected.
+    assert len(validation_messages) == 0
+    # The conformance check (rootElement must be /Software/Sbom) fires here
+    # and is reported via sbom.conformance_messages,
+    # not sbom.validation_messages.
+    assert len(sbom.conformance_messages) >= 1
     assert isinstance(spdx3_spdx_document, spdx3.SpdxDocument)
     assert getattr(spdx3_spdx_document, "name") == sbom.sbom_name
     assert (
@@ -418,8 +421,10 @@ def test_sbomchecker_output_json_validation_messages() -> None:
     test_file = Path(__file__).parent / "data" / "spdx3" / "has_no_sbom.json"
     sbom = sbom_checker.SbomChecker(str(test_file), sbom_spec="spdx3")
     got = sbom.output_json()
-    assert got["validationMessages"]
-    assert "root element" in got["validationMessages"][0]["message"]
+    assert got["conformanceMessages"]
+    print(got["conformanceMessages"][0]["message"])
+    assert "rootElement" in got["conformanceMessages"][0]["message"]
+    assert "SBOM type" in got["conformanceMessages"][0]["message"]
 
 
 def test_sbomchecker_output_html() -> None:

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -65,7 +65,9 @@ def test_sbomchecker_fsct3_no_errors(test_file: str) -> None:
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert not sbom.components_without_concluded_licenses
-    assert sbom.compliant
+    assert not sbom.compliant
+    # sbom.compliant will always be False because SPDX 2 do not have SBOM type,
+    # which is one of FSCTv3 baseline attributes.
 
 
 @pytest.mark.parametrize("test_file", test_files)
@@ -96,7 +98,9 @@ def test_fsct3checker_no_errors(test_file: str) -> None:
     assert not sbom.components_without_suppliers
     assert not sbom.components_without_identifiers
     assert not sbom.components_without_concluded_licenses
-    assert sbom.compliant
+    assert not sbom.compliant
+    # sbom.compliant will always be False because SPDX 2 do not have SBOM type,
+    # which is one of FSCTv3 baseline attributes.
 
 
 ### Test missing author name
@@ -507,6 +511,8 @@ def test_sbomchecker_fsct3_output_html() -> None:
         "<td class='conformance-res-tab-v'>True</td></tr>\n"
         "<tr><td class='conformance-res-tab-r'>SBOM creation timestamp provided?</td>"
         "<td class='conformance-res-tab-v'>True</td></tr>\n"
+        "<tr><td class='conformance-res-tab-r'>SBOM type provided?</td>"
+        "<td class='conformance-res-tab-v'>False</td></tr>\n"
         "<tr><td class='conformance-res-tab-r'>Dependency relationships provided?</td>"
         "<td class='conformance-res-tab-v'>True</td></tr>\n"
         "</tbody>\n"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -511,7 +511,7 @@ def test_sbomchecker_fsct3_output_html() -> None:
         "<td class='conformance-res-tab-v'>True</td></tr>\n"
         "<tr><td class='conformance-res-tab-r'>SBOM creation timestamp provided?</td>"
         "<td class='conformance-res-tab-v'>True</td></tr>\n"
-        "<tr><td class='conformance-res-tab-r'>SBOM type provided?</td>"
+        "<tr><td class='conformance-res-tab-r'>SBOM generation context (SBOM type) provided?</td>"
         "<td class='conformance-res-tab-v'>False</td></tr>\n"
         "<tr><td class='conformance-res-tab-r'>Dependency relationships provided?</td>"
         "<td class='conformance-res-tab-v'>True</td></tr>\n"


### PR DESCRIPTION
Aligned `SpdxDocument`'s `rootElement` validation with SPDX 3:

- Enforced inherited ElementCollection constraints on rootElement
- Removed SBOM type checks on rootElement (it's part of FSCTv3, not SPDX)

## Background

[`SpdxDocument`](https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/SpdxDocument/) is a subclass of [`ElementCollection`](https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ElementCollection/), so constraints over `ElementCollection` should also applied for `SpdxDocument` when checking for validity.

`ElementCollection` constraints:

> - If the ElementCollection has at least 1 element, it shall also have at least 1 rootElement.
> - The element shall not be of type SpdxDocument.
> - The rootElement shall not be of type SpdxDocument.

**Currently, these constraints are not yet part of SHACL, so `spdx-python-model` won't catch it.**

#385 also reports that the validity check for `SpdxDocument` is currently goes **beyond what SPDX 3 spec actually written**.
- It checks for `SpdxDocument`'s `rootElement` type, because it it where SBOM type metadata is recorded.
- But SBOM type requirement is only for CISA baseline attributes, not SPDX 3 requirement.

## What this PR does?

- Update `SpdxDocument` check in `validate_spdx3_data()` to cover all `ElementCollection` contraints
- Moves the SBOM type check logic from SPDX 3 validation to FSCTv3 conformance check instead.
  - Add new `conformance_messages` that separated from `validation_messages`
  - `conformance_message` will not failed the `conformance_check()`; it will only record what expected (warning)
  - Move the SBOM type check to `FSCT3Checker`; missing SBOM type will only failed `FSCT3Checker` but not `NTIAChecker`
  - Note that we call the SBOM type here an "SBOM generation context", to follow the term in 2025 CISA SBOM Minimum Elements and 2026 G7 SBOM for AI documents. Both "SBOM type" and "SBOM generation context" are about the software lifecycle phase that the SBOM got generated.
- Update relevant tests

To fix #385