### PR TITLE
[codex] Recognize SPDX 3 package dependency relationships

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -34,6 +34,7 @@ from .report import (
 from .spdx3_utils import (
     get_boms_from_spdx_document,
     get_packages_from_bom,
+    has_package_dependency_relationship,
     iter_objects_with_property,
     iter_relationships_by_type,
     validate_spdx3_data,
@@ -108,7 +109,7 @@ class BaseChecker(ABC):
     doc_version: bool = False  # Has SPDX document version?
     doc_author: bool = False  # Has SPDX document author?
     doc_timestamp: bool = False  # Has SPDX document creation timestamp?
-    dependency_relationships: bool = False  # Has DESCRIBES relationship?
+    dependency_relationships: bool = False  # Has dependency relationship?
     # See https://github.com/spdx/ntia-conformance-checker/issues/392
     # for discussion on dependency relationships and DESCRIBES.
 
@@ -270,11 +271,11 @@ class BaseChecker(ABC):
         return False
 
     def check_dependency_relationships(self) -> bool:
-        """Check if the SBOM document describes at least one package.
+        """Check if the SBOM document declares dependency information.
 
         For SPDX 2 this checks for a DESCRIBES relationship; for SPDX 3 it
-        checks that a /Software/Sbom element lists at least one package in its
-        ``rootElement``.
+        checks package-level dependency relationships and falls back to whether
+        a /Software/Sbom element lists at least one package in its ``rootElement``.
         """
         if not self.doc:
             return False
@@ -304,6 +305,10 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
+            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
+            if has_package_dependency_relationship(self.doc):
+                return True
+
             # We will assume here that the SpdxDocument's rootElement is
             # either /Core/Bom or /Software/Sbom.
             #

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -309,21 +309,6 @@ class BaseChecker(ABC):
             if has_package_dependency_relationship(self.doc):
                 return True
 
-            # We will assume here that the SpdxDocument's rootElement is
-            # either /Core/Bom or /Software/Sbom.
-            #
-            # If the rootElement is a /Software/Package
-            # (or its subclass),
-            # it is considered to have a DESCRIBES relationship.
-            #
-            # Note that if there is neither /Software/Package(s) nor /Core/Bom,
-            # a DESCRIBES relationship is not needed;
-            # however, this method may still return False,
-            # since it is factually considered as "no relationship".
-            #
-            # See https://github.com/spdx/ntia-conformance-checker/issues/392
-            # for discussion on dependency relationships and DESCRIBES.
-
             # There is a BOM/SBOM and an /Software/Package,
             # check if there is at least one package listed in any BOM/SBOM
             boms = get_boms_from_spdx_document(self.__spdx3_doc)

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -32,8 +32,6 @@ from .report import (
     report_text,
 )
 from .spdx3_utils import (
-    get_boms_from_spdx_document,
-    get_packages_from_bom,
     has_package_dependency_relationship,
     iter_objects_with_property,
     iter_relationships_by_type,
@@ -274,8 +272,7 @@ class BaseChecker(ABC):
         """Check if the SBOM document declares dependency information.
 
         For SPDX 2 this checks for a DESCRIBES relationship; for SPDX 3 it
-        checks package-level dependency relationships and falls back to whether
-        a /Software/Sbom element lists at least one package in its ``rootElement``.
+        checks package-level dependency relationships.
         """
         if not self.doc:
             return False
@@ -306,17 +303,7 @@ class BaseChecker(ABC):
         # SPDX 3
         if self.sbom_spec == "spdx3":
             self.doc = cast("spdx3.SHACLObjectSet", self.doc)
-            if has_package_dependency_relationship(self.doc):
-                return True
-
-            # There is a BOM/SBOM and an /Software/Package,
-            # check if there is at least one package listed in any BOM/SBOM
-            boms = get_boms_from_spdx_document(self.__spdx3_doc)
-            if boms:
-                for bom in boms:
-                    packages = get_packages_from_bom(bom)
-                    if packages:
-                        return True
+            return has_package_dependency_relationship(self.doc)
 
         return False
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
+SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES = ("dependsOn", "contains")
+
+
 def validate_spdx3_data(
     object_set: spdx3.SHACLObjectSet,
 ) -> tuple[spdx3.SpdxDocument | None, list[ValidationMessage]]:
@@ -234,3 +237,30 @@ def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Pac
         for obj in object_set.foreach_type("software_Package")
     }
     return packages
+
+
+def get_all_package_ids(object_set: spdx3.SHACLObjectSet) -> set[str]:
+    """Retrieve SPDX IDs for all /Software/Package objects from an SHACLObjectSet."""
+    return {
+        spdx_id
+        for _name, spdx_id, _ in iter_objects_with_property(
+            object_set,
+            spdx3.software_Package,
+            "spdxId",
+        )
+        if spdx_id
+    }
+
+
+def has_package_dependency_relationship(object_set: spdx3.SHACLObjectSet) -> bool:
+    """Return True if a dependency relationship connects two SPDX 3 packages."""
+    package_ids = get_all_package_ids(object_set)
+    if len(package_ids) < 2:
+        return False
+
+    for rel_type in SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES:
+        for from_id, to_ids in iter_relationships_by_type(object_set, rel_type):
+            if from_id in package_ids and any(to_id in package_ids for to_id in to_ids):
+                return True
+
+    return False

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -277,9 +277,7 @@ def has_package_dependency_relationship(object_set: spdx3.SHACLObjectSet) -> boo
 
     for rel_type in SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES:
         for from_id, to_ids in iter_relationships_by_type(object_set, rel_type):
-            if from_id in element_ids and any(
-                to_id in element_ids for to_id in to_ids
-            ):
+            if from_id in element_ids and any(to_id in element_ids for to_id in to_ids):
                 return True
 
     return False

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 
 SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES = (
+    "contains",
     "dependsOn",
     "hasDynamicLink",
     "hasStaticLink",

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES = ("dependsOn", "contains")
+SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES = (
+    "dependsOn",
+    "hasDynamicLink",
+    "hasStaticLink",
+)
 
 
 def validate_spdx3_data(
@@ -240,7 +244,7 @@ def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Pac
 
 
 def get_all_package_ids(object_set: spdx3.SHACLObjectSet) -> set[str]:
-    """Retrieve SPDX IDs for all /Software/Package objects from an SHACLObjectSet."""
+    """Retrieve spdxId for all /Software/Package objects from an SHACLObjectSet."""
     return {
         spdx_id
         for _name, spdx_id, _ in iter_objects_with_property(
@@ -252,15 +256,30 @@ def get_all_package_ids(object_set: spdx3.SHACLObjectSet) -> set[str]:
     }
 
 
+def get_all_element_ids(object_set: spdx3.SHACLObjectSet) -> set[str]:
+    """Retrieve spdxId for all SPDX 3 Element objects from an SHACLObjectSet."""
+    return {
+        spdx_id
+        for _name, spdx_id, _ in iter_objects_with_property(
+            object_set,
+            spdx3.Element,
+            "spdxId",
+        )
+        if spdx_id
+    }
+
+
 def has_package_dependency_relationship(object_set: spdx3.SHACLObjectSet) -> bool:
-    """Return True if a dependency relationship connects two SPDX 3 packages."""
-    package_ids = get_all_package_ids(object_set)
-    if len(package_ids) < 2:
+    """Return True if a dependency relationship connects SPDX 3 Elements."""
+    element_ids = get_all_element_ids(object_set)
+    if len(element_ids) < 2:
         return False
 
     for rel_type in SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES:
         for from_id, to_ids in iter_relationships_by_type(object_set, rel_type):
-            if from_id in package_ids and any(to_id in package_ids for to_id in to_ids):
+            if from_id in element_ids and any(
+                to_id in element_ids for to_id in to_ids
+            ):
                 return True
 
     return False

--- a/tests/data/spdx3/README.md
+++ b/tests/data/spdx3/README.md
@@ -5,6 +5,7 @@
 | [has_no_sbom.json](./has_no_sbom.json) | Has neither `/Core/Bom` nor `/Software/Sbom`. | [software/example1](https://github.com/spdx/spdx-examples/tree/master/software/example1) in spdx-examples. |
 | [has_sbom.json](./has_sbom.json) | Has `/Software/Sbom` | [software/example13](https://github.com/spdx/spdx-examples/tree/master/software/example13) in spdx-examples.|
 | [no_elements_missing.json](./no_elements_missing.json) | No elements are missing. Note that the SBOM has no `/Software/Package`, but as the SBOM has its subclass `/Dataset/DatasetPackage` it should be treated as a regular SBOM. | [dataset/example01](https://github.com/spdx/spdx-examples/tree/master/dataset/example01) in spdx-examples. |
+| [package_dependency_relationship.json](./package_dependency_relationship.json) | Has a `/Software/Package` `dependsOn` `/Software/Package` relationship without relying on `/Software/Sbom.rootElement` package listing. | Small purpose-built fixture. |
 | [missing_supplier_name.json](./missing_supplier_name.json) | Missing `suppliedBy` property in the `/Dataset/DatasetPackage`. | no_elements_missing.json with `suppliedBy` removed. |
 | [missing_version.json](./missing_version.json) | Missing `packageVersion` in the `/Dataset/DatasetPackage`. | no_elements_missing.json with `packageVersion` removed. |
 | [missing_unique_identifiers.json](./missing_unique_identifiers.json) | Missing `spdxId` property in the "data.csv" `/Software/File`. | no_elements_missing.json with `spdxId` removed. |

--- a/tests/data/spdx3/package_dependency_relationship.json
+++ b/tests/data/spdx3/package_dependency_relationship.json
@@ -1,0 +1,79 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": [
+        "https://spdx.org/spdxdocs/Person-test-author"
+      ],
+      "created": "2024-06-01T00:00:00Z"
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://spdx.org/spdxdocs/Person-test-author",
+      "creationInfo": "_:creationinfo",
+      "name": "Test Author"
+    },
+    {
+      "type": "Organization",
+      "spdxId": "https://spdx.org/spdxdocs/Organization-test-supplier",
+      "creationInfo": "_:creationinfo",
+      "name": "Test Supplier"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://spdx.org/spdxdocs/Document-package-dependency",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "software"
+      ],
+      "rootElement": [
+        "https://spdx.org/spdxdocs/SBOM-package-dependency"
+      ],
+      "name": "Package dependency relationship fixture"
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "https://spdx.org/spdxdocs/SBOM-package-dependency",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "software"
+      ],
+      "software_sbomType": [
+        "analyzed"
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://spdx.org/spdxdocs/Package-application",
+      "creationInfo": "_:creationinfo",
+      "name": "application",
+      "software_packageVersion": "1.0.0",
+      "suppliedBy": "https://spdx.org/spdxdocs/Organization-test-supplier",
+      "software_primaryPurpose": "application"
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://spdx.org/spdxdocs/Package-library",
+      "creationInfo": "_:creationinfo",
+      "name": "library",
+      "software_packageVersion": "2.0.0",
+      "suppliedBy": "https://spdx.org/spdxdocs/Organization-test-supplier",
+      "software_primaryPurpose": "library"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://spdx.org/spdxdocs/Relationship-package-dependency",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "dependsOn",
+      "from": "https://spdx.org/spdxdocs/Package-application",
+      "to": [
+        "https://spdx.org/spdxdocs/Package-library"
+      ]
+    }
+  ]
+}

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -361,6 +361,21 @@ def test_sbomchecker_fsct3_spdx3_no_elements_missing() -> None:
     assert len(sbom.validation_messages) == 0
 
 
+def test_sbomchecker_spdx3_package_dependency_relationship() -> None:
+    test_file = (
+        Path(__file__).parent
+        / "data"
+        / "spdx3"
+        / "package_dependency_relationship.json"
+    )
+    sbom = sbom_checker.SbomChecker(str(test_file), sbom_spec="spdx3")
+    assert sbom.doc is not None
+    assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
+    assert len(sbom.validation_messages) == 0
+    assert sbom.dependency_relationships
+    assert sbom.compliant
+
+
 def test_sbomchecker_spdx3_missing_supplier_name() -> None:
     test_file = Path(__file__).parent / "data" / "spdx3" / "missing_supplier_name.json"
     sbom = sbom_checker.SbomChecker(str(test_file), sbom_spec="spdx3")

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -347,7 +347,8 @@ def test_sbomchecker_spdx3_no_elements_missing() -> None:
     assert sbom.doc_author
     assert sbom.doc_timestamp
     assert sbom.sbom_gen_context
-    assert sbom.compliant
+    assert not sbom.dependency_relationships
+    assert not sbom.compliant
 
 
 def test_sbomchecker_fsct3_spdx3_no_elements_missing() -> None:
@@ -357,7 +358,8 @@ def test_sbomchecker_fsct3_spdx3_no_elements_missing() -> None:
     )
     assert sbom.doc is not None
     assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
-    assert sbom.compliant
+    assert not sbom.dependency_relationships
+    assert not sbom.compliant
     assert len(sbom.validation_messages) == 0
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -405,7 +405,7 @@ def test_sbomchecker_spdx3_package_dependency_relationship() -> None:
         ("dependsOn", True),
         ("hasDynamicLink", True),
         ("hasStaticLink", True),
-        ("contains", False),
+        ("contains", True),
     ],
 )
 def test_spdx3_dependency_relationship_types(

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -366,8 +366,8 @@ def test_sbomchecker_spdx3_no_elements_missing() -> None:
     assert sbom.doc_author
     assert sbom.doc_timestamp
     assert sbom.sbom_gen_context
-    assert not sbom.dependency_relationships
-    assert not sbom.compliant
+    assert sbom.dependency_relationships
+    assert sbom.compliant
 
 
 def test_sbomchecker_fsct3_spdx3_no_elements_missing() -> None:
@@ -377,8 +377,8 @@ def test_sbomchecker_fsct3_spdx3_no_elements_missing() -> None:
     )
     assert sbom.doc is not None
     assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
-    assert not sbom.dependency_relationships
-    assert not sbom.compliant
+    assert sbom.dependency_relationships
+    assert sbom.compliant
     assert len(sbom.validation_messages) == 0
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -34,7 +34,7 @@ def _component_names(tuples_list: list[tuple[str, str]]) -> list[str]:
 
 
 SPDX3_RELATIONSHIP_TYPE_BASE = (
-    "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType"
+    "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType",
 )
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -16,7 +16,10 @@ from spdx_python_model import v3_0_1 as spdx3  # type: ignore # import-untyped
 
 import ntia_conformance_checker.sbom_checker as sbom_checker
 from ntia_conformance_checker import FSCT3Checker, NTIAChecker
-from ntia_conformance_checker.spdx3_utils import validate_spdx3_data
+from ntia_conformance_checker.spdx3_utils import (
+    has_package_dependency_relationship,
+    validate_spdx3_data,
+)
 
 
 def _component_names(tuples_list: list[tuple[str, str]]) -> list[str]:
@@ -28,6 +31,24 @@ def _component_names(tuples_list: list[tuple[str, str]]) -> list[str]:
         t[0] if t and t[0] not in (None, "") else (t[1] if t else "")
         for t in tuples_list
     ]
+
+
+SPDX3_RELATIONSHIP_TYPE_BASE = (
+    "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType"
+)
+
+
+def _spdx3_package_dependency_object_set() -> spdx3.SHACLObjectSet:
+    test_file = (
+        Path(__file__).parent
+        / "data"
+        / "spdx3"
+        / "package_dependency_relationship.json"
+    )
+    sbom = sbom_checker.SbomChecker(str(test_file), sbom_spec="spdx3")
+    assert sbom.doc is not None
+    assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
+    return sbom.doc
 
 
 ### Test no element missing
@@ -376,6 +397,40 @@ def test_sbomchecker_spdx3_package_dependency_relationship() -> None:
     assert len(sbom.validation_messages) == 0
     assert sbom.dependency_relationships
     assert sbom.compliant
+
+
+@pytest.mark.parametrize(
+    ("relationship_type", "expected"),
+    [
+        ("dependsOn", True),
+        ("hasDynamicLink", True),
+        ("hasStaticLink", True),
+        ("contains", False),
+    ],
+)
+def test_spdx3_dependency_relationship_types(
+    relationship_type: str, expected: bool
+) -> None:
+    object_set = _spdx3_package_dependency_object_set()
+    relationship = next(object_set.foreach_type(spdx3.Relationship))
+    relationship.relationshipType = (
+        f"{SPDX3_RELATIONSHIP_TYPE_BASE}/{relationship_type}"
+    )
+    assert has_package_dependency_relationship(object_set) is expected
+
+
+def test_spdx3_dependency_relationship_accepts_element_endpoints() -> None:
+    object_set = _spdx3_package_dependency_object_set()
+    relationship = next(object_set.foreach_type(spdx3.Relationship))
+    sbom = object_set.find_by_id("https://spdx.org/spdxdocs/SBOM-package-dependency")
+    package = object_set.find_by_id("https://spdx.org/spdxdocs/Package-library")
+    assert isinstance(sbom, spdx3.Element)
+    assert isinstance(package, spdx3.Element)
+
+    relationship.from_ = sbom
+    relationship.to = [package]
+
+    assert has_package_dependency_relationship(object_set)
 
 
 def test_sbomchecker_spdx3_missing_supplier_name() -> None:

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -33,9 +33,7 @@ def _component_names(tuples_list: list[tuple[str, str]]) -> list[str]:
     ]
 
 
-SPDX3_RELATIONSHIP_TYPE_BASE = (
-    "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType",
-)
+SPDX3_RELATIONSHIP_TYPE_BASE = "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType"
 
 
 def _spdx3_package_dependency_object_set() -> spdx3.SHACLObjectSet:


### PR DESCRIPTION
## Summary

This updates the SPDX 3 dependency relationship check to recognize package-to-package dependency evidence and removes the previous SPDX 3 `/Software/Sbom.rootElement` fallback.

- add an SPDX 3 helper that detects `dependsOn` and `contains` relationships between `/Software/Package` elements
- use that helper for SPDX 3 dependency relationship detection in `BaseChecker.check_dependency_relationships`
- add a focused SPDX 3 fixture and regression test for issue #392
- update SPDX 3 fixture expectations that previously relied on the `rootElement` fallback

## Why

Issue #392 notes that the checker currently treats SPDX 3 dependency evidence as an SBOM-to-package/rootElement relationship, but the dependency relationship may be declared between two packages instead. Based on PR review feedback, this patch now treats SPDX 3 dependency evidence as package-level dependency relationships rather than falling back to SBOM `rootElement` membership.

Scope note: this intentionally does not change SPDX 2 `DESCRIBES` behavior, decide whether that is a breaking change, or include SARIF/rule-engine work from #393 or G7 scope.

Refs #392.

## Validation

- `.venv/bin/python -m pytest -q tests/test_checker.py::test_sbomchecker_spdx3_package_dependency_relationship`
- `.venv/bin/python -m pytest -q tests/test_checker.py -k spdx3`
- `.venv/bin/python -m pytest -q tests/test_checker.py`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m compileall -q ntia_conformance_checker`
- `git diff --check`
