### PR TITLE
Implement version-aware dynamic loading for SPDX 3.x bindings

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -13,7 +13,6 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Union, cast
 
-from spdx_python_model.bindings import v3_0_1 as spdx3
 from spdx_tools.spdx.model.relationship import RelationshipType
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 from spdx_tools.spdx.parser import parse_anything
@@ -24,6 +23,7 @@ from spdx_tools.spdx.validation.validation_message import (
     ValidationMessage,
 )
 
+from .cli_utils import get_spdx_version
 from .constants import DEFAULT_SBOM_SPEC
 from .graph_utils import analyze_graph_connectivity
 from .report import (
@@ -36,14 +36,16 @@ from .spdx3_utils import (
     has_package_dependency_relationship,
     iter_objects_with_property,
     iter_relationships_by_type,
+    load_spdx3_model,
     validate_spdx3_data,
 )
 
 if TYPE_CHECKING:
+    from spdx_python_model.bindings import v3_0_1 as spdx3_types
     from spdx_tools.spdx.model.document import Document
 
 
-# pylint: disable=too-many-instance-attributes,too-many-public-methods
+# pylint: disable=too-many-instance-attributes,too-many-public-methods, too-many-lines
 class BaseChecker(ABC):
     """Base class for all compliance/conformance checkers.
 
@@ -53,6 +55,9 @@ class BaseChecker(ABC):
     Any class inheriting from BaseChecker must implement its abstract methods,
     such as `check_compliance` and `output_json`.
     """
+
+    # Store the loaded SPDX 3 module for the specific version being checked.
+    spdx_module: Any = None
 
     # Minimum elements/baseline attributes required by a compliance standard
     MIN_ELEMENTS: list[str] = []
@@ -88,8 +93,8 @@ class BaseChecker(ABC):
     # For SPDX 3, we have to use SHACLObjectSet instead of SpdxDocument,
     # because we need access to relationships and other elements that are not
     # accessible from SpdxDocument.
-    doc: Document | spdx3.SHACLObjectSet | None = None
-    __spdx3_doc: spdx3.SpdxDocument | None = None  # cached SPDX 3 document
+    doc: Document | spdx3_types.SHACLObjectSet | None = None
+    __spdx3_doc: spdx3_types.SpdxDocument | None = None  # cached SPDX 3 document
 
     _parsing_errors: list[str] = []
     _validation_messages: list[ValidationMessage] = []
@@ -190,12 +195,21 @@ class BaseChecker(ABC):
             case "spdx2":
                 self.doc = self.parse_file()
             case "spdx3":
+                version_tuple = get_spdx_version(self.file, "spdx3")
+                major, minor = version_tuple if version_tuple else (3, 0)
+
+                self.spdx_module = load_spdx3_model(major, minor)
+
+                print(f"DEBUG: Loaded module: {self.spdx_module.__name__}")
+
                 object_set = self.parse_spdx3_file()
                 if not object_set:
                     logging.error("Failed to parse the SPDX 3 file.")
                 else:
                     self.doc = object_set
-                    self.__spdx3_doc, _val_msgs = validate_spdx3_data(object_set)
+                    self.__spdx3_doc, _val_msgs = validate_spdx3_data(
+                        object_set, self.spdx_module
+                    )
                     if not self.__spdx3_doc or _val_msgs:
                         logging.error("SpdxDocument not found or invalid.")
                     self._validation_messages.extend(_val_msgs)
@@ -309,8 +323,8 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
-            return has_package_dependency_relationship(self.doc)
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
+            return has_package_dependency_relationship(self.doc, self.spdx_module)
 
         return False
 
@@ -358,7 +372,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3" and isinstance(
-            self.__spdx3_doc, spdx3.SpdxDocument
+            self.__spdx3_doc, self.spdx_module.SpdxDocument
         ):
             doc_creation_info = getattr(self.__spdx3_doc, "creationInfo", None)
             if doc_creation_info:
@@ -382,7 +396,7 @@ class BaseChecker(ABC):
 
         # SPDX 3
         elif self.sbom_spec == "spdx3" and isinstance(
-            self.__spdx3_doc, spdx3.SpdxDocument
+            self.__spdx3_doc, self.spdx_module.SpdxDocument
         ):
             name = getattr(self.__spdx3_doc, "name", "")
 
@@ -401,7 +415,7 @@ class BaseChecker(ABC):
         if not self.doc or not self.__spdx3_doc or self.sbom_spec != "spdx3":
             return []
 
-        root_elements: spdx3.ListProxy[Union[str, spdx3.Element]] = (
+        root_elements: spdx3_types.ListProxy[Union[str, spdx3_types.Element]] = (
             self.__spdx3_doc.rootElement
         )
         if not root_elements:
@@ -411,7 +425,7 @@ class BaseChecker(ABC):
 
         # Assuming only one rootElement per document
         root_elem = root_elements[0]
-        if not isinstance(root_elem, spdx3.software_Sbom):
+        if not isinstance(root_elem, self.spdx_module.software_Sbom):
             doc_id = getattr(self.__spdx3_doc, "spdxId", None)
             root_elem_id = getattr(root_elem, "spdxId", None)
             error_msg = (
@@ -464,17 +478,14 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
 
             has_concluded_license_ids: set[str] = set()
-            no_assertion_uri = (
-                spdx3.expandedlicensing_IndividualLicensingInfo.NAMED_INDIVIDUALS[
-                    "NoAssertionLicense"
-                ]
-            )
+            lic_info = self.spdx_module.expandedlicensing_IndividualLicensingInfo
+            no_assertion_uri = lic_info.NAMED_INDIVIDUALS["NoAssertionLicense"]
 
             for from_id, to_ids in iter_relationships_by_type(
-                self.doc, "hasConcludedLicense"
+                self.doc, "hasConcludedLicense", self.spdx_module
             ):
                 # Filter out any "NoAssertionLicense" from the list
                 valid_licenses = [
@@ -489,7 +500,7 @@ class BaseChecker(ABC):
                 (name or "", spdx_id or "")
                 for name, spdx_id, _ in iter_objects_with_property(
                     self.doc,
-                    spdx3.software_Package,
+                    self.spdx_module.software_Package,
                     "spdxId",
                     self.reachable_component_ids,
                 )
@@ -531,13 +542,13 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
 
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, copyright_text in iter_objects_with_property(
                     self.doc,
-                    spdx3.software_Package,
+                    self.spdx_module.software_Package,
                     "software_copyrightText",
                     self.reachable_component_ids,
                 )
@@ -584,12 +595,15 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
 
             return [
                 (name or "", spdx_id or "")
                 for name, _, spdx_id in iter_objects_with_property(
-                    self.doc, spdx3.Element, "spdxId", self.reachable_component_ids
+                    self.doc,
+                    self.spdx_module.Element,
+                    "spdxId",
+                    self.reachable_component_ids,
                 )
                 if not spdx_id or (isinstance(spdx_id, str) and spdx_id.strip() == "")
             ]
@@ -625,13 +639,13 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
 
             return [
                 (name or "", spdx_id or "")
                 for _, spdx_id, name in iter_objects_with_property(
                     self.doc,
-                    spdx3.software_Package,
+                    self.spdx_module.software_Package,
                     "name",
                     self.reachable_component_ids,
                 )
@@ -673,13 +687,13 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
 
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, supplier in iter_objects_with_property(
                     self.doc,
-                    spdx3.software_Package,
+                    self.spdx_module.software_Package,
                     "suppliedBy",
                     self.reachable_component_ids,
                 )
@@ -725,13 +739,13 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
 
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, package_version in iter_objects_with_property(
                     self.doc,
-                    spdx3.software_Package,
+                    self.spdx_module.software_Package,
                     "software_packageVersion",
                     self.reachable_component_ids,
                 )
@@ -779,8 +793,8 @@ class BaseChecker(ABC):
 
         # SPDX 3
         if self.sbom_spec == "spdx3":
-            self.doc = cast("spdx3.SHACLObjectSet", self.doc)
-            objects: set[spdx3.SHACLObject] = getattr(self.doc, "objects", set())
+            self.doc = cast("spdx3_types.SHACLObjectSet", self.doc)
+            objects: set[spdx3_types.SHACLObject] = getattr(self.doc, "objects", set())
             return len(objects)
 
         return 0
@@ -824,12 +838,12 @@ class BaseChecker(ABC):
 
         return cast("Document", doc)
 
-    def parse_spdx3_file(self) -> spdx3.SHACLObjectSet | None:
+    def parse_spdx3_file(self) -> spdx3_types.SHACLObjectSet | None:
         """
         Parse SPDX 3 SBOM document.
 
         Returns:
-            spdx3.SHACLObjectSet | None: An SHACLObjectSet if successful, otherwise None.
+            spdx3_types.SHACLObjectSet | None: An SHACLObjectSet if successful, otherwise None.
         """
         if not self.file or str(self.file).strip() == "":
             logging.error("No file path provided.")
@@ -839,10 +853,10 @@ class BaseChecker(ABC):
             logging.error("File not found: %s", self.file)
             return None
 
-        object_set: spdx3.SHACLObjectSet = spdx3.SHACLObjectSet()
+        object_set: spdx3_types.SHACLObjectSet = self.spdx_module.SHACLObjectSet()
         try:
             with open(self.file, "rb") as f:
-                spdx3.JSONLDDeserializer().read(f, object_set)
+                self.spdx_module.JSONLDDeserializer().read(f, object_set)
         except (OSError, json.JSONDecodeError) as err:
             logging.warning("SPDX3 deserialization failed: %s", err)
             self._parsing_errors.append(str(err))

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -989,7 +989,10 @@ class BaseChecker(ABC):
         """Evaluate graph connectivity to isolate floating nodes and unknown pointers."""
 
         reachable, floating, _, has_unknown_pointers = analyze_graph_connectivity(
-            self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)
+            self.sbom_spec,
+            self.doc,
+            getattr(self, "_BaseChecker__spdx3_doc", None),
+            self.spdx_module
         )
 
         self.reachable_component_ids = reachable

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -11,8 +11,10 @@ import logging
 import os
 import warnings
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union, cast
 
+import spdx_python_model
 from spdx_tools.spdx.model.relationship import RelationshipType
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 from spdx_tools.spdx.parser import parse_anything
@@ -23,7 +25,6 @@ from spdx_tools.spdx.validation.validation_message import (
     ValidationMessage,
 )
 
-from .cli_utils import get_spdx_version
 from .constants import DEFAULT_SBOM_SPEC
 from .graph_utils import analyze_graph_connectivity
 from .report import (
@@ -36,7 +37,6 @@ from .spdx3_utils import (
     has_package_dependency_relationship,
     iter_objects_with_property,
     iter_relationships_by_type,
-    load_spdx3_model,
     validate_spdx3_data,
 )
 
@@ -195,17 +195,11 @@ class BaseChecker(ABC):
             case "spdx2":
                 self.doc = self.parse_file()
             case "spdx3":
-                version_tuple = get_spdx_version(self.file, "spdx3")
-                major, minor = version_tuple if version_tuple else (3, 0)
+                try:
+                    self.spdx_module, object_set = spdx_python_model.load(
+                        Path(self.file)
+                    )
 
-                self.spdx_module = load_spdx3_model(major, minor)
-
-                print(f"DEBUG: Loaded module: {self.spdx_module.__name__}")
-
-                object_set = self.parse_spdx3_file()
-                if not object_set:
-                    logging.error("Failed to parse the SPDX 3 file.")
-                else:
                     self.doc = object_set
                     self.__spdx3_doc, _val_msgs = validate_spdx3_data(
                         object_set, self.spdx_module
@@ -213,6 +207,11 @@ class BaseChecker(ABC):
                     if not self.__spdx3_doc or _val_msgs:
                         logging.error("SpdxDocument not found or invalid.")
                     self._validation_messages.extend(_val_msgs)
+                except ValueError:
+                    raise
+                except Exception as err:  # pylint: disable=broad-exception-caught
+                    logging.error("Failed to load SPDX 3 document: %s", err)
+                    self._parsing_errors.append(str(err))
             case _:
                 # We can add a heuristic to detect the spec from the file content here,
                 # in case sbom_spec is not provided or invalid.

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -992,7 +992,7 @@ class BaseChecker(ABC):
             self.sbom_spec,
             self.doc,
             getattr(self, "_BaseChecker__spdx3_doc", None),
-            self.spdx_module
+            self.spdx_module,
         )
 
         self.reachable_component_ids = reachable

--- a/ntia_conformance_checker/constants.py
+++ b/ntia_conformance_checker/constants.py
@@ -42,10 +42,14 @@ SUPPORTED_COMPLIANCE_STANDARDS_DESC = {
 DEFAULT_COMPLIANCE_STANDARD = "ntia"
 SUPPORTED_COMPLIANCE_STANDARDS = set(SUPPORTED_COMPLIANCE_STANDARDS_DESC.keys())
 
-SUPPORTED_SPDX_VERSIONS = {(2, 2), (2, 3), (3, 0)}  # (Major, Minor)
+SUPPORTED_SPDX_VERSIONS = {(2, 2), (2, 3), (3, 0), (3, 1)}  # (Major, Minor)
 SUPPORTED_SPDX2_VERSION_STRINGS = {
     f"SPDX-{maj}.{min}" for (maj, min) in SUPPORTED_SPDX_VERSIONS if maj == 2
 }  # e.g. "SPDX-2.2", "SPDX-2.3"
 SUPPORTED_SPDX3_VERSION_STRINGS = {
     f"{maj}.{min}" for (maj, min) in SUPPORTED_SPDX_VERSIONS if maj == 3
 }  # e.g. "3.0"
+SPDX3_MODEL_BINDINGS_MAP = {
+    (3, 0): "v3_0_1",
+    (3, 1): "v3_1",
+}

--- a/ntia_conformance_checker/constants.py
+++ b/ntia_conformance_checker/constants.py
@@ -49,7 +49,3 @@ SUPPORTED_SPDX2_VERSION_STRINGS = {
 SUPPORTED_SPDX3_VERSION_STRINGS = {
     f"{maj}.{min}" for (maj, min) in SUPPORTED_SPDX_VERSIONS if maj == 3
 }  # e.g. "3.0"
-SPDX3_MODEL_BINDINGS_MAP = {
-    (3, 0): "v3_0_1",
-    (3, 1): "v3_1",
-}

--- a/ntia_conformance_checker/graph_utils.py
+++ b/ntia_conformance_checker/graph_utils.py
@@ -6,7 +6,6 @@
 
 from typing import TYPE_CHECKING, Any, cast
 
-from spdx_python_model.bindings import v3_0_1 as spdx3
 from spdx_tools.spdx.model.relationship import RelationshipType
 
 from .constants import (
@@ -16,10 +15,11 @@ from .constants import (
 
 if TYPE_CHECKING:
     from spdx_tools.spdx.model.document import Document
+    from spdx_python_model.bindings import v3_0_1 as spdx3_types
 
 
 def analyze_graph_connectivity(
-    sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None
+    sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None, spdx_module: Any = None
 ) -> tuple[set[str], set[str], dict[str, list[str]], bool]:
     """
     Analyzes the graph to find reachable nodes, floating nodes, and unknown pointer edges.
@@ -28,7 +28,7 @@ def analyze_graph_connectivity(
         tuple: (reachable_ids, floating_ids, unknown_pointer_edges, has_unknown_pointers)
     """
     reachable_ids, connection_map = get_reachable_components(
-        sbom_spec, parsed_data, spdx3_doc
+        sbom_spec, parsed_data, spdx3_doc, spdx_module
     )
     all_doc_ids: set[str] = set()
 
@@ -38,7 +38,7 @@ def analyze_graph_connectivity(
             pkg.spdx_id for pkg in spdx2_doc.packages if isinstance(pkg.spdx_id, str)
         }
     elif sbom_spec == "spdx3":
-        spdx3_doc_set = cast("spdx3.SHACLObjectSet", parsed_data)
+        spdx3_doc_set = cast("spdx3_types.SHACLObjectSet", parsed_data)
         all_doc_ids = {
             getattr(obj, "spdxId")
             for obj in spdx3_doc_set.objects
@@ -95,7 +95,7 @@ def _build_spdx2_graph(spdx2_doc: "Document") -> tuple[list[str], dict[str, list
 
 
 def _extract_spdx3_relationship_edges(
-    obj: spdx3.Relationship, graph_connection_map: dict[str, list[str]]
+    obj: spdx3_types.Relationship, graph_connection_map: dict[str, list[str]]
 ) -> None:
     """Helper to extract explicit relationship edges."""
     rel_type_iri = getattr(obj, "relationshipType", "")
@@ -125,7 +125,7 @@ def _extract_spdx3_relationship_edges(
 
 
 def _extract_spdx3_collection_edges(
-    obj: spdx3.ElementCollection, graph_connection_map: dict[str, list[str]]
+    obj: spdx3_types.ElementCollection, graph_connection_map: dict[str, list[str]]
 ) -> None:
     """Helper to extract implicit collection edges (e.g. Sbom, Document)."""
     col_id = getattr(obj, "spdxId", None)
@@ -143,7 +143,9 @@ def _extract_spdx3_collection_edges(
 
 
 def _build_spdx3_graph(
-    object_set: spdx3.SHACLObjectSet, spdx3_doc: spdx3.SpdxDocument | None
+    object_set: spdx3_types.SHACLObjectSet,
+    spdx3_doc: spdx3_types.SpdxDocument | None,
+    spdx_module: Any
 ) -> tuple[list[str], dict[str, list[str]]]:
     """Build the initial queue and connection map for SPDX 3."""
     queue: list[str] = []
@@ -160,7 +162,7 @@ def _build_spdx3_graph(
     # Build the graph connection map
     for obj in object_set.objects:
         # Capture explicit relationships from Relationship objects
-        if isinstance(obj, spdx3.Relationship):
+        if isinstance(obj, spdx_module.Relationship):
             from_ = getattr(obj, "from_", None)
             from_id = (
                 from_ if isinstance(from_, str) else getattr(from_, "spdxId", None)
@@ -180,14 +182,14 @@ def _build_spdx3_graph(
                 _extract_spdx3_relationship_edges(obj, graph_connection_map)
 
         # Capture implicit relationships from Collections (like Sbom, Bom, etc.)
-        if isinstance(obj, spdx3.ElementCollection):
+        if isinstance(obj, spdx_module.ElementCollection):
             _extract_spdx3_collection_edges(obj, graph_connection_map)
 
     return queue, graph_connection_map
 
 
 def get_reachable_components(
-    sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None
+    sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None, spdx_module: Any = None
 ) -> tuple[set[str], dict[str, list[str]]]:
     """
     Get all components connected to the root by using Breadth-First Search.
@@ -210,7 +212,7 @@ def get_reachable_components(
 
     # SPDX 3
     if sbom_spec == "spdx3":
-        queue, graph_connection_map = _build_spdx3_graph(parsed_data, spdx3_doc)
+        queue, graph_connection_map = _build_spdx3_graph(parsed_data, spdx3_doc, spdx_module)
 
     reachable_component_ids: set[str] = set(queue)
 

--- a/ntia_conformance_checker/graph_utils.py
+++ b/ntia_conformance_checker/graph_utils.py
@@ -4,6 +4,8 @@
 
 """Graph utilities for SPDX 2 and SPDX 3."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, cast
 
 from spdx_tools.spdx.model.relationship import RelationshipType
@@ -179,11 +181,15 @@ def _build_spdx3_graph(
 
             # Normal relationships between packages build the map
             else:
-                _extract_spdx3_relationship_edges(obj, graph_connection_map)
+                _extract_spdx3_relationship_edges(
+                    cast("spdx3_types.Relationship", obj), graph_connection_map
+                )
 
         # Capture implicit relationships from Collections (like Sbom, Bom, etc.)
         if isinstance(obj, spdx_module.ElementCollection):
-            _extract_spdx3_collection_edges(obj, graph_connection_map)
+            _extract_spdx3_collection_edges(
+                cast("spdx3_types.ElementCollection", obj), graph_connection_map
+            )
 
     return queue, graph_connection_map
 

--- a/ntia_conformance_checker/graph_utils.py
+++ b/ntia_conformance_checker/graph_utils.py
@@ -14,8 +14,8 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from spdx_tools.spdx.model.document import Document
     from spdx_python_model.bindings import v3_0_1 as spdx3_types
+    from spdx_tools.spdx.model.document import Document
 
 
 def analyze_graph_connectivity(
@@ -145,7 +145,7 @@ def _extract_spdx3_collection_edges(
 def _build_spdx3_graph(
     object_set: spdx3_types.SHACLObjectSet,
     spdx3_doc: spdx3_types.SpdxDocument | None,
-    spdx_module: Any
+    spdx_module: Any,
 ) -> tuple[list[str], dict[str, list[str]]]:
     """Build the initial queue and connection map for SPDX 3."""
     queue: list[str] = []
@@ -212,7 +212,9 @@ def get_reachable_components(
 
     # SPDX 3
     if sbom_spec == "spdx3":
-        queue, graph_connection_map = _build_spdx3_graph(parsed_data, spdx3_doc, spdx_module)
+        queue, graph_connection_map = _build_spdx3_graph(
+            parsed_data, spdx3_doc, spdx_module
+        )
 
     reachable_component_ids: set[str] = set(queue)
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -6,15 +6,12 @@
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING, Any, Union, cast
 
 from spdx_tools.spdx.validation.validation_message import (
     ValidationContext,
     ValidationMessage,
 )
-
-from .constants import SPDX3_MODEL_BINDINGS_MAP
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -302,27 +299,3 @@ def has_package_dependency_relationship(
                 return True
 
     return False
-
-
-class UnsupportedVersionError(Exception):
-    """Raised when the required SPDX Python bindings are not available."""
-
-
-def load_spdx3_model(major: int, minor: int) -> Any:
-    """Dynamically loads the appropriate spdx_python_model version bindings."""
-    version_key = (major, minor)
-
-    # Check if the requested version is supported and available
-    if version_key not in SPDX3_MODEL_BINDINGS_MAP:
-        raise UnsupportedVersionError(
-            f"Bindings for SPDX {major}.{minor} are not implemented in this tool."
-        )
-
-    version_suffix = SPDX3_MODEL_BINDINGS_MAP[version_key]
-    module_path = f"spdx_python_model.bindings.{version_suffix}"
-    try:
-        return importlib.import_module(module_path)
-    except ImportError as exc:
-        raise UnsupportedVersionError(
-            f"Bindings for SPDX {major}.{minor} ({module_path}) are not available."
-        ) from exc

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import importlib
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from spdx_tools.spdx.validation.validation_message import (
     ValidationContext,
@@ -220,8 +220,9 @@ def iter_relationships_by_type(
         # Remove the IRI prefix of entry name before compare
         if not _rel_type or _rel_type.split("/")[-1] != rel_type:
             continue
-        from_: str | spdx3_types.Element | None = obj.from_
-        to_elements: spdx3_types.ListProxy[Union[str, spdx3_types.Element]] = obj.to
+        rel_obj = cast("spdx3_types.Relationship", obj)
+        from_: str | spdx3_types.Element | None = rel_obj.from_
+        to_elements: spdx3_types.ListProxy[Union[str, spdx3_types.Element]] = rel_obj.to
         if not from_ or not to_elements:
             continue
 
@@ -243,7 +244,8 @@ def get_all_packages(
 ) -> set[spdx3_types.software_Package]:
     """Retrieve all /Software/Package objects from an SHACLObjectSet."""
     packages: set[spdx3_types.software_Package] = set(
-        object_set.foreach_type(spdx_module.software_Package)
+        cast("spdx3_types.software_Package", pkg)
+        for pkg in object_set.foreach_type(spdx_module.software_Package)
     )
     return packages
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -6,16 +6,20 @@
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING, Any, Union
 
-from spdx_python_model.bindings import v3_0_1 as spdx3
 from spdx_tools.spdx.validation.validation_message import (
     ValidationContext,
     ValidationMessage,
 )
 
+from .constants import SPDX3_MODEL_BINDINGS_MAP
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from spdx_python_model.bindings import v3_0_1 as spdx3_types
 
 
 SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES = (
@@ -27,8 +31,8 @@ SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES = (
 
 
 def validate_spdx3_data(
-    object_set: spdx3.SHACLObjectSet,
-) -> tuple[spdx3.SpdxDocument | None, list[ValidationMessage]]:
+    object_set: Any, spdx_module: Any
+) -> tuple[spdx3_types.SpdxDocument | None, list[ValidationMessage]]:
     """
     Validate an SHACLObjectSet if it contains a valid SpdxDocument.
 
@@ -49,11 +53,11 @@ def validate_spdx3_data(
     # which is originally meant for SPDX 2, to report validation errors for
     # SPDX 3 as well, so the print/HTML/JSON output functions can be reused.
 
-    doc: spdx3.SpdxDocument | None = None
+    doc: spdx3_types.SpdxDocument | None = None
     validation_messages: list[ValidationMessage] = []
 
-    spdx_documents: list[spdx3.SpdxDocument] = list(
-        object_set.foreach_type(spdx3.SpdxDocument)
+    spdx_documents: list[spdx3_types.SpdxDocument] = list(
+        object_set.foreach_type(spdx_module.SpdxDocument)
     )
 
     # == SPDX 3 JSON serialization constraint =====
@@ -81,8 +85,10 @@ def validate_spdx3_data(
 
     doc = spdx_documents[0]
     doc_id = getattr(doc, "spdxId", None)
-    elements: spdx3.ListProxy[Union[str, spdx3.Element]] = doc.element
-    root_elements: spdx3.ListProxy[Union[str, spdx3.Element]] = doc.rootElement
+    elements: spdx3_types.ListProxy[Union[str, spdx3_types.Element]] = doc.element
+    root_elements: spdx3_types.ListProxy[Union[str, spdx3_types.Element]] = (
+        doc.rootElement
+    )
 
     # ElementCollection constraint: if there is at least one element,
     # there shall also be at least one rootElement.
@@ -101,7 +107,7 @@ def validate_spdx3_data(
     # ElementCollection constraint: element items shall not be of type SpdxDocument.
     # Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/
     for elem in elements:
-        if isinstance(elem, spdx3.SpdxDocument):
+        if isinstance(elem, spdx_module.SpdxDocument):
             elem_id = getattr(elem, "spdxId", None)
             error_msg = (
                 "An SpdxDocument element shall not be of type SpdxDocument. "
@@ -113,7 +119,7 @@ def validate_spdx3_data(
     # ElementCollection constraint: rootElement items shall not be of type SpdxDocument.
     # Ref: https://spdx.github.io/spdx-spec/latest/model/Core/Classes/ElementCollection/
     for root_elem in root_elements:
-        if isinstance(root_elem, spdx3.SpdxDocument):
+        if isinstance(root_elem, spdx_module.SpdxDocument):
             root_elem_id = getattr(root_elem, "spdxId", None)
             error_msg = (
                 "An SpdxDocument rootElement shall not be of type SpdxDocument. "
@@ -126,8 +132,8 @@ def validate_spdx3_data(
 
 
 def get_boms_from_spdx_document(
-    spdx_doc: spdx3.SpdxDocument | None,
-) -> list[spdx3.Bom] | None:
+    spdx_doc: spdx3_types.SpdxDocument | None,
+) -> list[spdx3_types.Bom] | None:
     """
     Retrieve the BOMs that are rootElements of an SPDX 3 SpdxDocument.
 
@@ -140,7 +146,7 @@ def get_boms_from_spdx_document(
     if not spdx_doc:
         return None
 
-    root_elements: list[spdx3.Bom] = getattr(spdx_doc, "rootElement", [])
+    root_elements: list[spdx3_types.Bom] = getattr(spdx_doc, "rootElement", [])
     if not root_elements:
         return None
 
@@ -148,8 +154,8 @@ def get_boms_from_spdx_document(
 
 
 def get_packages_from_bom(
-    bom: spdx3.Bom | None,
-) -> list[spdx3.software_Package] | None:
+    bom: spdx3_types.Bom | None,
+) -> list[spdx3_types.software_Package] | None:
     """
     Retrieve the /Software/Packages that are rootElements of an SPDX 3 BOM.
 
@@ -162,7 +168,7 @@ def get_packages_from_bom(
     if not bom:
         return None
 
-    root_elements: list[spdx3.software_Package] = getattr(bom, "rootElement", [])
+    root_elements: list[spdx3_types.software_Package] = getattr(bom, "rootElement", [])
     if not root_elements or len(root_elements) != 1:
         return None
 
@@ -170,8 +176,8 @@ def get_packages_from_bom(
 
 
 def iter_objects_with_property(
-    object_set: spdx3.SHACLObjectSet,
-    typ: type[spdx3.SHACLObject] = spdx3.Artifact,
+    object_set: spdx3_types.SHACLObjectSet,
+    typ: Any,
     property_name: str = "spdxId",
     reachable_ids: set[str] | None = None,
 ) -> Iterator[tuple[str, str, Any]]:
@@ -201,20 +207,21 @@ def iter_objects_with_property(
 
 
 def iter_relationships_by_type(
-    object_set: spdx3.SHACLObjectSet,
+    object_set: spdx3_types.SHACLObjectSet,
     rel_type: str,
+    spdx_module: Any,
 ) -> Iterator[tuple[str, list[str]]]:
     """
     Yield (from_id, to_ids_list) for each relationship of the specified relationship type.
     """
 
-    for obj in object_set.foreach_type(spdx3.Relationship):
+    for obj in object_set.foreach_type(spdx_module.Relationship):
         _rel_type = getattr(obj, "relationshipType", "")
         # Remove the IRI prefix of entry name before compare
         if not _rel_type or _rel_type.split("/")[-1] != rel_type:
             continue
-        from_: str | spdx3.Element | None = obj.from_
-        to_elements: spdx3.ListProxy[Union[str, spdx3.Element]] = obj.to
+        from_: str | spdx3_types.Element | None = obj.from_
+        to_elements: spdx3_types.ListProxy[Union[str, spdx3_types.Element]] = obj.to
         if not from_ or not to_elements:
             continue
 
@@ -231,49 +238,89 @@ def iter_relationships_by_type(
             yield from_id, to_ids
 
 
-def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Package]:
+def get_all_packages(
+    object_set: spdx3_types.SHACLObjectSet, spdx_module: Any
+) -> set[spdx3_types.software_Package]:
     """Retrieve all /Software/Package objects from an SHACLObjectSet."""
-    packages: set[spdx3.software_Package] = set(
-        object_set.foreach_type(spdx3.software_Package)
+    packages: set[spdx3_types.software_Package] = set(
+        object_set.foreach_type(spdx_module.software_Package)
     )
     return packages
 
 
 def get_all_package_ids(
-    object_set: spdx3.SHACLObjectSet, reachable_ids: set[str] | None = None
+    object_set: spdx3_types.SHACLObjectSet,
+    spdx_module: Any,
+    reachable_ids: set[str] | None = None,
 ) -> set[str]:
     """Retrieve spdxId for all /Software/Package objects from an SHACLObjectSet."""
     return {
         spdx_id
         for _name, spdx_id, _ in iter_objects_with_property(
-            object_set, spdx3.software_Package, "spdxId", reachable_ids
+            object_set,
+            spdx_module.software_Package,
+            "spdxId",
+            reachable_ids,
         )
         if spdx_id
     }
 
 
 def get_all_element_ids(
-    object_set: spdx3.SHACLObjectSet, reachable_ids: set[str] | None = None
+    object_set: spdx3_types.SHACLObjectSet,
+    spdx_module: Any,
+    reachable_ids: set[str] | None = None,
 ) -> set[str]:
     """Retrieve spdxId for all SPDX 3 Element objects from an SHACLObjectSet."""
     return {
         spdx_id
         for _name, spdx_id, _ in iter_objects_with_property(
-            object_set, spdx3.Element, "spdxId", reachable_ids
+            object_set,
+            spdx_module.Element,
+            "spdxId",
+            reachable_ids,
         )
         if spdx_id
     }
 
 
-def has_package_dependency_relationship(object_set: spdx3.SHACLObjectSet) -> bool:
+def has_package_dependency_relationship(
+    object_set: spdx3_types.SHACLObjectSet, spdx_module: Any
+) -> bool:
     """Return True if a dependency relationship connects SPDX 3 Elements."""
-    element_ids = get_all_element_ids(object_set)
+    element_ids = get_all_element_ids(object_set, spdx_module)
     if len(element_ids) < 2:
         return False
 
     for rel_type in SPDX3_PACKAGE_DEPENDENCY_RELATIONSHIP_TYPES:
-        for from_id, to_ids in iter_relationships_by_type(object_set, rel_type):
+        for from_id, to_ids in iter_relationships_by_type(
+            object_set, rel_type, spdx_module
+        ):
             if from_id in element_ids and any(to_id in element_ids for to_id in to_ids):
                 return True
 
     return False
+
+
+class UnsupportedVersionError(Exception):
+    """Raised when the required SPDX Python bindings are not available."""
+
+
+def load_spdx3_model(major: int, minor: int) -> Any:
+    """Dynamically loads the appropriate spdx_python_model version bindings."""
+    version_key = (major, minor)
+
+    # Check if the requested version is supported and available
+    if version_key not in SPDX3_MODEL_BINDINGS_MAP:
+        raise UnsupportedVersionError(
+            f"Bindings for SPDX {major}.{minor} are not implemented in this tool."
+        )
+
+    version_suffix = SPDX3_MODEL_BINDINGS_MAP[version_key]
+    module_path = f"spdx_python_model.bindings.{version_suffix}"
+    try:
+        return importlib.import_module(module_path)
+    except ImportError as exc:
+        raise UnsupportedVersionError(
+            f"Bindings for SPDX {major}.{minor} ({module_path}) are not available."
+        ) from exc

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -329,7 +329,9 @@ def test_sbomchecker_spdx3_general() -> None:
     assert isinstance(sbom.doc, spdx3.SHACLObjectSet)
     assert sbom.sbom_name == "hello"
     assert not sbom.sbom_gen_context  # No SBOM -> No SBOM generation context
-    spdx3_spdx_document, validation_messages = validate_spdx3_data(sbom.doc)
+    spdx3_spdx_document, validation_messages = validate_spdx3_data(
+        sbom.doc, sbom.spdx_module
+    )
     # The file is spec-valid SPDX 3; no SPDX 3 spec errors expected.
     assert len(validation_messages) == 0
     # The conformance check (rootElement must be /Software/Sbom) fires here
@@ -414,21 +416,23 @@ def test_spdx3_dependency_relationship_types(
     relationship.relationshipType = (
         f"{SPDX3_RELATIONSHIP_TYPE_BASE}/{relationship_type}"
     )
-    assert has_package_dependency_relationship(object_set) is expected
+    assert has_package_dependency_relationship(object_set, spdx3) is expected
 
 
 def test_spdx3_dependency_relationship_accepts_element_endpoints() -> None:
     object_set = _spdx3_package_dependency_object_set()
     relationship = next(object_set.foreach_type(spdx3.Relationship))
-    sbom = object_set.find_by_id("https://spdx.org/spdxdocs/SBOM-package-dependency")
+    sbom_element = object_set.find_by_id(
+        "https://spdx.org/spdxdocs/SBOM-package-dependency"
+    )
     package = object_set.find_by_id("https://spdx.org/spdxdocs/Package-library")
-    assert isinstance(sbom, spdx3.Element)
+    assert isinstance(sbom_element, spdx3.Element)
     assert isinstance(package, spdx3.Element)
 
-    relationship.from_ = sbom
+    relationship.from_ = sbom_element
     relationship.to = [package]
 
-    assert has_package_dependency_relationship(object_set)
+    assert has_package_dependency_relationship(object_set, spdx3)
 
 
 def test_sbomchecker_spdx3_missing_supplier_name() -> None:


### PR DESCRIPTION
### **Description:**

This PR removed the hardcoded version bindings (`v3_0_1`) and implemented a flexible version aware dynamic module loader. This introduces official support for the upcoming SPDX 3.1 specification.

### **Key Changes:**

* **`ntia_conformance_checker/constants.py`**
    * Added `(3, 1)` to `SUPPORTED_SPDX_VERSIONS`.
    * Introduced `SPDX3_MODEL_BINDINGS_MAP` as a single source of truth for mapping major/minor SPDX versions to their corresponding `spdx-python-model` binding module names.


* **`ntia_conformance_checker/spdx3_utils.py`**
    * Implemented `load_spdx3_model(major, minor)` to programmatically import binding namespaces via `importlib`.
    * Refactored helper functions to accept the active `spdx_module` as a runtime argument.
    * Isolated static type hints inside a `TYPE_CHECKING` block ( as `spdx3_types`) to satisfy `mypy` without causing runtime version locking.


* **`ntia_conformance_checker/base_checker.py`**
    * Updated `BaseChecker` to detect the SBOM version at initialization and hold the corresponding module dynamically (`self.spdx_module`).
    * Replaced hardcoded class lookups (e.g., `spdx3.software_Package`) with variable runtime lookups (e.g., `self.spdx_module.software_Package`).


* **`tests/test_checker.py`**
    * Updated existing test assertions to pass the dynamic `spdx_module` into `validate_spdx3_data()`.