### PR TITLE
handle list cardinality in spdx3 relationship targets

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -481,16 +481,25 @@ class BaseChecker(ABC):
         if self.sbom_spec == "spdx3":
             self.doc = cast("spdx3.SHACLObjectSet", self.doc)
 
-            has_concluded_license_ids: set[str] = {
-                from_id
-                for from_id, to_id in iter_relationships_by_type(
-                    self.doc, "hasConcludedLicense"
-                )
-                if to_id.strip()
-                != spdx3.expandedlicensing_IndividualLicensingInfo.NAMED_INDIVIDUALS[
+            has_concluded_license_ids: set[str] = set()
+            no_assertion_uri = (
+                spdx3.expandedlicensing_IndividualLicensingInfo.NAMED_INDIVIDUALS[
                     "NoAssertionLicense"
                 ]
-            }
+            )
+
+            for from_id, to_ids in iter_relationships_by_type(
+                self.doc, "hasConcludedLicense"
+            ):
+
+                # Filter out any "NoAssertionLicense" from the list
+                valid_licenses = [
+                    t_id for t_id in to_ids if t_id.strip() != no_assertion_uri
+                ]
+
+                # If there is at least one valid license left, this package is safe!
+                if valid_licenses:
+                    has_concluded_license_ids.add(from_id)
 
             return [
                 (name or "", spdx_id or "")

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -201,7 +201,9 @@ def iter_relationships_by_type(
         if not _rel_type or _rel_type.split("/")[-1] != rel_type:
             continue
         from_: spdx3.Element | None = getattr(obj, "from_", None)
-        to_elements: spdx3.Element | list[spdx3.Element] | None = getattr(obj, "to", None)
+        to_elements: spdx3.Element | list[spdx3.Element] | None = getattr(
+            obj, "to", None
+        )
         if not from_ or not to_elements:
             continue
 
@@ -212,7 +214,9 @@ def iter_relationships_by_type(
 
         for to_item in to_elements:
             # Safely extract to_id whether it's a string URI or an Element object
-            to_id = to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
+            to_id = (
+                to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
+            )
             yield from_id, to_id
 
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -190,9 +190,9 @@ def iter_objects_with_property(
 def iter_relationships_by_type(
     object_set: spdx3.SHACLObjectSet,
     rel_type: str,
-) -> Iterator[tuple[str, str]]:
+) -> Iterator[tuple[str, list[str]]]:
     """
-    Yield (from_id, to_id) for each relationship of the specified relationship type.
+    Yield (from_id, to_ids_list) for each relationship of the specified relationship type.
     """
 
     for obj in object_set.foreach_type("Relationship"):
@@ -201,23 +201,30 @@ def iter_relationships_by_type(
         if not _rel_type or _rel_type.split("/")[-1] != rel_type:
             continue
         from_: spdx3.Element | None = getattr(obj, "from_", None)
-        to_elements: spdx3.Element | list[spdx3.Element] | None = getattr(
-            obj, "to", None
-        )
+        to_elements = getattr(obj, "to", None)
         if not from_ or not to_elements:
             continue
 
         from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", "")
-        # Normalize to_elements into a list so we can handle 1 or many uniformly
-        if not isinstance(to_elements, list):
+        # Normalize to_elements into a standard Python list
+        if isinstance(to_elements, str) or not hasattr(to_elements, "__iter__"):
+            # It's a single string or a single Element object
             to_elements = [to_elements]
+        else:
+            # It's a ListProxy or an actual list. Force it to be a standard Python list.
+            to_elements = list(to_elements)
 
+        to_ids = []
         for to_item in to_elements:
             # Safely extract to_id whether it's a string URI or an Element object
             to_id = (
                 to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
             )
-            yield from_id, to_id
+            if to_id:
+                to_ids.append(to_id)
+
+        if from_id and to_ids:
+            yield from_id, to_ids
 
 
 def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Package]:

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -201,14 +201,19 @@ def iter_relationships_by_type(
         if not _rel_type or _rel_type.split("/")[-1] != rel_type:
             continue
         from_: spdx3.Element | None = getattr(obj, "from_", None)
-        to: spdx3.Element | None = getattr(obj, "to", None)
-        if not from_ or not to:
+        to_elements: spdx3.Element | list[spdx3.Element] | None = getattr(obj, "to", None)
+        if not from_ or not to_elements:
             continue
 
-        from_id = getattr(from_, "spdxId", "")
-        to_id = getattr(to, "spdxId", "")
+        from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", "")
+        # Normalize to_elements into a list so we can handle 1 or many uniformly
+        if not isinstance(to_elements, list):
+            to_elements = [to_elements]
 
-        yield from_id, to_id
+        for to_item in to_elements:
+            # Safely extract to_id whether it's a string URI or an Element object
+            to_id = to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
+            yield from_id, to_id
 
 
 def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Package]:


### PR DESCRIPTION
Resolves #397.

This PR updates `iter_relationships_by_type` to  handle 1..* list targets in SPDX 3 relationships, while maintaining backwards compatibility for existing base_checker parsing logic.