### PR TITLE
Add a missing space to error message

### DIFF
--- a/ntia_conformance_checker/base_checker.py
+++ b/ntia_conformance_checker/base_checker.py
@@ -417,7 +417,7 @@ class BaseChecker(ABC):
             error_msg = (
                 "To have SBOM type (SBOM generation context) information, "
                 "the rootElement of the SpdxDocument shall be of type "
-                "/Software/Sbom."
+                "/Software/Sbom. "
                 f"Found: {type(root_elem).__name__!r}"
             )
             context = ValidationContext(parent_id=doc_id, spdx_id=root_elem_id)


### PR DESCRIPTION
Currently the error message is:

```
/Software/Sbom.Found:
```

insert a space to make it:

```
/Software/Sbom. Found:
```
