### PR TITLE
Implement graph-based element discovery for SPDX 2 & 3

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -968,9 +968,6 @@ class BaseChecker(ABC):
 
     def _evaluate_graph_connectivity(self) -> None:
         """Evaluate graph connectivity to isolate floating nodes and unknown pointers."""
-        self.reachable_component_ids = get_reachable_components(
-            self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)
-        )
 
         reachable, floating, has_unknown_pointers = analyze_graph_connectivity(
             self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -62,15 +62,18 @@ class BaseChecker(ABC):
     _COMPONENTS_WITHOUT_INFO = {
         "name": ("components_without_names", "Components missing a name"),
         "version": ("components_without_versions", "Components missing a version"),
-        "identifier": ("components_without_identifiers", "Components missing an identifier"),
+        "identifier": (
+            "components_without_identifiers",
+            "Components missing an identifier",
+        ),
         "supplier": ("components_without_suppliers", "Components missing a supplier"),
         "concluded_license": (
-            "components_without_concluded_licenses", 
-            "Components missing a concluded license"
+            "components_without_concluded_licenses",
+            "Components missing a concluded license",
         ),
         "copyright_text": (
             "components_without_copyright_texts",
-            "Components missing a copyright text"
+            "Components missing a copyright text",
         ),
     }
 
@@ -181,7 +184,7 @@ class BaseChecker(ABC):
 
         self.reachable_component_ids: set[str] = set()
         self.floating_component_ids: set[str] = set()
-        self.has_disconnected_components: bool = False
+        self.has_unknown_components: bool = False
 
         match sbom_spec:
             case "spdx2":
@@ -219,7 +222,9 @@ class BaseChecker(ABC):
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = self.get_components_without_versions()
             self.components_without_suppliers = self.get_components_without_suppliers()
-            self.components_without_identifiers = self.get_components_without_identifiers()
+            self.components_without_identifiers = (
+                self.get_components_without_identifiers()
+            )
             self.components_without_concluded_licenses = (
                 self.get_components_without_concluded_licenses()
             )
@@ -229,9 +234,9 @@ class BaseChecker(ABC):
 
             # List of (info_name, components) tuples,
             # where components is a list of (component_name, spdx_id) tuples
-            self.all_components_without_info: list[tuple[str, list[tuple[str, str]]]] = (
-                self._get_all_components_without_info()
-            )
+            self.all_components_without_info: list[
+                tuple[str, list[tuple[str, str]]]
+            ] = self._get_all_components_without_info()
 
         self.table_elements: list[tuple[str, bool]] = []
 
@@ -962,7 +967,7 @@ class BaseChecker(ABC):
         return result
 
     def _evaluate_graph_connectivity(self) -> None:
-        """Evaluate graph connectivity to isolate floating nodes and dangling pointers."""
+        """Evaluate graph connectivity to isolate floating nodes and unknown pointers."""
         self.reachable_component_ids = get_reachable_components(
             self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)
         )
@@ -988,10 +993,12 @@ class BaseChecker(ABC):
         if self.floating_component_ids:
             logging.warning(
                 "Found %d disconnected 'floating' elements. They will be ignored for compliance.",
-                len(self.floating_component_ids)
+                len(self.floating_component_ids),
             )
 
         if not self.reachable_component_ids.issubset(all_doc_ids):
-            logging.error("Disconnected components detected!"
-                          "A relationship points to a missing element.")
-            self.has_dangling_pointers = True
+            logging.error(
+                "Unknown components detected!"
+                "A relationship points to a missing element."
+            )
+            self.has_unknown_components = True

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -25,7 +25,7 @@ from spdx_tools.spdx.validation.validation_message import (
 )
 
 from .constants import DEFAULT_SBOM_SPEC
-from .graph_utils import get_reachable_components
+from .graph_utils import analyze_graph_connectivity, get_reachable_components
 from .report import (
     ReportContext,
     get_validation_messages_json,
@@ -487,7 +487,10 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, _ in iter_objects_with_property(
-                    self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids,
+                    self.doc,
+                    spdx3.software_Package,
+                    "spdxId",
+                    self.reachable_component_ids,
                 )
                 if spdx_id not in has_concluded_license_ids
             ]
@@ -623,7 +626,10 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for _, spdx_id, name in iter_objects_with_property(
-                    self.doc, spdx3.software_Package, "name", self.reachable_component_ids,
+                    self.doc,
+                    spdx3.software_Package,
+                    "name",
+                    self.reachable_component_ids,
                 )
                 if not name or (isinstance(name, str) and name.strip() == "")
             ]
@@ -667,7 +673,10 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, supplier in iter_objects_with_property(
-                    self.doc, spdx3.software_Package, "suppliedBy",self.reachable_component_ids,
+                    self.doc,
+                    spdx3.software_Package,
+                    "suppliedBy",
+                    self.reachable_component_ids,
                 )
                 if not supplier
                 or (
@@ -715,7 +724,9 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, package_version in iter_objects_with_property(
-                    self.doc, spdx3.software_Package, "software_packageVersion",
+                    self.doc,
+                    spdx3.software_Package,
+                    "software_packageVersion",
                     self.reachable_component_ids,
                 )
                 if not package_version
@@ -961,33 +972,22 @@ class BaseChecker(ABC):
             self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)
         )
 
-        all_doc_ids: set[str] = set()
+        reachable, floating, has_unknown_pointers = analyze_graph_connectivity(
+            self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)
+        )
 
-        if self.sbom_spec == "spdx2":
-            spdx2_doc = cast("Document", self.doc)
-            all_doc_ids = {
-                pkg.spdx_id
-                for pkg in spdx2_doc.packages
-                if isinstance(pkg.spdx_id, str)
-            }
-        elif self.sbom_spec == "spdx3":
-            spdx3_doc_set = cast("spdx3.SHACLObjectSet", self.doc)
-            all_doc_ids = {
-                getattr(obj, "spdxId")
-                for obj in spdx3_doc_set.objects
-                if isinstance(getattr(obj, "spdxId", None), str)
-            }
+        self.reachable_component_ids = reachable
+        self.floating_component_ids = floating
+        self.has_unknown_pointers = has_unknown_pointers
 
-        self.floating_component_ids = all_doc_ids - self.reachable_component_ids
         if self.floating_component_ids:
             logging.warning(
                 "Found %d disconnected 'floating' elements. They will be ignored for compliance.",
                 len(self.floating_component_ids),
             )
 
-        if not self.reachable_component_ids.issubset(all_doc_ids):
+        if self.has_unknown_pointers:
             logging.error(
                 "Unknown components detected!"
                 "A relationship points to a missing element."
             )
-            self.has_unknown_components = True

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -25,6 +25,7 @@ from spdx_tools.spdx.validation.validation_message import (
 )
 
 from .constants import DEFAULT_SBOM_SPEC
+from .graph_utils import get_reachable_components
 from .report import (
     ReportContext,
     get_validation_messages_json,
@@ -61,18 +62,15 @@ class BaseChecker(ABC):
     _COMPONENTS_WITHOUT_INFO = {
         "name": ("components_without_names", "Components missing a name"),
         "version": ("components_without_versions", "Components missing a version"),
-        "identifier": (
-            "components_without_identifiers",
-            "Components missing an identifier",
-        ),
+        "identifier": ("components_without_identifiers", "Components missing an identifier"),
         "supplier": ("components_without_suppliers", "Components missing a supplier"),
         "concluded_license": (
-            "components_without_concluded_licenses",
-            "Components missing a concluded license",
+            "components_without_concluded_licenses", 
+            "Components missing a concluded license"
         ),
         "copyright_text": (
             "components_without_copyright_texts",
-            "Components missing a copyright text",
+            "Components missing a copyright text"
         ),
     }
 
@@ -181,6 +179,10 @@ class BaseChecker(ABC):
         self._validation_messages = []
         self._conformance_messages = []
 
+        self.reachable_component_ids: set[str] = set()
+        self.floating_component_ids: set[str] = set()
+        self.has_disconnected_components: bool = False
+
         match sbom_spec:
             case "spdx2":
                 self.doc = self.parse_file()
@@ -200,6 +202,8 @@ class BaseChecker(ABC):
                 raise ValueError(f"Unsupported SBOM specification: {sbom_spec}")
 
         if self.doc:
+            self._evaluate_graph_connectivity()
+
             if validate and sbom_spec == "spdx2":
                 self.doc = cast("Document", self.doc)
                 self._validation_messages = validate_full_spdx_document(self.doc)
@@ -215,9 +219,7 @@ class BaseChecker(ABC):
             self.components_without_names = self.get_components_without_names()
             self.components_without_versions = self.get_components_without_versions()
             self.components_without_suppliers = self.get_components_without_suppliers()
-            self.components_without_identifiers = (
-                self.get_components_without_identifiers()
-            )
+            self.components_without_identifiers = self.get_components_without_identifiers()
             self.components_without_concluded_licenses = (
                 self.get_components_without_concluded_licenses()
             )
@@ -227,9 +229,9 @@ class BaseChecker(ABC):
 
             # List of (info_name, components) tuples,
             # where components is a list of (component_name, spdx_id) tuples
-            self.all_components_without_info: list[
-                tuple[str, list[tuple[str, str]]]
-            ] = self._get_all_components_without_info()
+            self.all_components_without_info: list[tuple[str, list[tuple[str, str]]]] = (
+                self._get_all_components_without_info()
+            )
 
         self.table_elements: list[tuple[str, bool]] = []
 
@@ -483,6 +485,7 @@ class BaseChecker(ABC):
                     self.doc,
                     spdx3.software_Package,
                     "spdxId",
+                    self.reachable_component_ids,
                 )
                 if spdx_id not in has_concluded_license_ids
             ]
@@ -529,6 +532,7 @@ class BaseChecker(ABC):
                     self.doc,
                     spdx3.software_Package,
                     "software_copyrightText",
+                    self.reachable_component_ids,
                 )
                 if not copyright_text
                 or (isinstance(copyright_text, str) and copyright_text.strip() == "")
@@ -577,7 +581,7 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, _, spdx_id in iter_objects_with_property(
-                    self.doc, spdx3.Element, "spdxId"
+                    self.doc, spdx3.Element, "spdxId", self.reachable_component_ids
                 )
                 if not spdx_id or (isinstance(spdx_id, str) and spdx_id.strip() == "")
             ]
@@ -617,7 +621,10 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for _, spdx_id, name in iter_objects_with_property(
-                    self.doc, spdx3.software_Package, "name"
+                    self.doc,
+                    spdx3.software_Package,
+                    "name",
+                    self.reachable_component_ids,
                 )
                 if not name or (isinstance(name, str) and name.strip() == "")
             ]
@@ -661,7 +668,10 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, supplier in iter_objects_with_property(
-                    self.doc, spdx3.software_Package, "suppliedBy"
+                    self.doc,
+                    spdx3.software_Package,
+                    "suppliedBy",
+                    self.reachable_component_ids,
                 )
                 if not supplier
                 or (
@@ -709,7 +719,10 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, package_version in iter_objects_with_property(
-                    self.doc, spdx3.software_Package, "software_packageVersion"
+                    self.doc,
+                    spdx3.software_Package,
+                    "software_packageVersion",
+                    self.reachable_component_ids,
                 )
                 if not package_version
                 or (isinstance(package_version, str) and package_version.strip() == "")
@@ -947,3 +960,38 @@ class BaseChecker(ABC):
             }
 
         return result
+
+    def _evaluate_graph_connectivity(self) -> None:
+        """Evaluate graph connectivity to isolate floating nodes and dangling pointers."""
+        self.reachable_component_ids = get_reachable_components(
+            self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)
+        )
+
+        all_doc_ids: set[str] = set()
+
+        if self.sbom_spec == "spdx2":
+            spdx2_doc = cast("Document", self.doc)
+            all_doc_ids = {
+                pkg.spdx_id
+                for pkg in spdx2_doc.packages
+                if isinstance(pkg.spdx_id, str)
+            }
+        elif self.sbom_spec == "spdx3":
+            spdx3_doc_set = cast("spdx3.SHACLObjectSet", self.doc)
+            all_doc_ids = {
+                getattr(obj, "spdxId")
+                for obj in spdx3_doc_set.objects
+                if isinstance(getattr(obj, "spdxId", None), str)
+            }
+
+        self.floating_component_ids = all_doc_ids - self.reachable_component_ids
+        if self.floating_component_ids:
+            logging.warning(
+                "Found %d disconnected 'floating' elements. They will be ignored for compliance.",
+                len(self.floating_component_ids)
+            )
+
+        if not self.reachable_component_ids.issubset(all_doc_ids):
+            logging.error("Disconnected components detected!"
+                          "A relationship points to a missing element.")
+            self.has_dangling_pointers = True

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -451,7 +451,8 @@ class BaseChecker(ABC):
             return [
                 (package.name or "", package.spdx_id or "")
                 for package in packages
-                if (
+                if package.spdx_id in self.reachable_component_ids
+                and (
                     package.license_concluded is None
                     or isinstance(package.license_concluded, SpdxNoAssertion)
                     or (
@@ -517,7 +518,8 @@ class BaseChecker(ABC):
             return [
                 (package.name or "", package.spdx_id or "")
                 for package in packages
-                if (
+                if package.spdx_id in self.reachable_component_ids
+                and (
                     package.copyright_text is None
                     or isinstance(package.copyright_text, SpdxNoAssertion)
                     or (
@@ -570,7 +572,8 @@ class BaseChecker(ABC):
             return [
                 (package.name or "", package.spdx_id or "")
                 for package in packages
-                if (
+                if package.spdx_id in self.reachable_component_ids
+                and (
                     package.spdx_id is None
                     or (
                         isinstance(package.spdx_id, str)
@@ -613,7 +616,8 @@ class BaseChecker(ABC):
             return [
                 (package.name or "", package.spdx_id or "")
                 for package in packages
-                if (
+                if package.spdx_id in self.reachable_component_ids
+                and (
                     package.name is None
                     or (isinstance(package.name, str) and package.name.strip() == "")
                 )
@@ -656,7 +660,8 @@ class BaseChecker(ABC):
             return [
                 (package.name or "", package.spdx_id or "")
                 for package in packages
-                if (
+                if package.spdx_id in self.reachable_component_ids
+                and (
                     package.supplier is None
                     or isinstance(package.supplier, SpdxNoAssertion)
                     or (
@@ -707,7 +712,8 @@ class BaseChecker(ABC):
             return [
                 (package.name or "", package.spdx_id or "")
                 for package in packages
-                if (
+                if package.spdx_id in self.reachable_component_ids
+                and (
                     package.version is None
                     or isinstance(package.version, SpdxNoAssertion)
                     or (

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -25,7 +25,7 @@ from spdx_tools.spdx.validation.validation_message import (
 )
 
 from .constants import DEFAULT_SBOM_SPEC
-from .graph_utils import analyze_graph_connectivity, get_reachable_components
+from .graph_utils import analyze_graph_connectivity
 from .report import (
     ReportContext,
     get_validation_messages_json,

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -487,10 +487,7 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, _ in iter_objects_with_property(
-                    self.doc,
-                    spdx3.software_Package,
-                    "spdxId",
-                    self.reachable_component_ids,
+                    self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids,
                 )
                 if spdx_id not in has_concluded_license_ids
             ]
@@ -626,10 +623,7 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for _, spdx_id, name in iter_objects_with_property(
-                    self.doc,
-                    spdx3.software_Package,
-                    "name",
-                    self.reachable_component_ids,
+                    self.doc, spdx3.software_Package, "name", self.reachable_component_ids,
                 )
                 if not name or (isinstance(name, str) and name.strip() == "")
             ]
@@ -673,10 +667,7 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, supplier in iter_objects_with_property(
-                    self.doc,
-                    spdx3.software_Package,
-                    "suppliedBy",
-                    self.reachable_component_ids,
+                    self.doc, spdx3.software_Package, "suppliedBy",self.reachable_component_ids,
                 )
                 if not supplier
                 or (
@@ -724,9 +715,7 @@ class BaseChecker(ABC):
             return [
                 (name or "", spdx_id or "")
                 for name, spdx_id, package_version in iter_objects_with_property(
-                    self.doc,
-                    spdx3.software_Package,
-                    "software_packageVersion",
+                    self.doc, spdx3.software_Package, "software_packageVersion",
                     self.reachable_component_ids,
                 )
                 if not package_version

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -975,7 +975,7 @@ class BaseChecker(ABC):
     def _evaluate_graph_connectivity(self) -> None:
         """Evaluate graph connectivity to isolate floating nodes and unknown pointers."""
 
-        reachable, floating, has_unknown_pointers = analyze_graph_connectivity(
+        reachable, floating, _, has_unknown_pointers = analyze_graph_connectivity(
             self.sbom_spec, self.doc, getattr(self, "_BaseChecker__spdx3_doc", None)
         )
 

--- a/ntia_conformance_checker/constants.py
+++ b/ntia_conformance_checker/constants.py
@@ -11,10 +11,26 @@ SUPPORTED_SBOM_SPECS_DESC = {
 DEFAULT_SBOM_SPEC = "spdx2"
 SUPPORTED_SBOM_SPECS = set(SUPPORTED_SBOM_SPECS_DESC.keys())
 
-VALID_SPDX2_RELATIONSHIP_TYPES = {
+VALID_SPDX2_COMPOSITION_RELATIONSHIPS = {
     "DESCRIBES",
     "CONTAINS",
     "DEPENDS_ON",
+    "DYNAMIC_LINK",
+    "STATIC_LINK",
+    "HAS_PREREQUISITE",
+}
+VALID_SPDX3_COMPOSITION_RELATIONSHIPS = {
+    # Composition
+    "contains",
+    "hasOptionalComponent",
+    "packagedBy",
+    # Dependencies
+    "dependsOn",
+    "hasDynamicLink",
+    "hasStaticLink",
+    "hasPrerequisite",
+    "hasOptionalDependency",
+    "hasProvidedDependency",
 }
 
 SUPPORTED_COMPLIANCE_STANDARDS_DESC = {

--- a/ntia_conformance_checker/constants.py
+++ b/ntia_conformance_checker/constants.py
@@ -11,6 +11,12 @@ SUPPORTED_SBOM_SPECS_DESC = {
 DEFAULT_SBOM_SPEC = "spdx2"
 SUPPORTED_SBOM_SPECS = set(SUPPORTED_SBOM_SPECS_DESC.keys())
 
+VALID_SPDX2_RELATIONSHIP_TYPES = {
+    "DESCRIBES",
+    "CONTAINS",
+    "DEPENDS_ON",
+}
+
 SUPPORTED_COMPLIANCE_STANDARDS_DESC = {
     # "cisasbom2025": "2025 CISA SBOM Minimum Elements",
     # https://www.cisa.gov/resources-tools/resources/2025-minimum-elements-software-bill-materials-sbom

--- a/ntia_conformance_checker/graph_utils.py
+++ b/ntia_conformance_checker/graph_utils.py
@@ -9,7 +9,10 @@ from typing import TYPE_CHECKING, Any, cast
 from spdx_python_model.bindings import v3_0_1 as spdx3
 from spdx_tools.spdx.model.relationship import RelationshipType
 
-from .constants import VALID_SPDX2_RELATIONSHIP_TYPES
+from .constants import (
+    VALID_SPDX2_COMPOSITION_RELATIONSHIPS,
+    VALID_SPDX3_COMPOSITION_RELATIONSHIPS,
+)
 
 if TYPE_CHECKING:
     from spdx_tools.spdx.model.document import Document
@@ -75,7 +78,7 @@ def _build_spdx2_graph(spdx2_doc: "Document") -> tuple[list[str], dict[str, list
             queue.append(target_id)
 
         # Build the graph connection map
-        if rel.relationship_type.name in VALID_SPDX2_RELATIONSHIP_TYPES:
+        if rel.relationship_type.name in VALID_SPDX2_COMPOSITION_RELATIONSHIPS:
             if source_id not in graph_connection_map:
                 graph_connection_map[source_id] = []
             graph_connection_map[source_id].append(target_id)
@@ -86,6 +89,16 @@ def _extract_spdx3_relationship_edges(
     obj: spdx3.Relationship, graph_connection_map: dict[str, list[str]]
 ) -> None:
     """Helper to extract explicit relationship edges."""
+    rel_type_iri = getattr(obj, "relationshipType", "")
+    if not rel_type_iri:
+        return
+
+    # Extract the actual name from the IRI (e.g., ".../contains" -> "contains")
+    rel_name = rel_type_iri.split("/")[-1]
+
+    if rel_name not in VALID_SPDX3_COMPOSITION_RELATIONSHIPS:
+        return
+
     from_ = getattr(obj, "from_", None)
     from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", None)
 
@@ -127,6 +140,8 @@ def _build_spdx3_graph(
     queue: list[str] = []
     graph_connection_map: dict[str, list[str]] = {}
 
+    doc_id = getattr(spdx3_doc, "spdxId", None) if spdx3_doc else None
+
     if spdx3_doc and getattr(spdx3_doc, "rootElement", None):
         for root in spdx3_doc.rootElement:
             root_id = root if isinstance(root, str) else getattr(root, "spdxId", "")
@@ -137,7 +152,23 @@ def _build_spdx3_graph(
     for obj in object_set.objects:
         # Capture explicit relationships from Relationship objects
         if isinstance(obj, spdx3.Relationship):
-            _extract_spdx3_relationship_edges(obj, graph_connection_map)
+            from_ = getattr(obj, "from_", None)
+            from_id = (
+                from_ if isinstance(from_, str) else getattr(from_, "spdxId", None)
+            )
+
+            # If a relationship originates from the Document itself,
+            # its targets are treated as Roots.
+            if doc_id and from_id == doc_id:
+                to_ids = [
+                    t if isinstance(t, str) else getattr(t, "spdxId", "")
+                    for t in getattr(obj, "to", [])
+                ]
+                queue.extend([t for t in to_ids if t])
+
+            # Normal relationships between packages build the map
+            else:
+                _extract_spdx3_relationship_edges(obj, graph_connection_map)
 
         # Capture implicit relationships from Collections (like Sbom, Bom, etc.)
         if isinstance(obj, spdx3.ElementCollection):

--- a/ntia_conformance_checker/graph_utils.py
+++ b/ntia_conformance_checker/graph_utils.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph utilities for SPDX 2 and SPDX 3."""
+
+from typing import TYPE_CHECKING, Any
+
+from spdx_python_model.bindings import v3_0_1 as spdx3
+from spdx_tools.spdx.model.relationship import RelationshipType
+
+from .constants import VALID_SPDX2_RELATIONSHIP_TYPES
+
+if TYPE_CHECKING:
+    from spdx_tools.spdx.model.document import Document
+
+
+def _build_spdx2_graph(doc: "Document") -> tuple[list[str], dict[str, list[str]]]:
+    """Build the initial queue and connection map for SPDX 2."""
+    queue: list[str] = []
+    graph_connection_map: dict[str, list[str]] = {}
+
+    if not doc.relationships:
+        return queue, graph_connection_map
+
+    doc_id = "SPDXRef-DOCUMENT"
+    if getattr(doc, "creation_info", None) and getattr(
+        doc.creation_info, "spdx_id", None
+    ):
+        doc_id = doc.creation_info.spdx_id
+
+    for rel in doc.relationships:
+        source_id = rel.spdx_element_id
+        target_id = rel.related_spdx_element_id
+
+        if not isinstance(source_id, str) or not isinstance(target_id, str):
+            continue
+
+        # Get the root elements
+        if rel.relationship_type == RelationshipType.DESCRIBES and source_id in (
+            doc_id,
+            "SPDXRef-DOCUMENT",
+        ):
+            queue.append(target_id)
+
+        # Build the graph connection map
+        if rel.relationship_type.name in VALID_SPDX2_RELATIONSHIP_TYPES:
+            if source_id not in graph_connection_map:
+                graph_connection_map[source_id] = []
+            graph_connection_map[source_id].append(target_id)
+    return queue, graph_connection_map
+
+
+def _extract_spdx3_relationship_edges(
+    obj: spdx3.Relationship, graph_connection_map: dict[str, list[str]]
+) -> None:
+    """Helper to extract explicit relationship edges."""
+    from_ = getattr(obj, "from_", None)
+    from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", None)
+
+    if not from_id:
+        return
+
+    to_ids = [
+        t if isinstance(t, str) else getattr(t, "spdxId", "")
+        for t in getattr(obj, "to", [])
+    ]
+
+    if from_id not in graph_connection_map:
+        graph_connection_map[from_id] = []
+    graph_connection_map[from_id].extend([t for t in to_ids if t])
+
+
+def _extract_spdx3_collection_edges(
+    obj: spdx3.ElementCollection, graph_connection_map: dict[str, list[str]]
+) -> None:
+    """Helper to extract implicit collection edges (e.g. Sbom, Document)."""
+    col_id = getattr(obj, "spdxId", None)
+    if not col_id:
+        return
+
+    if col_id not in graph_connection_map:
+        graph_connection_map[col_id] = []
+
+    for attr in ("rootElement", "element"):
+        for elem in getattr(obj, attr, []):
+            e_id = elem if isinstance(elem, str) else getattr(elem, "spdxId", "")
+            if e_id:
+                graph_connection_map[col_id].append(e_id)
+
+
+def _build_spdx3_graph(
+    doc: spdx3.SHACLObjectSet, spdx3_doc: spdx3.SpdxDocument | None
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Build the initial queue and connection map for SPDX 3."""
+    queue: list[str] = []
+    graph_connection_map: dict[str, list[str]] = {}
+
+    if spdx3_doc and getattr(spdx3_doc, "rootElement", None):
+        for root in spdx3_doc.rootElement:
+            root_id = root if isinstance(root, str) else getattr(root, "spdxId", "")
+            if root_id:
+                queue.append(root_id)
+
+    # Build the graph connection map
+    for obj in doc.objects:
+        # Capture explicit relationships from Relationship objects
+        if isinstance(obj, spdx3.Relationship):
+            _extract_spdx3_relationship_edges(obj, graph_connection_map)
+
+        # Capture implicit relationships from Collections (like Sbom, Bom, etc.)
+        if isinstance(obj, spdx3.ElementCollection):
+            _extract_spdx3_collection_edges(obj, graph_connection_map)
+
+    return queue, graph_connection_map
+
+
+def get_reachable_components(
+    sbom_spec: str, doc: Any, spdx3_doc: Any = None
+) -> set[str]:
+    """
+    Get all components connected to the root by using Breadth-First Search.
+    """
+
+    if not doc:
+        return set()
+
+    queue: list[str] = []
+
+    # graph_connection_map: source_id -> list[target_ids]
+    graph_connection_map: dict[str, list[str]] = {}
+
+    # SPDX 2
+    if sbom_spec == "spdx2":
+        queue, graph_connection_map = _build_spdx2_graph(doc)
+
+    # SPDX 3
+    if sbom_spec == "spdx3":
+        queue, graph_connection_map = _build_spdx3_graph(doc, spdx3_doc)
+
+    reachable_component_ids: set[str] = set(queue)
+
+    # Perform BFS to find all reachable components
+    while queue:
+        current_id = queue.pop(0)
+
+        if current_id in graph_connection_map:
+            for target_id in graph_connection_map[current_id]:
+                if target_id not in reachable_component_ids:
+                    reachable_component_ids.add(target_id)
+                    queue.append(target_id)
+
+    return reachable_component_ids

--- a/ntia_conformance_checker/graph_utils.py
+++ b/ntia_conformance_checker/graph_utils.py
@@ -20,14 +20,16 @@ if TYPE_CHECKING:
 
 def analyze_graph_connectivity(
     sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None
-) -> tuple[set[str], set[str], bool]:
+) -> tuple[set[str], set[str], dict[str, list[str]], bool]:
     """
-    Analyzes the graph to find reachable nodes, floating nodes, and unknown pointers.
+    Analyzes the graph to find reachable nodes, floating nodes, and unknown pointer edges.
 
     Returns:
-        tuple: (reachable_ids, floating_ids, has_unknown_pointers)
+        tuple: (reachable_ids, floating_ids, unknown_pointer_edges, has_unknown_pointers)
     """
-    reachable_ids = get_reachable_components(sbom_spec, parsed_data, spdx3_doc)
+    reachable_ids, connection_map = get_reachable_components(
+        sbom_spec, parsed_data, spdx3_doc
+    )
     all_doc_ids: set[str] = set()
 
     if sbom_spec == "spdx2":
@@ -44,9 +46,16 @@ def analyze_graph_connectivity(
         }
 
     floating_ids = all_doc_ids - reachable_ids
-    has_unknown_pointerns = not reachable_ids.issubset(all_doc_ids)
+    has_unknown_pointers = not reachable_ids.issubset(all_doc_ids)
 
-    return reachable_ids, floating_ids, has_unknown_pointerns
+    # Find exactly which edges point to unknown nodes
+    unknown_pointer_edges: dict[str, list[str]] = {}
+    for source_id, target_ids in connection_map.items():
+        missing_targets = [t for t in target_ids if t not in all_doc_ids]
+        if missing_targets:
+            unknown_pointer_edges[source_id] = missing_targets
+
+    return reachable_ids, floating_ids, unknown_pointer_edges, has_unknown_pointers
 
 
 def _build_spdx2_graph(spdx2_doc: "Document") -> tuple[list[str], dict[str, list[str]]]:
@@ -179,13 +188,16 @@ def _build_spdx3_graph(
 
 def get_reachable_components(
     sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None
-) -> set[str]:
+) -> tuple[set[str], dict[str, list[str]]]:
     """
     Get all components connected to the root by using Breadth-First Search.
+
+    Returns:
+        tuple: (reachable_component_ids, graph_connection_map)
     """
 
     if not parsed_data:
-        return set()
+        return set(), {}
 
     queue: list[str] = []
 
@@ -212,4 +224,4 @@ def get_reachable_components(
                     reachable_component_ids.add(target_id)
                     queue.append(target_id)
 
-    return reachable_component_ids
+    return reachable_component_ids, graph_connection_map

--- a/ntia_conformance_checker/graph_utils.py
+++ b/ntia_conformance_checker/graph_utils.py
@@ -4,7 +4,7 @@
 
 """Graph utilities for SPDX 2 and SPDX 3."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from spdx_python_model.bindings import v3_0_1 as spdx3
 from spdx_tools.spdx.model.relationship import RelationshipType
@@ -15,21 +15,52 @@ if TYPE_CHECKING:
     from spdx_tools.spdx.model.document import Document
 
 
-def _build_spdx2_graph(doc: "Document") -> tuple[list[str], dict[str, list[str]]]:
+def analyze_graph_connectivity(
+    sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None
+) -> tuple[set[str], set[str], bool]:
+    """
+    Analyzes the graph to find reachable nodes, floating nodes, and unknown pointers.
+
+    Returns:
+        tuple: (reachable_ids, floating_ids, has_unknown_pointers)
+    """
+    reachable_ids = get_reachable_components(sbom_spec, parsed_data, spdx3_doc)
+    all_doc_ids: set[str] = set()
+
+    if sbom_spec == "spdx2":
+        spdx2_doc = cast("Document", parsed_data)
+        all_doc_ids = {
+            pkg.spdx_id for pkg in spdx2_doc.packages if isinstance(pkg.spdx_id, str)
+        }
+    elif sbom_spec == "spdx3":
+        spdx3_doc_set = cast("spdx3.SHACLObjectSet", parsed_data)
+        all_doc_ids = {
+            getattr(obj, "spdxId")
+            for obj in spdx3_doc_set.objects
+            if isinstance(getattr(obj, "spdxId", None), str)
+        }
+
+    floating_ids = all_doc_ids - reachable_ids
+    has_unknown_pointerns = not reachable_ids.issubset(all_doc_ids)
+
+    return reachable_ids, floating_ids, has_unknown_pointerns
+
+
+def _build_spdx2_graph(spdx2_doc: "Document") -> tuple[list[str], dict[str, list[str]]]:
     """Build the initial queue and connection map for SPDX 2."""
     queue: list[str] = []
     graph_connection_map: dict[str, list[str]] = {}
 
-    if not doc.relationships:
+    if not spdx2_doc.relationships:
         return queue, graph_connection_map
 
     doc_id = "SPDXRef-DOCUMENT"
-    if getattr(doc, "creation_info", None) and getattr(
-        doc.creation_info, "spdx_id", None
+    if getattr(spdx2_doc, "creation_info", None) and getattr(
+        spdx2_doc.creation_info, "spdx_id", None
     ):
-        doc_id = doc.creation_info.spdx_id
+        doc_id = spdx2_doc.creation_info.spdx_id
 
-    for rel in doc.relationships:
+    for rel in spdx2_doc.relationships:
         source_id = rel.spdx_element_id
         target_id = rel.related_spdx_element_id
 
@@ -90,7 +121,7 @@ def _extract_spdx3_collection_edges(
 
 
 def _build_spdx3_graph(
-    doc: spdx3.SHACLObjectSet, spdx3_doc: spdx3.SpdxDocument | None
+    object_set: spdx3.SHACLObjectSet, spdx3_doc: spdx3.SpdxDocument | None
 ) -> tuple[list[str], dict[str, list[str]]]:
     """Build the initial queue and connection map for SPDX 3."""
     queue: list[str] = []
@@ -103,7 +134,7 @@ def _build_spdx3_graph(
                 queue.append(root_id)
 
     # Build the graph connection map
-    for obj in doc.objects:
+    for obj in object_set.objects:
         # Capture explicit relationships from Relationship objects
         if isinstance(obj, spdx3.Relationship):
             _extract_spdx3_relationship_edges(obj, graph_connection_map)
@@ -116,13 +147,13 @@ def _build_spdx3_graph(
 
 
 def get_reachable_components(
-    sbom_spec: str, doc: Any, spdx3_doc: Any = None
+    sbom_spec: str, parsed_data: Any, spdx3_doc: Any = None
 ) -> set[str]:
     """
     Get all components connected to the root by using Breadth-First Search.
     """
 
-    if not doc:
+    if not parsed_data:
         return set()
 
     queue: list[str] = []
@@ -132,11 +163,11 @@ def get_reachable_components(
 
     # SPDX 2
     if sbom_spec == "spdx2":
-        queue, graph_connection_map = _build_spdx2_graph(doc)
+        queue, graph_connection_map = _build_spdx2_graph(parsed_data)
 
     # SPDX 3
     if sbom_spec == "spdx3":
-        queue, graph_connection_map = _build_spdx3_graph(doc, spdx3_doc)
+        queue, graph_connection_map = _build_spdx3_graph(parsed_data, spdx3_doc)
 
     reachable_component_ids: set[str] = set(queue)
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -173,6 +173,7 @@ def iter_objects_with_property(
     object_set: spdx3.SHACLObjectSet,
     typ: type[spdx3.SHACLObject] = spdx3.Artifact,
     property_name: str = "spdxId",
+    reachable_ids: set[str] | None = None,
 ) -> Iterator[tuple[str, str, Any]]:
     """
     Yield (name, spdxId, property) for each SPDX 3 object.
@@ -181,6 +182,7 @@ def iter_objects_with_property(
         object_set (spdx3.SHACLObjectSet): The SHACLObjectSet to iterate over.
         typ (type[spdx3.SHACLObject]): The type of SPDX3 object
         property_name (str): The property name to retrieve.
+        reachable_ids (set[str] | None): A set of reachable SPDX IDs from root.
 
     Yields:
         Iterator[tuple[str, str, Any]]: A tuple containing the name,
@@ -190,6 +192,10 @@ def iter_objects_with_property(
     for obj in object_set.foreach_type(typ):
         name = (getattr(obj, "name", "") or "").strip()
         spdx_id = (getattr(obj, "spdxId", "") or "").strip()
+
+        if reachable_ids is not None and spdx_id not in reachable_ids:
+            continue
+
         property_ = getattr(obj, property_name, None)
         yield name, spdx_id, property_
 
@@ -233,27 +239,27 @@ def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Pac
     return packages
 
 
-def get_all_package_ids(object_set: spdx3.SHACLObjectSet) -> set[str]:
+def get_all_package_ids(
+    object_set: spdx3.SHACLObjectSet, reachable_ids: set[str] | None = None
+) -> set[str]:
     """Retrieve spdxId for all /Software/Package objects from an SHACLObjectSet."""
     return {
         spdx_id
         for _name, spdx_id, _ in iter_objects_with_property(
-            object_set,
-            spdx3.software_Package,
-            "spdxId",
+            object_set, spdx3.software_Package, "spdxId", reachable_ids
         )
         if spdx_id
     }
 
 
-def get_all_element_ids(object_set: spdx3.SHACLObjectSet) -> set[str]:
+def get_all_element_ids(
+    object_set: spdx3.SHACLObjectSet, reachable_ids: set[str] | None = None
+) -> set[str]:
     """Retrieve spdxId for all SPDX 3 Element objects from an SHACLObjectSet."""
     return {
         spdx_id
         for _name, spdx_id, _ in iter_objects_with_property(
-            object_set,
-            spdx3.Element,
-            "spdxId",
+            object_set, spdx3.Element, "spdxId", reachable_ids
         )
         if spdx_id
     }

--- a/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx2.json
+++ b/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx2.json
@@ -1,0 +1,44 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "name": "SPDX2-Orphan-Component-Test",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://swinslow.net/spdx-examples/spdx2-orphan",
+  "creationInfo": {
+    "comment": "",
+    "creators": [
+      "Person: Induwara"
+    ],
+    "created": "2026-07-01T12:00:00Z"
+  },
+  "packages": [
+    {
+      "name": "Valid-Root-Package",
+      "SPDXID": "SPDXRef-Package-Valid",
+      "versionInfo": "1.0.0",
+      "supplier": "Organization: Test Supplier",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "name": "",
+      "SPDXID": "SPDXRef-Package-Orphan",
+      "versionInfo": "9.9.9",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-Valid"
+    }
+  ]
+}

--- a/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx3.json
+++ b/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx3.json
@@ -1,0 +1,86 @@
+{
+  "@context": "https://spdx.github.io/spdx-spec/v3.0.1/rdf/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Person1"
+      ],
+      "created": "2026-07-01T12:00:00Z"
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Person1",
+      "creationInfo": "_:creationinfo",
+      "name": "Induwara"
+    },
+    {
+      "type": "Organization",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Supplier",
+      "creationInfo": "_:creationinfo",
+      "name": "Test Supplier"
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "CC0-1.0"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://swinslow.net/spdx-examples/document1",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "software"
+      ],
+      "dataLicense": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
+      "rootElement": [
+        "https://swinslow.net/spdx-examples/SBOM1"
+      ],
+      "name": "Orphan-Component-Test-SBOM"
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "https://swinslow.net/spdx-examples/SBOM1",
+      "creationInfo": "_:creationinfo",
+      "profileConformance": [
+        "core",
+        "software"
+      ],
+      "rootElement": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Package-Valid"
+      ],
+      "software_sbomType": [
+        "analyzed"
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Package-Valid",
+      "creationInfo": "_:creationinfo",
+      "name": "Valid-Root-Package",
+      "software_packageVersion": "1.0.0",
+      "suppliedBy": "https://swinslow.net/spdx-examples/SPDXRef-Supplier"
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Package-Orphan",
+      "creationInfo": "_:creationinfo",
+      "name": "",
+      "software_packageVersion": "9.9.9"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-RelValid",
+      "creationInfo": "_:creationinfo",
+      "relationshipType": "describes",
+      "from": "https://swinslow.net/spdx-examples/document1",
+      "to": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Package-Valid"
+      ]
+    }
+  ]
+}

--- a/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx3.json
+++ b/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx3.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://spdx.github.io/spdx-spec/v3.0.1/rdf/spdx-context.jsonld",
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
   "@graph": [
     {
       "type": "CreationInfo",

--- a/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx3.json
+++ b/tests/data/graph_connectivity/disconnected_component/disconnected_component_spdx3.json
@@ -73,8 +73,26 @@
       "software_packageVersion": "9.9.9"
     },
     {
+      "type": "software_Package",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Package-Sub",
+      "name": "Valid-Sub-Package",
+      "software_packageVersion": "2.0",
+      "suppliedBy": "https://swinslow.net/spdx-examples/SPDXRef-Supplier",
+      "creationInfo": "_:creationinfo"
+    },
+    {
       "type": "Relationship",
-      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-RelValid",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-RelValid-1",
+      "relationshipType": "contains",
+      "from": "https://swinslow.net/spdx-examples/SPDXRef-Package-Valid",
+      "to": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Package-Sub"
+      ],
+      "creationInfo": "_:creationinfo"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-RelValid-2",
       "creationInfo": "_:creationinfo",
       "relationshipType": "describes",
       "from": "https://swinslow.net/spdx-examples/document1",

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx2.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx2.json
@@ -1,9 +1,9 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "spdxVersion": "SPDX-2.3",
-  "name": "SPDX2-Dangling-Dependency-Test",
+  "name": "SPDX2-Unknown-Component-Dependency-Test",
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://swinslow.net/spdx-examples/spdx2-dangling",
+  "documentNamespace": "https://swinslow.net/spdx-examples/spdx2-unknown",
   "creationInfo": {
     "comment": "",
     "creators": [

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx2.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx2.json
@@ -1,0 +1,33 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "name": "SPDX2-Dangling-Dependency-Test",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://swinslow.net/spdx-examples/spdx2-dangling",
+  "creationInfo": {
+    "comment": "",
+    "creators": [
+      "Person: Induwara"
+    ],
+    "created": "2026-07-01T12:00:00Z"
+  },
+  "packages": [
+    {
+      "name": "Root-Application-Package",
+      "SPDXID": "SPDXRef-Package-A",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-B"
+    }
+  ]
+}

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx2.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx2.json
@@ -16,17 +16,23 @@
       "name": "Root-Application-Package",
       "SPDXID": "SPDXRef-Package-A",
       "versionInfo": "1.0.0",
+      "supplier": "Organization: Test Supplier",
       "downloadLocation": "NOASSERTION",
       "filesAnalyzed": false,
-      "licenseConcluded": "NOASSERTION",
-      "licenseDeclared": "NOASSERTION",
-      "copyrightText": "NOASSERTION"
+      "licenseConcluded": "CC0-1.0",
+      "licenseDeclared": "CC0-1.0",
+      "copyrightText": "Copyright 2026 Induwara"
     }
   ],
   "relationships": [
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-A"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-A",
+      "relationshipType": "DEPENDS_ON",
       "relatedSpdxElement": "SPDXRef-Package-B"
     }
   ]

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
@@ -1,0 +1,53 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "@id": "_:creationInfo_0",
+      "type": "CreationInfo",
+      "specVersion": "3.0.1",
+      "createdBy": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Person1"
+      ],
+      "created": "2026-07-01T12:00:00Z"
+    },
+    {
+      "@id": "https://swinslow.net/spdx-examples/document1",
+      "type": "SpdxDocument",
+      "dataLicense": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
+      "rootElement": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Package-A"
+      ],
+      "name": "Dangling-Dependency-Test-SBOM",
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "@id": "https://swinslow.net/spdx-examples/SPDXRef-Person1",
+      "type": "Person",
+      "name": "Induwara",
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "@id": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
+      "type": "simplelicensing_LicenseExpression",
+      "simplelicensing_licenseExpression": "CC0-1.0",
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "@id": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
+      "type": "software_Package",
+      "name": "Root-Application-Package",
+      "software_packageVersion": "1.0.0",
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "@id": "https://swinslow.net/spdx-examples/SPDXRef-Rel1",
+      "type": "Relationship",
+      "relationshipType": "describes",
+      "from": "https://swinslow.net/spdx-examples/document1",
+      "to": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Package-B"
+      ],
+      "creationInfo": "_:creationInfo_0"
+    }
+  ]
+}

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
@@ -17,7 +17,7 @@
       "rootElement": [
         "https://swinslow.net/spdx-examples/SPDXRef-Package-A"
       ],
-      "name": "Dangling-Dependency-Test-SBOM",
+      "name": "Unknown-Component-Dependency-Test-SBOM",
       "creationInfo": "_:creationInfo_0"
     },
     {

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
@@ -51,12 +51,41 @@
       "creationInfo": "_:creationInfo_0"
     },
     {
-      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel-License",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Package-Decoy",
+      "type": "software_Package",
+      "name": "Decoy-Sub-Package",
+      "suppliedBy": "https://swinslow.net/spdx-examples/SPDXRef-Person1",
+      "software_packageVersion": "1.0.0",
+      "software_copyrightText": "NOASSERTION",
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel-License-1",
       "type": "Relationship",
       "relationshipType": "hasConcludedLicense",
       "from": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
       "to": [
         "https://swinslow.net/spdx-examples/SPDXRef-CC0"
+      ],
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel-License-2",
+      "type": "Relationship",
+      "relationshipType": "hasConcludedLicense",
+      "from": "https://swinslow.net/spdx-examples/SPDXRef-Package-Decoy",
+      "to": [
+        "https://swinslow.net/spdx-examples/SPDXRef-CC0"
+      ],
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel-Valid-Decoy",
+      "type": "Relationship",
+      "relationshipType": "contains",
+      "from": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
+      "to": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Package-Decoy"
       ],
       "creationInfo": "_:creationInfo_0"
     },

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
@@ -11,7 +11,7 @@
       "created": "2026-07-01T12:00:00Z"
     },
     {
-      "@id": "https://swinslow.net/spdx-examples/document1",
+      "spdxId": "https://swinslow.net/spdx-examples/document1",
       "type": "SpdxDocument",
       "dataLicense": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
       "rootElement": [
@@ -21,26 +21,26 @@
       "creationInfo": "_:creationInfo_0"
     },
     {
-      "@id": "https://swinslow.net/spdx-examples/SPDXRef-Person1",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Person1",
       "type": "Person",
       "name": "Induwara",
       "creationInfo": "_:creationInfo_0"
     },
     {
-      "@id": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
       "type": "simplelicensing_LicenseExpression",
       "simplelicensing_licenseExpression": "CC0-1.0",
       "creationInfo": "_:creationInfo_0"
     },
     {
-      "@id": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
       "type": "software_Package",
       "name": "Root-Application-Package",
       "software_packageVersion": "1.0.0",
       "creationInfo": "_:creationInfo_0"
     },
     {
-      "@id": "https://swinslow.net/spdx-examples/SPDXRef-Rel1",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel1",
       "type": "Relationship",
       "relationshipType": "describes",
       "from": "https://swinslow.net/spdx-examples/document1",

--- a/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
+++ b/tests/data/graph_connectivity/missing_relationship_target/missing_relationship_target_spdx3.json
@@ -15,7 +15,7 @@
       "type": "SpdxDocument",
       "dataLicense": "https://swinslow.net/spdx-examples/SPDXRef-CC0",
       "rootElement": [
-        "https://swinslow.net/spdx-examples/SPDXRef-Package-A"
+        "https://swinslow.net/spdx-examples/SPDXRef-Sbom1"
       ],
       "name": "Unknown-Component-Dependency-Test-SBOM",
       "creationInfo": "_:creationInfo_0"
@@ -33,17 +33,38 @@
       "creationInfo": "_:creationInfo_0"
     },
     {
-      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
-      "type": "software_Package",
-      "name": "Root-Application-Package",
-      "software_packageVersion": "1.0.0",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Sbom1",
+      "type": "software_Sbom",
+      "software_sbomType": ["analyzed"],
+      "rootElement": [
+        "https://swinslow.net/spdx-examples/SPDXRef-Package-A"
+      ],
       "creationInfo": "_:creationInfo_0"
     },
     {
-      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel1",
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
+      "type": "software_Package",
+      "name": "Root-Application-Package",
+      "suppliedBy": "https://swinslow.net/spdx-examples/SPDXRef-Person1",
+      "software_packageVersion": "1.0.0",
+      "software_copyrightText": "NOASSERTION",
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel-License",
       "type": "Relationship",
-      "relationshipType": "describes",
-      "from": "https://swinslow.net/spdx-examples/document1",
+      "relationshipType": "hasConcludedLicense",
+      "from": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
+      "to": [
+        "https://swinslow.net/spdx-examples/SPDXRef-CC0"
+      ],
+      "creationInfo": "_:creationInfo_0"
+    },
+    {
+      "spdxId": "https://swinslow.net/spdx-examples/SPDXRef-Rel-Dangling",
+      "type": "Relationship",
+      "relationshipType": "contains",
+      "from": "https://swinslow.net/spdx-examples/SPDXRef-Package-A",
       "to": [
         "https://swinslow.net/spdx-examples/SPDXRef-Package-B"
       ],

--- a/tests/data/other_tests/test_components_without_functions.spdx
+++ b/tests/data/other_tests/test_components_without_functions.spdx
@@ -225,6 +225,11 @@ Relationship: SPDXRef-CommonsLangSrc GENERATED_FROM NOASSERTION
 Relationship: SPDXRef-JenaLib CONTAINS SPDXRef-Package
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-File
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package1
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package2
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package3
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package4
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package5
 
 ## Annotations
 Annotator: Person: Jane Doe

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -237,7 +237,7 @@ def test_sbomchecker_missing_supplier_name(test_file: str) -> None:
     assert not sbom.components_without_versions
     TestCase().assertCountEqual(
         _component_names(sbom.components_without_suppliers),
-        ["glibc", "Jena", "Saxon"],
+        ["glibc", "Saxon"],
     )
     assert not sbom.components_without_identifiers
     assert not sbom.compliant

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -647,3 +647,52 @@ def test_deprecation_parsing_error() -> None:
     assert len(caught) == 1
     assert issubclass(caught[0].category, DeprecationWarning)
     assert "parsing_error" in str(caught[0].message)
+
+
+### Test missing relationship target
+
+dirname = os.path.join(
+    os.path.dirname(__file__),
+    "data",
+    "graph_connectivity",
+    "missing_relationship_target",
+)
+test_files_missing_target = [os.path.join(dirname, fn) for fn in os.listdir(dirname)]
+
+
+@pytest.mark.parametrize("test_file", test_files_missing_target)
+def test_missing_relationship_target(test_file: str) -> None:
+    """Test that a relationship node points to an ID that does not exist in the document."""
+    sbom = sbom_checker.SbomChecker(test_file)
+    assert sbom.compliant is False
+
+
+### Test diconnected graph
+
+dirname = os.path.join(
+    os.path.dirname(__file__), "data", "graph_connectivity", "disconnected_component"
+)
+test_files_disconnected = [os.path.join(dirname, fn) for fn in os.listdir(dirname)]
+
+
+@pytest.mark.parametrize("test_file", test_files_disconnected)
+def test_disconnected_component(test_file: str) -> None:
+    """Test that the BFS algorithm successfully isolates floating components."""
+    # Dynamically set the spec based on the filename
+    spec = "spdx3" if "spdx3" in test_file else "spdx2"
+    sbom = sbom_checker.SbomChecker(test_file, sbom_spec=spec)
+
+    # Assert the valid root package was successfully reached
+    assert any(
+        "Package-Valid" in spdx_id for spdx_id in sbom.reachable_component_ids
+    ), "The root package should be in the reachable list."
+
+    # Assert the orphan package was successfully caught as noise
+    assert any(
+        "Package-Orphan" in spdx_id for spdx_id in sbom.floating_component_ids
+    ), "The orphan package should be isolated in the floating list."
+
+    # Assert the orphan package was NOT processed for compliance
+    assert not any(
+        "Package-Orphan" in spdx_id for spdx_id in sbom.reachable_component_ids
+    ), "The orphan package MUST NOT be in the reachable list."

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -667,7 +667,7 @@ def test_missing_relationship_target(test_file: str) -> None:
     assert sbom.compliant is False
 
 
-### Test diconnected graph
+### Test disconnected graph
 
 dirname = os.path.join(
     os.path.dirname(__file__), "data", "graph_connectivity", "disconnected_component"


### PR DESCRIPTION
This PR replaces the global search component logic with a Bread-First Search(BFS) graph traversal logic.

Previously, the checker evaluated all components present in the whole document which led to false compliance failures when document contained disconnected or "floating" subgraphs. Moreover, it didn't have the ability to identify for relationships pointing to non-existent components.

This PR ensures that only components connected to the root SpdxDocument are evaluated for compliance and resolving both of these vulnerabilities(disconnected components, missing relationship target components)

**Resolves** #409 and #410 

**Key changes**
- Introduced `get_reachable_components()` , a BFS graph traversal utility that builds a relationship edge map and isolates all reachable nodes from the root for both SPDX2 and SPDX3.
- Added `reachable_component_ids` and `floating_component_ids` properties.
- Added active logging to warn users of disconnected floating elements and error logs for missing pointers.
- Added targeted test fixtures in `tests/data/graph_connectivity/` for both spdx2 and spdx3.
- Added `test_disconnected_component` to verify that floating(disconnected) nodes are successfully isolated into the noise list and bypass NTIA validation.
- Added `test_missing_relationship_target` to verify that relationships pointing to unknown component IDs, correctly trigger a Disconnected pointer failure.