### PR TITLE
Fix get_packages_from_bom() to return only Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ and this project adheres to [Semantic Versioning][semver].
   This changes the return signature to `Iterator[tuple[str, list[str]]]`
   ([#398])
 - Filter `get_packages_from_bom` to return only package instances from
-  BOM root elements and support multi-root BOMs ([#422])
+  BOM root elements and support multi-root BOMs ([#423])
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
-[#422]: https://github.com/spdx/ntia-conformance-checker/pull/422
+[#423]: https://github.com/spdx/ntia-conformance-checker/pull/423
 
 ## [5.0.3] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning][semver].
   and properly unbox `ListProxy` objects.
   This changes the return signature to `Iterator[tuple[str, list[str]]]`
   ([#398])
-- Filter `get_packages_from_bom` to return only package instances from
-  BOM root elements and support multi-root BOMs ([#423])
+- Filter `get_packages_from_bom` and `get_boms_from_spdx_document` to return
+  matching instances (empty list on none) and support multi-root BOMs ([#423])
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
 [#423]: https://github.com/spdx/ntia-conformance-checker/pull/423

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,9 @@ and this project adheres to [Semantic Versioning][semver].
   ([#398])
 - Filter `get_packages_from_bom` and `get_boms_from_spdx_document` to return
   matching instances (empty list on none) and support multi-root BOMs ([#423])
-- Handle `OSError` when writing JSON output file in `print_output` ([#424])
+- Handle `OSError` when writing JSON output file in `print_output`
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
-[#423]: https://github.com/spdx/ntia-conformance-checker/pull/423
-[#424]: https://github.com/spdx/ntia-conformance-checker/pull/424
 
 ## [5.0.3] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ and this project adheres to [Semantic Versioning][semver].
   and properly unbox `ListProxy` objects.
   This changes the return signature to `Iterator[tuple[str, list[str]]]`
   ([#398])
-- Filter `get_packages_from_bom` and `get_boms_from_spdx_document` to return
-  matching instances (empty list on none) and support multi-root BOMs ([#423])
 - Handle `OSError` when writing JSON output file in `print_output`
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ and this project adheres to [Semantic Versioning][semver].
   and properly unbox `ListProxy` objects.
   This changes the return signature to `Iterator[tuple[str, list[str]]]`
   ([#398])
+- Filter `get_packages_from_bom` to return only package instances from
+  BOM root elements and support multi-root BOMs ([#422])
 
 [#398]: https://github.com/spdx/ntia-conformance-checker/pull/398
+[#422]: https://github.com/spdx/ntia-conformance-checker/pull/422
 
 ## [5.0.3] - 2026-06-02
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -127,7 +127,7 @@ def validate_spdx3_data(
 
 def get_boms_from_spdx_document(
     spdx_doc: spdx3.SpdxDocument | None,
-) -> list[spdx3.Bom] | None:
+) -> list[spdx3.Bom]:
     """
     Retrieve the BOMs that are rootElements of an SPDX 3 SpdxDocument.
 
@@ -135,21 +135,18 @@ def get_boms_from_spdx_document(
         spdx_doc (spdx3.SpdxDocument | None): The SPDX 3 SpdxDocument.
 
     Returns:
-        list[spdx3.Bom] | None: A list of BOMs if found, otherwise None.
+        list[spdx3.Bom]: A list of BOMs if found, otherwise an empty list.
     """
     if not spdx_doc:
-        return None
+        return []
 
-    root_elements: list[spdx3.Bom] = getattr(spdx_doc, "rootElement", [])
-    if not root_elements:
-        return None
-
-    return root_elements
+    root_elements: list[Any] = getattr(spdx_doc, "rootElement", [])
+    return [elem for elem in root_elements if isinstance(elem, spdx3.Bom)]
 
 
 def get_packages_from_bom(
     bom: spdx3.Bom | None,
-) -> list[spdx3.software_Package] | None:
+) -> list[spdx3.software_Package]:
     """
     Retrieve the /Software/Packages that are rootElements of an SPDX 3 BOM.
 
@@ -157,19 +154,13 @@ def get_packages_from_bom(
         bom (spdx3.Bom | None): The SPDX 3 Bom.
 
     Returns:
-        list[spdx3.software_Package] | None: A list of packages if found, otherwise None.
+        list[spdx3.software_Package]: A list of packages if found, otherwise an empty list.
     """
     if not bom:
-        return None
+        return []
 
     root_elements: list[Any] = getattr(bom, "rootElement", [])
-    packages: list[spdx3.software_Package] = [
-        elem for elem in root_elements if isinstance(elem, spdx3.software_Package)
-    ]
-    if not packages:
-        return None
-
-    return packages
+    return [elem for elem in root_elements if isinstance(elem, spdx3.software_Package)]
 
 
 def iter_objects_with_property(

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -162,11 +162,14 @@ def get_packages_from_bom(
     if not bom:
         return None
 
-    root_elements: list[spdx3.software_Package] = getattr(bom, "rootElement", [])
-    if not root_elements or len(root_elements) != 1:
+    root_elements: list[Any] = getattr(bom, "rootElement", [])
+    packages: list[spdx3.software_Package] = [
+        elem for elem in root_elements if isinstance(elem, spdx3.software_Package)
+    ]
+    if not packages:
         return None
 
-    return root_elements
+    return packages
 
 
 def iter_objects_with_property(

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -718,8 +718,8 @@ def _create_test_spdx3_creation_info(
 
 
 def test_get_packages_from_bom_none_or_empty() -> None:
-    """Test get_packages_from_bom returns None for None or empty rootElement."""
-    assert get_packages_from_bom(None) is None
+    """Test get_packages_from_bom returns empty list for None or empty rootElement."""
+    assert not get_packages_from_bom(None)
 
     creation_info = _create_test_spdx3_creation_info()
     bom_empty = spdx3.software_Sbom(
@@ -727,11 +727,11 @@ def test_get_packages_from_bom_none_or_empty() -> None:
         creationInfo=creation_info,
         name="bom-empty",
     )
-    assert get_packages_from_bom(bom_empty) is None
+    assert not get_packages_from_bom(bom_empty)
 
 
 def test_get_packages_from_bom_non_packages_only() -> None:
-    """Test get_packages_from_bom returns None when rootElements contain no packages."""
+    """Test get_packages_from_bom returns empty list when rootElements contain no packages."""
     creation_info = _create_test_spdx3_creation_info()
     file = spdx3.software_File(
         _id="http://example.com/spdx3/file1",
@@ -744,7 +744,7 @@ def test_get_packages_from_bom_non_packages_only() -> None:
         name="bom",
         rootElement=[file],
     )
-    assert get_packages_from_bom(bom) is None
+    assert not get_packages_from_bom(bom)
 
 
 def test_get_packages_from_bom_filters_only_packages_and_subclasses() -> None:
@@ -778,14 +778,13 @@ def test_get_packages_from_bom_filters_only_packages_and_subclasses() -> None:
     )
 
     packages = get_packages_from_bom(bom)
-    assert packages is not None
     assert len(packages) == 3
     assert packages == [pkg, ai_pkg, data_pkg]
 
 
 def test_get_boms_from_spdx_document() -> None:
     """Test get_boms_from_spdx_document retrieves rootElements of SpdxDocument."""
-    assert get_boms_from_spdx_document(None) is None
+    assert not get_boms_from_spdx_document(None)
 
     creation_info = _create_test_spdx3_creation_info()
     doc_empty = spdx3.SpdxDocument(
@@ -793,7 +792,7 @@ def test_get_boms_from_spdx_document() -> None:
         creationInfo=creation_info,
         name="doc-empty",
     )
-    assert get_boms_from_spdx_document(doc_empty) is None
+    assert not get_boms_from_spdx_document(doc_empty)
 
     bom = spdx3.software_Sbom(
         _id="http://example.com/spdx3/bom1",
@@ -807,5 +806,5 @@ def test_get_boms_from_spdx_document() -> None:
         rootElement=[bom],
     )
     boms = get_boms_from_spdx_document(doc_with_bom)
-    assert boms is not None
+    assert boms
     assert boms == [bom]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -8,6 +8,7 @@
 
 import os
 import warnings
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest import TestCase
 
@@ -17,6 +18,8 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 import ntia_conformance_checker.sbom_checker as sbom_checker
 from ntia_conformance_checker import FSCT3Checker, NTIAChecker
 from ntia_conformance_checker.spdx3_utils import (
+    get_boms_from_spdx_document,
+    get_packages_from_bom,
     has_package_dependency_relationship,
     validate_spdx3_data,
 )
@@ -696,3 +699,113 @@ def test_disconnected_component(test_file: str) -> None:
     assert not any(
         "Package-Orphan" in spdx_id for spdx_id in sbom.reachable_component_ids
     ), "The orphan package MUST NOT be in the reachable list."
+
+
+### Test get_packages_from_bom and get_boms_from_spdx_document
+
+
+def _create_test_spdx3_creation_info(
+    base_iri: str = "http://example.com/spdx3",
+) -> spdx3.CreationInfo:
+    """Create a minimal valid SPDX 3 CreationInfo instance for testing."""
+    return spdx3.CreationInfo(
+        _id=f"{base_iri}/creation-info",
+        specVersion="3.0.1",
+        created=datetime.now(timezone.utc),
+        createdBy=[f"{base_iri}/actor1"],
+        createdUsing=[f"{base_iri}/tool1"],
+    )
+
+
+def test_get_packages_from_bom_none_or_empty() -> None:
+    """Test get_packages_from_bom returns None for None or empty rootElement."""
+    assert get_packages_from_bom(None) is None
+
+    creation_info = _create_test_spdx3_creation_info()
+    bom_empty = spdx3.software_Sbom(
+        _id="http://example.com/spdx3/bom-empty",
+        creationInfo=creation_info,
+        name="bom-empty",
+    )
+    assert get_packages_from_bom(bom_empty) is None
+
+
+def test_get_packages_from_bom_non_packages_only() -> None:
+    """Test get_packages_from_bom returns None when rootElements contain no packages."""
+    creation_info = _create_test_spdx3_creation_info()
+    file = spdx3.software_File(
+        _id="http://example.com/spdx3/file1",
+        creationInfo=creation_info,
+        name="file1",
+    )
+    bom = spdx3.software_Sbom(
+        _id="http://example.com/spdx3/bom",
+        creationInfo=creation_info,
+        name="bom",
+        rootElement=[file],
+    )
+    assert get_packages_from_bom(bom) is None
+
+
+def test_get_packages_from_bom_filters_only_packages_and_subclasses() -> None:
+    """Test get_packages_from_bom returns only software_Package and its subclasses."""
+    creation_info = _create_test_spdx3_creation_info()
+    pkg = spdx3.software_Package(
+        _id="http://example.com/spdx3/pkg1",
+        creationInfo=creation_info,
+        name="pkg1",
+    )
+    ai_pkg = spdx3.ai_AIPackage(
+        _id="http://example.com/spdx3/ai-pkg1",
+        creationInfo=creation_info,
+        name="ai-pkg1",
+    )
+    data_pkg = spdx3.dataset_DatasetPackage(
+        _id="http://example.com/spdx3/data-pkg1",
+        creationInfo=creation_info,
+        name="data-pkg1",
+    )
+    file = spdx3.software_File(
+        _id="http://example.com/spdx3/file1",
+        creationInfo=creation_info,
+        name="file1",
+    )
+    bom = spdx3.software_Sbom(
+        _id="http://example.com/spdx3/bom",
+        creationInfo=creation_info,
+        name="bom",
+        rootElement=[pkg, ai_pkg, data_pkg, file],
+    )
+
+    packages = get_packages_from_bom(bom)
+    assert packages is not None
+    assert len(packages) == 3
+    assert packages == [pkg, ai_pkg, data_pkg]
+
+
+def test_get_boms_from_spdx_document() -> None:
+    """Test get_boms_from_spdx_document retrieves rootElements of SpdxDocument."""
+    assert get_boms_from_spdx_document(None) is None
+
+    creation_info = _create_test_spdx3_creation_info()
+    doc_empty = spdx3.SpdxDocument(
+        _id="http://example.com/spdx3/doc-empty",
+        creationInfo=creation_info,
+        name="doc-empty",
+    )
+    assert get_boms_from_spdx_document(doc_empty) is None
+
+    bom = spdx3.software_Sbom(
+        _id="http://example.com/spdx3/bom1",
+        creationInfo=creation_info,
+        name="bom1",
+    )
+    doc_with_bom = spdx3.SpdxDocument(
+        _id="http://example.com/spdx3/doc-with-bom",
+        creationInfo=creation_info,
+        name="doc-with-bom",
+        rootElement=[bom],
+    )
+    boms = get_boms_from_spdx_document(doc_with_bom)
+    assert boms is not None
+    assert boms == [bom]


### PR DESCRIPTION
- Filter `rootElement` items in `get_packages_from_bom` (to `software_Package`) and `get_boms_from_spdx_document` (to `Bom`) -- this will match the function names and their intent 
- Remove the restriction rejecting BOMs with more than one `rootElement` (to follow 0..* cardinality of [Bom.rootElement](https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/Bom/))
- Return `[]` when no matching elements exist or input is `None`, simplifying caller iteration while preserving existing falsy evaluation.
