### PR TITLE
Fix SPDX 3 count for get_total_number_components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning][semver].
   and properly unbox `ListProxy` objects.
   This changes the return signature to `Iterator[tuple[str, list[str]]]`
   ([#398])
+- Fixed `BaseChecker.get_total_number_components` for SPDX 3 documents
+  to return the total count of packages (including `Package` and its subclasses
+  such as `AIPackage` and `DatasetPackage`) instead of all SHACL objects.
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,15 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 - BREAKING CHANGE:
-  Fixed `iter_relationships_by_type` in `spdx3_utils.py`
-  to correctly handle `1..*` cardinality for relationship targets
-  and properly unbox `ListProxy` objects.
-  This changes the return signature to `Iterator[tuple[str, list[str]]]`
-  ([#398])
-- Fixed `BaseChecker.get_total_number_components` for SPDX 3 documents
-  to return the total count of packages (including `Package` and its subclasses
-  such as `AIPackage` and `DatasetPackage`) instead of all SHACL objects.
+  Correct relationship target cardinality (`1..*`) and `ListProxy` unboxing
+  in `iter_relationships_by_type`, changing the return signature to
+  `Iterator[tuple[str, list[str]]]` ([#398])
+- Restrict `BaseChecker.get_total_number_components` in SPDX 3 to count
+  packages and subclasses (`AIPackage`, `DatasetPackage`) instead of all
+  SHACL objects ([#421])
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
+[#421]: https://github.com/spdx/ntia-conformance-checker/pull/421
 
 ## [5.0.3] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,17 +16,14 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 - BREAKING CHANGE:
-  Correct relationship target cardinality (`1..*`) and `ListProxy` unboxing
-  in `iter_relationships_by_type`, changing the return signature to
-  `Iterator[tuple[str, list[str]]]` ([#398])
-- Restrict `BaseChecker.get_total_number_components` in SPDX 3 to count
-  packages and subclasses (`AIPackage`, `DatasetPackage`) instead of all
-  SHACL objects ([#421])
-- Handle `OSError` when writing JSON output file in `print_output` ([#424])
+  Fixed `iter_relationships_by_type` in `spdx3_utils.py`
+  to correctly handle `1..*` cardinality for relationship targets
+  and properly unbox `ListProxy` objects.
+  This changes the return signature to `Iterator[tuple[str, list[str]]]`
+  ([#398])
+- Handle `OSError` when writing JSON output file in `print_output`
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
-[#421]: https://github.com/spdx/ntia-conformance-checker/pull/421
-[#424]: https://github.com/spdx/ntia-conformance-checker/pull/424
 
 ## [5.0.3] - 2026-06-02
 

--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -33,6 +33,7 @@ from .report import (
     report_text,
 )
 from .spdx3_utils import (
+    get_all_packages,
     has_package_dependency_relationship,
     iter_objects_with_property,
     iter_relationships_by_type,
@@ -764,6 +765,10 @@ class BaseChecker(ABC):
         """
         Retrieve total number of components.
 
+        For SPDX 2, this returns the total count of packages.
+        For SPDX 3, this returns the total count of packages and package
+        subclasses (including AIPackage and DatasetPackage).
+
         Returns:
             int: The total number of components.
         """
@@ -780,8 +785,7 @@ class BaseChecker(ABC):
         # SPDX 3
         if self.sbom_spec == "spdx3":
             self.doc = cast("spdx3.SHACLObjectSet", self.doc)
-            objects: set[spdx3.SHACLObject] = getattr(self.doc, "objects", set())
-            return len(objects)
+            return len(get_all_packages(self.doc))
 
         return 0
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -232,7 +232,12 @@ def iter_relationships_by_type(
 
 
 def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Package]:
-    """Retrieve all /Software/Package objects from an SHACLObjectSet."""
+    """
+    Retrieve all /Software/Package objects from an SHACLObjectSet.
+
+    This includes instances of software_Package and its subclasses,
+    such as ai_AIPackage and dataset_DatasetPackage.
+    """
     packages: set[spdx3.software_Package] = set(
         object_set.foreach_type(spdx3.software_Package)
     )

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -846,7 +846,8 @@ def test_get_total_number_components_spdx2() -> None:
 
 
 def test_get_total_number_components_spdx3_packages_and_subclasses() -> None:
-    """Test get_total_number_components returns 3 for SPDX 3 with Package, AIPackage, DatasetPackage."""
+    """Test get_total_number_components returns 3
+    for SPDX 3 with Package, AIPackage, DatasetPackage."""
     object_set = spdx3.SHACLObjectSet()
     creation_info = _create_test_spdx3_creation_info()
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -8,15 +8,23 @@
 
 import os
 import warnings
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest import TestCase
 
 import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
+from spdx_tools.spdx.model.document import (
+    CreationInfo as SPDX2CreationInfo,
+)
+from spdx_tools.spdx.model.document import (
+    Document,
+)
 
 import ntia_conformance_checker.sbom_checker as sbom_checker
 from ntia_conformance_checker import FSCT3Checker, NTIAChecker
 from ntia_conformance_checker.spdx3_utils import (
+    get_all_packages,
     has_package_dependency_relationship,
     validate_spdx3_data,
 )
@@ -696,3 +704,204 @@ def test_disconnected_component(test_file: str) -> None:
     assert not any(
         "Package-Orphan" in spdx_id for spdx_id in sbom.reachable_component_ids
     ), "The orphan package MUST NOT be in the reachable list."
+
+
+### Test get_all_packages and get_total_number_components
+
+
+def _create_test_spdx3_creation_info(
+    base_iri: str = "http://example.com/spdx3",
+) -> spdx3.CreationInfo:
+    """Create a minimal valid SPDX 3 CreationInfo instance for testing."""
+    return spdx3.CreationInfo(
+        _id=f"{base_iri}/creation-info",
+        specVersion="3.0.1",
+        created=datetime.now(timezone.utc),
+        createdBy=[f"{base_iri}/actor1"],
+        createdUsing=[f"{base_iri}/tool1"],
+    )
+
+
+def test_get_all_packages_empty() -> None:
+    """Test get_all_packages returns empty set for empty SHACLObjectSet."""
+    object_set = spdx3.SHACLObjectSet()
+    packages = get_all_packages(object_set)
+    assert packages == set()
+    assert len(packages) == 0
+
+
+def test_get_all_packages_non_packages_only() -> None:
+    """Test get_all_packages ignores non-package elements."""
+    object_set = spdx3.SHACLObjectSet()
+    creation_info = _create_test_spdx3_creation_info()
+
+    doc = spdx3.SpdxDocument(
+        _id="http://example.com/spdx3/doc",
+        creationInfo=creation_info,
+        name="test-doc",
+    )
+    sbom = spdx3.software_Sbom(
+        _id="http://example.com/spdx3/sbom",
+        creationInfo=creation_info,
+        name="test-sbom",
+    )
+    file = spdx3.software_File(
+        _id="http://example.com/spdx3/file",
+        creationInfo=creation_info,
+        name="test-file",
+    )
+    agent = spdx3.Agent(
+        _id="http://example.com/spdx3/agent",
+        creationInfo=creation_info,
+        name="test-agent",
+    )
+    rel = spdx3.Relationship(
+        _id="http://example.com/spdx3/rel",
+        creationInfo=creation_info,
+        relationshipType=f"{SPDX3_RELATIONSHIP_TYPE_BASE}/contains",
+        from_="http://example.com/spdx3/doc",
+        to=["http://example.com/spdx3/file"],
+    )
+
+    object_set.add(doc)
+    object_set.add(sbom)
+    object_set.add(file)
+    object_set.add(agent)
+    object_set.add(rel)
+
+    packages = get_all_packages(object_set)
+    assert packages == set()
+
+
+def test_get_all_packages_with_package_and_subclasses() -> None:
+    """Test get_all_packages retrieves Package, AIPackage, and DatasetPackage."""
+    object_set = spdx3.SHACLObjectSet()
+    creation_info = _create_test_spdx3_creation_info()
+
+    pkg = spdx3.software_Package(
+        _id="http://example.com/spdx3/pkg1",
+        creationInfo=creation_info,
+        name="regular-package",
+    )
+    ai_pkg = spdx3.ai_AIPackage(
+        _id="http://example.com/spdx3/ai-pkg1",
+        creationInfo=creation_info,
+        name="ai-package",
+    )
+    data_pkg = spdx3.dataset_DatasetPackage(
+        _id="http://example.com/spdx3/data-pkg1",
+        creationInfo=creation_info,
+        name="dataset-package",
+    )
+    file = spdx3.software_File(
+        _id="http://example.com/spdx3/file1",
+        creationInfo=creation_info,
+        name="file1",
+    )
+
+    object_set.add(pkg)
+    object_set.add(ai_pkg)
+    object_set.add(data_pkg)
+    object_set.add(file)
+
+    packages = get_all_packages(object_set)
+    assert len(packages) == 3
+    package_names = {getattr(p, "name") for p in packages}
+    assert package_names == {"regular-package", "ai-package", "dataset-package"}
+
+
+def test_get_total_number_components_none_or_unknown_spec() -> None:
+    """Test get_total_number_components when doc is None or unknown spec."""
+    checker = sbom_checker.SbomChecker(test_files[0])
+    checker.doc = None
+    assert checker.get_total_number_components() == 0
+
+    checker.doc = spdx3.SHACLObjectSet()
+    checker.sbom_spec = "unknown_spec"
+    assert checker.get_total_number_components() == 0
+
+
+def test_get_total_number_components_spdx2() -> None:
+    """Test get_total_number_components for SPDX 2 documents."""
+    filepath = os.path.join(
+        os.path.dirname(__file__), "data", "other_tests", "SPDXSBOMExample.spdx.yml"
+    )
+    sbom = sbom_checker.SbomChecker(filepath)
+    assert sbom.get_total_number_components() == 3
+
+    creation_info = SPDX2CreationInfo(
+        spdx_version="SPDX-2.3",
+        spdx_id="SPDXRef-DOCUMENT",
+        name="empty-doc",
+        document_namespace="https://example.com/spdx/doc",
+        created=datetime.now(timezone.utc),
+        creators=[],
+    )
+    doc_empty = Document(creation_info=creation_info, packages=[])
+    checker = sbom_checker.SbomChecker(filepath)
+    checker.doc = doc_empty
+    checker.sbom_spec = "spdx2"
+    assert checker.get_total_number_components() == 0
+
+
+def test_get_total_number_components_spdx3_packages_and_subclasses() -> None:
+    """Test get_total_number_components for SPDX 3 with Package, AIPackage, DatasetPackage."""
+    object_set = spdx3.SHACLObjectSet()
+    creation_info = _create_test_spdx3_creation_info()
+
+    doc = spdx3.SpdxDocument(
+        _id="http://example.com/spdx3/doc",
+        creationInfo=creation_info,
+        name="test-spdx3-doc",
+    )
+    pkg = spdx3.software_Package(
+        _id="http://example.com/spdx3/pkg",
+        creationInfo=creation_info,
+        name="pkg",
+    )
+    ai_pkg = spdx3.ai_AIPackage(
+        _id="http://example.com/spdx3/aipkg",
+        creationInfo=creation_info,
+        name="aipkg",
+    )
+    dataset_pkg = spdx3.dataset_DatasetPackage(
+        _id="http://example.com/spdx3/datasetpkg",
+        creationInfo=creation_info,
+        name="datasetpkg",
+    )
+    file = spdx3.software_File(
+        _id="http://example.com/spdx3/file",
+        creationInfo=creation_info,
+        name="file",
+    )
+
+    object_set.add(doc)
+    object_set.add(pkg)
+    object_set.add(ai_pkg)
+    object_set.add(dataset_pkg)
+    object_set.add(file)
+
+    test_file = Path(__file__).parent / "data" / "spdx3" / "has_sbom.json"
+    checker = sbom_checker.SbomChecker(str(test_file), sbom_spec="spdx3")
+    checker.doc = object_set
+    assert checker.get_total_number_components() == 3
+
+
+def test_get_total_number_components_spdx3_files() -> None:
+    """Test get_total_number_components with real SPDX 3 test files."""
+    spdx3_files_expected = [
+        ("has_sbom.json", 4),
+        ("has_no_sbom.json", 1),
+        ("no_elements_missing.json", 1),
+        ("missing_supplier_name.json", 1),
+        ("missing_version.json", 1),
+        ("package_dependency_relationship.json", 2),
+    ]
+
+    for filename, expected_count in spdx3_files_expected:
+        test_file = Path(__file__).parent / "data" / "spdx3" / filename
+        sbom = sbom_checker.SbomChecker(str(test_file), sbom_spec="spdx3")
+        assert sbom.get_total_number_components() == expected_count, (
+            f"Expected {expected_count} components in {filename}, "
+            f"got {sbom.get_total_number_components()}"
+        )

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -731,7 +731,8 @@ def test_get_all_packages_empty() -> None:
 
 
 def test_get_all_packages_non_packages_only() -> None:
-    """Test get_all_packages ignores non-package elements."""
+    """Test get_all_packages returns empty set for SHACLObjectSet that
+    contains only non-package elements."""
     object_set = spdx3.SHACLObjectSet()
     creation_info = _create_test_spdx3_creation_info()
 
@@ -822,7 +823,7 @@ def test_get_total_number_components_none_or_unknown_spec() -> None:
 
 
 def test_get_total_number_components_spdx2() -> None:
-    """Test get_total_number_components for SPDX 2 documents."""
+    """Test get_total_number_components returns 0 for empty SPDX 2 documents."""
     filepath = os.path.join(
         os.path.dirname(__file__), "data", "other_tests", "SPDXSBOMExample.spdx.yml"
     )
@@ -845,7 +846,7 @@ def test_get_total_number_components_spdx2() -> None:
 
 
 def test_get_total_number_components_spdx3_packages_and_subclasses() -> None:
-    """Test get_total_number_components for SPDX 3 with Package, AIPackage, DatasetPackage."""
+    """Test get_total_number_components returns 3 for SPDX 3 with Package, AIPackage, DatasetPackage."""
     object_set = spdx3.SHACLObjectSet()
     creation_info = _create_test_spdx3_creation_info()
 


### PR DESCRIPTION
Should only count the packages, not every SHACL objects.

Change from `len(objects)`
to `len(get_all_packages(self.doc))`
