### PR TITLE
Add -q and -vv to verbosity level options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Added
+
+<!-- TODO: replace with [#NNN] link once this PR is opened -->
+
+- `-v`/`-vv`/`--debug` log verbosity levels and `-q`/`--quiet` to show
+  errors only; `-k` short flag for `--skip-validation`
+
+### Changed
+
+- BREAKING CHANGE: Default log level is now `WARNING` (previously `INFO`);
+  use `-v` to restore the old default verbosity
+- `--output quiet` renamed to `--output none` (`quiet` still accepted;
+  the name is now reserved for log verbosity)
+
 ### Fixed
 
 - BREAKING CHANGE:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
-<!-- TODO: replace with [#NNN] link once this PR is opened -->
-
 - `-v`/`-vv`/`--debug` log verbosity levels and `-q`/`--quiet` to show
-  errors only; `-k` short flag for `--skip-validation`
+  errors only; `-k` short flag for `--skip-validation` ([#406])
 
 ### Changed
 
 - BREAKING CHANGE: Default log level is now `WARNING` (previously `INFO`);
-  use `-v` to restore the old default verbosity
+  use `-v` to restore the old default verbosity ([#406])
 - `--output quiet` renamed to `--output none` (`quiet` still accepted;
-  the name is now reserved for log verbosity)
+  the name is now reserved for log verbosity) ([#406])
 
 ### Fixed
 
@@ -37,6 +35,7 @@ and this project adheres to [Semantic Versioning][semver].
   ([#398])
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
+[#406]: https://github.com/spdx/ntia-conformance-checker/pull/406
 
 ## [5.0.3] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
-- BREAKING CHANGE: Default log level is now `WARNING` (previously `INFO`);
+- Default log level is now `WARNING` (previously `INFO`);
   use `-v` to restore the old default verbosity ([#406])
 - `--output quiet` renamed to `--output none` (`quiet` still accepted;
   the name is now reserved for log verbosity) ([#406])

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ choices:
     ntia        2021 NTIA SBOM Minimum Elements
 
   Report output types (for --output):
-    print       Print report to console
-    json        Report in JSON format
     html        Report in HTML format
+    json        Report in JSON format
     none        No report
+    print       Report in regular text format
 
 Examples:
   sbomcheck sbom.spdx

--- a/README.md
+++ b/README.md
@@ -103,12 +103,14 @@ options:
                         SBOM specification of the input file; see below for details [default: spdx2]
   -c, --comply {fsct3-min,ntia}
                         Compliance standards to check against; see below for details [default: ntia]
-  --skip-validation     Skip validation
-  -r, --output {html,json,print,quiet}
-                        Report output type; see below for details [default: print]
+  -k, --skip-validation
+                        Skip validation
+  -r, --output TYPE     Report output type; see below for details [default: print]
   -o, --output-file PATH
                         Filepath for report output; if omitted, prints to console
-  -v, --verbose         Print more information (debug)
+  -v, --verbose         Increase log verbosity to info
+  -vv, --debug          Increase log verbosity to debug
+  -q, --quiet           Quiet logs: show errors only
   -V, --version         Display version of sbomcheck
 
 choices:
@@ -121,10 +123,10 @@ choices:
     ntia        2021 NTIA SBOM Minimum Elements
 
   Report output types (for --output):
-    html        Report in HTML format
-    json        Report in JSON format
     print       Print report to console
-    quiet       No output unless there are errors
+    json        Report in JSON format
+    html        Report in HTML format
+    none        No report
 
 Examples:
   sbomcheck sbom.spdx

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 # Advertised report output types (shown in --help / README).
 _OUTPUT_CHOICES = {
-    "print": "Print report to console",
+    "print": "Report in regular text format",
     "json": "Report in JSON format",
     "html": "Report in HTML format",
     "none": "No report",

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -41,7 +41,6 @@ _OUTPUT_CHOICES = {
 # Undocumented alias for backward compatibility. Not in _OUTPUT_CHOICES
 # because "quiet" is the log-verbosity flag (-q/--quiet).
 _OUTPUT_ALIASES = {"quiet": "none"}
-_OUTPUT_ALLOWED = set(_OUTPUT_CHOICES) | set(_OUTPUT_ALIASES)
 
 
 def get_parsed_args() -> argparse.Namespace:

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -38,8 +38,8 @@ _OUTPUT_CHOICES = {
     "none": "No report",
 }
 
-# Accepted but undocumented (backward compatibility): "quiet" is the old name
-# for "none" -- "quiet" is now reserved for log verbosity (-q/--quiet).
+# Undocumented alias for backward compatibility. Not in _OUTPUT_CHOICES
+# because "quiet" is the log-verbosity flag (-q/--quiet).
 _OUTPUT_ALIASES = {"quiet": "none"}
 _OUTPUT_ALLOWED = set(_OUTPUT_CHOICES) | set(_OUTPUT_ALIASES)
 
@@ -339,4 +339,4 @@ def print_output(
             else:
                 print(html_output)
 
-    # "none" (and its legacy alias "quiet") emit no report.
+    # "none" (and its alias "quiet") emit no report.

--- a/ntia_conformance_checker/cli_utils.py
+++ b/ntia_conformance_checker/cli_utils.py
@@ -30,12 +30,18 @@ from .constants import (
 if TYPE_CHECKING:
     from .base_checker import BaseChecker
 
+# Advertised report output types (shown in --help / README).
 _OUTPUT_CHOICES = {
     "print": "Print report to console",
     "json": "Report in JSON format",
     "html": "Report in HTML format",
-    "quiet": "No output unless there are errors",
+    "none": "No report",
 }
+
+# Accepted but undocumented (backward compatibility): "quiet" is the old name
+# for "none" -- "quiet" is now reserved for log verbosity (-q/--quiet).
+_OUTPUT_ALIASES = {"quiet": "none"}
+_OUTPUT_ALLOWED = set(_OUTPUT_CHOICES) | set(_OUTPUT_ALIASES)
 
 
 def get_parsed_args() -> argparse.Namespace:
@@ -102,6 +108,7 @@ def get_parsed_args() -> argparse.Namespace:
         help=argparse.SUPPRESS,  # hide from help
     )
     parser.add_argument(
+        "-k",
         "--skip-validation",
         action="store_true",
         default=False,
@@ -110,7 +117,7 @@ def get_parsed_args() -> argparse.Namespace:
     parser.add_argument(
         "-r",
         "--output",
-        choices=sorted(_OUTPUT_CHOICES),
+        metavar="TYPE",
         default="print",
         help="Report output type; see below for details [default: print]",
     )
@@ -128,8 +135,22 @@ def get_parsed_args() -> argparse.Namespace:
     parser.add_argument(
         "-v",
         "--verbose",
+        action="count",
+        default=0,
+        help="Increase log verbosity: -v = info, -vv = debug",
+    )
+    parser.add_argument(
+        "--debug",
         action="store_true",
-        help="Print more information (debug)",
+        default=False,
+        help="Set log verbosity to debug (same as -vv)",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Quiet logs: show errors only",
     )
     parser.add_argument(
         "-V",
@@ -139,6 +160,15 @@ def get_parsed_args() -> argparse.Namespace:
     )
 
     args = parser.parse_args()
+
+    # Normalise the report output type: map undocumented aliases and validate.
+    if args.output in _OUTPUT_ALIASES:
+        args.output = _OUTPUT_ALIASES[args.output]
+    if args.output not in _OUTPUT_CHOICES:
+        parser.error(
+            f"argument -r/--output: invalid choice: {args.output!r} "
+            f"(choose from {', '.join(sorted(_OUTPUT_CHOICES))})"
+        )
 
     if getattr(args, "file_opt", None):
         args.file = args.file_opt
@@ -309,4 +339,4 @@ def print_output(
             else:
                 print(html_output)
 
-    # do nothing if output_type is "quiet" or unrecognized
+    # "none" (and its legacy alias "quiet") emit no report.

--- a/ntia_conformance_checker/main.py
+++ b/ntia_conformance_checker/main.py
@@ -18,8 +18,23 @@ def main() -> None:
 
     args = get_parsed_args()
 
-    log_level = logging.DEBUG if args.verbose else logging.INFO
+    # Log floor on the shared severity scale error > warning > note > none:
+    #   -q/--quiet  -> error   (errors only)
+    #   (default)   -> warning (errors + warnings)
+    #   -v          -> note    (+ info)        [logging.INFO]
+    #   -vv/--debug -> none    (everything)    [logging.DEBUG]
+    if args.quiet:
+        log_level = logging.ERROR
+    elif args.debug or args.verbose >= 2:
+        log_level = logging.DEBUG
+    elif args.verbose >= 1:
+        log_level = logging.INFO
+    else:
+        log_level = logging.WARNING
     logging.basicConfig(level=log_level, format="%(levelname)s: %(message)s")
+
+    # Reports show extra detail (per-component misses) at -v or higher.
+    verbose = log_level <= logging.INFO
 
     logging.debug("Checking SBOM: %s", args.file)
     logging.debug("SBOM specification: %s", args.sbom_spec)
@@ -53,7 +68,7 @@ def main() -> None:
         sbom,
         output_type=args.output,
         output_file=args.output_file,
-        verbose=args.verbose,
+        verbose=verbose,
     )
 
     sys.exit(0 if sbom.compliant else 1)  # 0 indicates success

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026-present SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the CLI option surface (argument parsing + alias handling)."""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest import MonkeyPatch
+
+from ntia_conformance_checker import cli_utils
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def _parse(monkeypatch: MonkeyPatch, argv: list[str]) -> argparse.Namespace:
+    monkeypatch.setattr(sys, "argv", ["sbomcheck", *argv])
+    return cli_utils.get_parsed_args()
+
+
+# ---- report output type --------------------------------------------------
+
+
+def test_output_quiet_aliases_to_none(monkeypatch: MonkeyPatch) -> None:
+    assert _parse(monkeypatch, ["f.json", "--output", "quiet"]).output == "none"
+
+
+def test_output_none_accepted(monkeypatch: MonkeyPatch) -> None:
+    assert _parse(monkeypatch, ["f.json", "-r", "none"]).output == "none"
+
+
+def test_output_invalid_exits(monkeypatch: MonkeyPatch) -> None:
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["f.json", "--output", "bogus"])
+
+
+# ---- log verbosity -------------------------------------------------------
+
+
+def test_verbosity_flags(monkeypatch: MonkeyPatch) -> None:
+    assert _parse(monkeypatch, ["f.json"]).verbose == 0
+    assert _parse(monkeypatch, ["f.json", "-v"]).verbose == 1
+    assert _parse(monkeypatch, ["f.json", "-vv"]).verbose == 2
+    assert _parse(monkeypatch, ["f.json", "--debug"]).debug is True
+    assert _parse(monkeypatch, ["f.json", "-q"]).quiet is True
+
+
+def test_skip_validation_shortcut(monkeypatch: MonkeyPatch) -> None:
+    assert _parse(monkeypatch, ["f.json", "-k"]).skip_validation is True


### PR DESCRIPTION
Revise logging and command-line options to control terminal printout verbosity; map the logging level and verbosity to align with common Unix tools.

Separate more clearly between verbosity/log levels and conformance report format.

- **Terminal verbosity/log levels**

  | Options | Verbosity | Log level | Notes |
  | - | - | - | - |
  | -q, --quiet | Quiet | ERROR | New option |
  | (none) | Default | WARNING | New default |
  | -v, --verbose | Verbose | INFO | |
  | -vv, --debug | Very verbose | DEBUG | New option |

  see changes in ntia_conformance_checker/main.py (L21-33) and ntia_conformance_checker/cli_utils.py (L137)

- **Conformance report format**
  - Rename `--output quiet` to `--output none` (`quiet` kept as an accepted alias); to avoid confusion, since "quiet" now used for verbosity (see above)
  - Drop argparse `choices=` on -r/--output in favor of explicit validation so the alias can be normalised before checking.
- Add `-k` shorthand for `--skip-validation` (all other options already have their shorthand, except this one)