### PR TITLE
Add BSI TR-03183-2 conformance checker for SPDX 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Currently, the supported specifications are:
   ["minimum elements."][ntia]
 - 2024 CISA Framing Software Component Transparency (FSCT3)
   ["minimum expected."][fsct3]
+- BSI TR-03183-2 v2.1.0 Minimum Elements.
+  ["SBOM requirements."][bsi]
 
 The minimum elements include:
 
@@ -52,6 +54,12 @@ FSCT3 requires these Baseline Attributes as part of its "minimum expected":
 - License
 - Copyright Holder (inside Copyright Notice)
 
+BSI TR-03183-2 introduces stricter requirements for component files and relationships, including:
+- SHA-512 Hashes for deployable components
+- Structured component properties (e.g., container, firmware)
+- Strict concluded licensing targets
+- Explicit dependency completeness definitions
+
 Mappings:
 
 - The mapping of the NTIA elements required data fields to the SPDX 2.3
@@ -62,7 +70,14 @@ Mappings:
   in [this slide][sbom-reqs] from Takashi Ninjouji of OpenChain Japan SBOM
   Sub-WG, presented at SPDX General Meeting 2024-12-05.
 
-## Installation
+> [!NOTE]
+> ### BSI TR-03183-2 Implementation Notes
+> To ensure strict compatibility with the official SPDX 3.0.1 specification, this checker adapts two of the examples provided in the BSI TR-03183-2 v2.1.0 document:
+> 
+> * **Deployable URIs:** `binaryArtifact` is evaluated strictly as an `ExternalRefType` inside an `externalRef` array (rather than a direct property of `software_File`).
+> * **Source Code URIs:** Artifacts must be defined using concrete subclasses (e.g., `software_File`, `software_Package`, `software_Snippet`) instead of the abstract `software_SoftwareArtifact` class.
+> 
+> For full technical details regarding these design decisions, please refer to [PR #428](https://github.com/spdx/ntia-conformance-checker/pull/428).
 
 This tool requires Python 3.10 or newer.
 Its dependencies may require a more recent version of Python.
@@ -101,7 +116,7 @@ options:
   -h, --help            show this help message and exit
   -s, --sbom-spec {spdx2,spdx3}
                         SBOM specification of the input file; see below for details [default: spdx2]
-  -c, --comply {fsct3-min,ntia}
+  -c, --comply {bsi,fsct3-min,ntia}
                         Compliance standards to check against; see below for details [default: ntia]
   -k, --skip-validation
                         Skip validation
@@ -119,6 +134,7 @@ choices:
     spdx3       System Package Data Exchange (SPDX) 3.x
 
   Compliance standards (for --comply):
+    bsi         BSI TR-03183-2 v2.1.0 Minimum Elements
     fsct3-min   2024 CISA Framing Software Component Transparency (minimum expectation)
     ntia        2021 NTIA SBOM Minimum Elements
 
@@ -202,6 +218,8 @@ each with a specific CSS class for easy styling and targeting:
   [contribution in 2022][gsoc2022] by [@linynjosh][].
 - SPDX 3 support and improved FSCT3 checker, available in [v4.0.0][],
   are [GSoC 2025 contribution][gsoc2025] by [@bact][].
+- BSI TR-03183-2 conformance checker and structural graph validation architecture
+  are [GSoC 2026 contribution][gsoc2026] by [@InduwaraGunasena][].
 - The project is maintained by a community of SPDX adopters and enthusiasts.
 - See SPDX's participation in Google Summer of Code (GSoC):
   <https://github.com/spdx/GSoC>.
@@ -211,7 +229,9 @@ each with a specific CSS class for easy styling and targeting:
 [@linynjosh]: https://github.com/linynjosh
 [v4.0.0]: https://github.com/spdx/ntia-conformance-checker/blob/main/CHANGELOG.md#400---2025-09-05
 [gsoc2025]: https://github.com/spdx/ntia-conformance-checker/wiki/Adding-SPDX-3.0-Support
+[gsoc2026]: https://github.com/spdx/ntia-conformance-checker/wiki/BSI-TR%E2%80%9003183%E2%80%902-Conformance-and-Structural-Graph-Validation-for-SPDX-SBOMs
 [@bact]: https://github.com/bact
+[@InduwaraGunasena]: https://github.com/InduwaraGunasena
 
 ## License
 
@@ -243,5 +263,6 @@ Check out the [frequently asked questions](./FAQ.md) document.
 [ntia]: https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom
 [ntia-spdx23]: https://spdx.github.io/spdx-spec/v2.3/how-to-use/#k22-mapping-ntia-minimum-elements-to-spdx-fields
 [fsct3]: https://www.cisa.gov/resources-tools/resources/framing-software-component-transparency-2024
+[bsi]: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2_v2_1_0.html
 [sbom-reqs]: https://drive.google.com/file/d/14HZGYD7pSSWEmtaHZzWrzPhxCXaCnloJ/view
 [pypi]: https://pypi.org/project/ntia-conformance-checker/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Mappings:
 > 
 > For full technical details regarding these design decisions, please refer to [PR #428](https://github.com/spdx/ntia-conformance-checker/pull/428).
 
+## Installation
+
 This tool requires Python 3.10 or newer.
 Its dependencies may require a more recent version of Python.
 

--- a/ntia_conformance_checker/__init__.py
+++ b/ntia_conformance_checker/__init__.py
@@ -4,7 +4,13 @@
 
 """Export functions for usage as library."""
 
-__all__ = ["BaseChecker", "FSCT3Checker", "NTIAChecker", "SbomChecker", "BSIChecker"]
+__all__ = [
+    "BaseChecker", 
+    "BSIChecker",
+    "FSCT3Checker", 
+    "NTIAChecker", 
+    "SbomChecker", 
+]
 
 from .base_checker import BaseChecker
 from .bsi_checker import BSIChecker

--- a/ntia_conformance_checker/__init__.py
+++ b/ntia_conformance_checker/__init__.py
@@ -5,11 +5,11 @@
 """Export functions for usage as library."""
 
 __all__ = [
-    "BaseChecker", 
+    "BaseChecker",
     "BSIChecker",
-    "FSCT3Checker", 
-    "NTIAChecker", 
-    "SbomChecker", 
+    "FSCT3Checker",
+    "NTIAChecker",
+    "SbomChecker",
 ]
 
 from .base_checker import BaseChecker

--- a/ntia_conformance_checker/__init__.py
+++ b/ntia_conformance_checker/__init__.py
@@ -4,9 +4,10 @@
 
 """Export functions for usage as library."""
 
-__all__ = ["BaseChecker", "FSCT3Checker", "NTIAChecker", "SbomChecker"]
+__all__ = ["BaseChecker", "FSCT3Checker", "NTIAChecker", "SbomChecker", "BSIChecker"]
 
 from .base_checker import BaseChecker
+from .bsi_checker import BSIChecker
 from .fsct_checker import FSCT3Checker
 from .ntia_checker import NTIAChecker
 from .sbom_checker import SbomChecker

--- a/ntia_conformance_checker/bsi_checker.py
+++ b/ntia_conformance_checker/bsi_checker.py
@@ -5,6 +5,7 @@
 """BSI Minimum Elements checking functionality."""
 
 from __future__ import annotations
+
 from typing import Any
 
 from spdx_python_model.bindings import v3_0_1 as spdx3
@@ -17,6 +18,7 @@ from .spdx3_utils import (
     iter_objects_with_property,
     iter_relationships_by_type,
 )
+
 
 # pylint: disable=too-many-instance-attributes
 class BSIChecker(BaseChecker):
@@ -112,7 +114,9 @@ class BSIChecker(BaseChecker):
         self.doc_uri: bool = False
         self.dependency_completeness: bool = False
 
-        super().__init__(file=file, validate=validate, compliance=compliance, sbom_spec=sbom_spec)
+        super().__init__(
+            file=file, validate=validate, compliance=compliance, sbom_spec=sbom_spec
+        )
 
         if self.doc:
             self.compliant = self.check_compliance()
@@ -194,26 +198,44 @@ class BSIChecker(BaseChecker):
         )
         self.components_without_creators = self.get_components_without_creators()
         self.components_without_filenames = self.get_components_without_filenames()
-        self.components_without_executable_prop = self.get_components_without_executable_prop()
-        self.components_without_archive_prop = self.get_components_without_archive_prop()
-        self.components_without_structured_prop = self.get_components_without_structured_prop()
-        self.components_without_sha512_hashes = self.get_components_without_sha512_hashes()
+        self.components_without_executable_prop = (
+            self.get_components_without_executable_prop()
+        )
+        self.components_without_archive_prop = (
+            self.get_components_without_archive_prop()
+        )
+        self.components_without_structured_prop = (
+            self.get_components_without_structured_prop()
+        )
+        self.components_without_sha512_hashes = (
+            self.get_components_without_sha512_hashes()
+        )
 
         # Run Additional/Optional checks
-        self.components_without_source_code_uris = self.get_components_without_source_code_uris()
-        self.components_without_deployable_uris = self.get_components_without_deployable_uris()
+        self.components_without_source_code_uris = (
+            self.get_components_without_source_code_uris()
+        )
+        self.components_without_deployable_uris = (
+            self.get_components_without_deployable_uris()
+        )
         self.components_without_unique_identifiers = (
             self.get_components_without_unique_identifiers()
         )
-        self.components_without_original_licenses = self.get_components_without_original_licenses()
+        self.components_without_original_licenses = (
+            self.get_components_without_original_licenses()
+        )
         self.components_without_effective_licenses = (
             self.get_components_without_effective_licenses()
         )
         self.components_without_source_code_hashes = (
             self.get_components_without_source_code_hashes()
         )
-        self.components_without_security_txt = self.get_components_without_security_txt()
-        self.components_without_bom_references = self.get_components_without_bom_references()
+        self.components_without_security_txt = (
+            self.get_components_without_security_txt()
+        )
+        self.components_without_bom_references = (
+            self.get_components_without_bom_references()
+        )
 
         # Refresh the aggregated tracking list used by the base class reporter
         self.all_components_without_info = self._get_all_components_without_info()
@@ -228,13 +250,14 @@ class BSIChecker(BaseChecker):
             ]
         )
 
-
     @staticmethod
     def _is_valid_creator(
         creator: Any, doc: spdx3.SHACLObjectSet, url_id_types: tuple[str, ...]
     ) -> bool:
         """Validate if a creator object has a valid email or URL identifier."""
-        creator_obj = creator if not isinstance(creator, str) else doc.find_by_id(creator)
+        creator_obj = (
+            creator if not isinstance(creator, str) else doc.find_by_id(creator)
+        )
         if not isinstance(creator_obj, (spdx3.Person, spdx3.Organization)):
             return False
 
@@ -252,7 +275,6 @@ class BSIChecker(BaseChecker):
                 return True
 
         return False
-
 
     def check_doc_creator(self) -> bool:
         """
@@ -274,7 +296,8 @@ class BSIChecker(BaseChecker):
             return False
 
         return any(
-            self._is_valid_creator(c, self.doc, ("urlscheme", "other")) for c in creators
+            self._is_valid_creator(c, self.doc, ("urlscheme", "other"))
+            for c in creators
         )
 
     def check_sbom_uri(self) -> bool:
@@ -380,13 +403,19 @@ class BSIChecker(BaseChecker):
             return missing
 
         valid_license_ids = set()
-        for from_id, to_ids in iter_relationships_by_type(self.doc, "hasConcludedLicense"):
+        for from_id, to_ids in iter_relationships_by_type(
+            self.doc, "hasConcludedLicense"
+        ):
             has_valid_expression = False
             for target_id in to_ids:
                 obj = self.doc.find_by_id(target_id)
                 if obj and isinstance(obj, spdx3.simplelicensing_LicenseExpression):
                     expr = getattr(obj, "simplelicensing_licenseExpression", "")
-                    if expr and isinstance(expr, str) and expr.strip() != "NoAssertionLicense":
+                    if (
+                        expr
+                        and isinstance(expr, str)
+                        and expr.strip() != "NoAssertionLicense"
+                    ):
                         has_valid_expression = True
                         break
 
@@ -509,7 +538,9 @@ class BSIChecker(BaseChecker):
                 raw_purpose = getattr(obj, "software_primaryPurpose", None) or getattr(
                     obj, "primaryPurpose", None
                 )
-                purposes = raw_purpose if isinstance(raw_purpose, list) else [raw_purpose]
+                purposes = (
+                    raw_purpose if isinstance(raw_purpose, list) else [raw_purpose]
+                )
                 purposes_str = [str(p).lower() for p in purposes]
 
                 if any("source" in p for p in purposes_str):
@@ -584,7 +615,7 @@ class BSIChecker(BaseChecker):
                 for ext_id in ext_ids:
                     id_type = str(getattr(ext_id, "externalIdentifierType", "")).lower()
                     # Extract the base type name from the IRI/Enum
-                    id_type_clean = id_type.rsplit('/', maxsplit=1)[-1]
+                    id_type_clean = id_type.rsplit("/", maxsplit=1)[-1]
 
                     if id_type_clean in valid_types:
                         has_valid_id = True
@@ -606,13 +637,19 @@ class BSIChecker(BaseChecker):
 
         valid_license_ids = set()
 
-        for from_id, to_ids in iter_relationships_by_type(self.doc, "hasDeclaredLicense"):
+        for from_id, to_ids in iter_relationships_by_type(
+            self.doc, "hasDeclaredLicense"
+        ):
             has_valid_expression = False
             for target_id in to_ids:
                 obj = self.doc.find_by_id(target_id)
                 if obj and isinstance(obj, spdx3.simplelicensing_LicenseExpression):
                     expr = getattr(obj, "simplelicensing_licenseExpression", "")
-                    if expr and isinstance(expr, str) and expr.strip() != "NoAssertionLicense":
+                    if (
+                        expr
+                        and isinstance(expr, str)
+                        and expr.strip() != "NoAssertionLicense"
+                    ):
                         has_valid_expression = True
                         break
 
@@ -641,13 +678,18 @@ class BSIChecker(BaseChecker):
         for rel in self.doc.foreach_type(spdx3.Relationship):
             rel_type = getattr(rel, "relationshipType", "")
 
-            if rel_type and str(rel_type).rsplit('/', maxsplit=1)[-1].lower() == "other":
+            if (
+                rel_type
+                and str(rel_type).rsplit("/", maxsplit=1)[-1].lower() == "other"
+            ):
                 comment = getattr(rel, "comment", "")
 
                 if comment and "hasEffectiveLicense" in str(comment):
                     from_obj = getattr(rel, "from_", None)
                     from_id = (
-                        from_obj if isinstance(from_obj, str) else getattr(from_obj, "spdxId", "")
+                        from_obj
+                        if isinstance(from_obj, str)
+                        else getattr(from_obj, "spdxId", "")
                     )
 
                     if from_id:
@@ -686,7 +728,9 @@ class BSIChecker(BaseChecker):
                 raw_purpose = getattr(obj, "software_primaryPurpose", None) or getattr(
                     obj, "primaryPurpose", None
                 )
-                purposes = raw_purpose if isinstance(raw_purpose, list) else [raw_purpose]
+                purposes = (
+                    raw_purpose if isinstance(raw_purpose, list) else [raw_purpose]
+                )
                 purposes_str = [str(p).lower() for p in purposes]
 
                 if any("source" in p for p in purposes_str):

--- a/ntia_conformance_checker/bsi_checker.py
+++ b/ntia_conformance_checker/bsi_checker.py
@@ -1,0 +1,763 @@
+# SPDX-FileCopyrightText: 2026 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""BSI Minimum Elements checking functionality."""
+
+from __future__ import annotations
+from typing import Any
+
+from spdx_python_model.bindings import v3_0_1 as spdx3
+
+from .base_checker import BaseChecker
+from .spdx3_utils import (
+    get_dependency_relationships_completeness,
+    get_distribution_artifacts_map,
+    has_sha512_hash,
+    iter_objects_with_property,
+    iter_relationships_by_type,
+)
+
+# pylint: disable=too-many-instance-attributes
+class BSIChecker(BaseChecker):
+    """
+    BSI Minimum Elements check according to BSI TR-03183-2 v2.1.0.
+
+    See:
+        https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2_v2_1_0.html
+    """
+
+    MIN_ELEMENTS = [
+        "creator",
+        "name",
+        "version",
+        "filename",
+        "distribution_licenses",
+        "sha512_hash",
+        "executable_property",
+        "archive_property",
+        "structured_property",
+    ]
+
+    _COMPONENTS_WITHOUT_INFO = {
+        **BaseChecker._COMPONENTS_WITHOUT_INFO,
+        "creator": (
+            "components_without_creators",
+            "Components missing a creator (Email/URL)",
+        ),
+        "filename": (
+            "components_without_filenames",
+            "Components missing a distribution filename",
+        ),
+        "executable_property": (
+            "components_without_executable_prop",
+            "Components missing executable property",
+        ),
+        "archive_property": (
+            "components_without_archive_prop",
+            "Components missing archive property",
+        ),
+        "structured_property": (
+            "components_without_structured_prop",
+            "Components missing structured property",
+        ),
+        "distribution_licenses": (
+            "components_without_concluded_licenses",
+            "Components missing distribution licenses",
+        ),
+        "sha512_hash": (
+            "components_without_sha512_hashes",
+            "Components missing SHA-512 hash",
+        ),
+    }
+
+    def __init__(
+        self,
+        file: str,
+        validate: bool = True,
+        compliance: str = "bsi",
+        sbom_spec: str = "spdx3",
+    ):
+        """
+        Initialize the BSI Minimum Element Checker.
+
+        Args:
+            file (str): The name of the file to be checked.
+            validate (bool): Whether to validate the file.
+            compliance (str): The compliance standard to be used.
+            sbom_spec (str): The SBOM specification to be used.
+        """
+
+        if compliance not in {"bsi"}:
+            raise ValueError("Only BSI compliance is supported.")
+
+        self.components_without_creators: list[tuple[str, str]] = []
+        self.components_without_filenames: list[tuple[str, str]] = []
+        self.components_without_executable_prop: list[tuple[str, str]] = []
+        self.components_without_archive_prop: list[tuple[str, str]] = []
+        self.components_without_structured_prop: list[tuple[str, str]] = []
+        self.components_without_sha512_hashes: list[tuple[str, str]] = []
+
+        # Initialize Additional/Optional lists (Warnings)
+        self.components_without_source_code_uris: list[tuple[str, str]] = []
+        self.components_without_deployable_uris: list[tuple[str, str]] = []
+        self.components_without_unique_identifiers: list[tuple[str, str]] = []
+        self.components_without_original_licenses: list[tuple[str, str]] = []
+        self.components_without_effective_licenses: list[tuple[str, str]] = []
+        self.components_without_source_code_hashes: list[tuple[str, str]] = []
+        self.components_without_security_txt: list[tuple[str, str]] = []
+        self.components_without_bom_references: list[tuple[str, str]] = []
+
+        self.doc_creator: bool = False
+        self.doc_uri: bool = False
+        self.dependency_completeness: bool = False
+
+        super().__init__(file=file, validate=validate, compliance=compliance, sbom_spec=sbom_spec)
+
+        if self.doc:
+            self.compliant = self.check_compliance()
+
+        self.table_elements = [
+            ("Creator of the SBOM", self.doc_creator),
+            ("Timestamp", self.doc_timestamp),
+            ("Dependency Completeness", self.dependency_completeness),
+            ("Component Names", not bool(self.components_without_names)),
+            ("Component Versions", not bool(self.components_without_versions)),
+            ("Component Creators", not bool(self.components_without_creators)),
+            ("Distribution Filenames", not bool(self.components_without_filenames)),
+            (
+                "Executable Properties",
+                not bool(self.components_without_executable_prop),
+            ),
+            ("Archive Properties", not bool(self.components_without_archive_prop)),
+            (
+                "Structured Properties",
+                not bool(self.components_without_structured_prop),
+            ),
+            (
+                "Distribution Licenses",
+                not bool(self.components_without_concluded_licenses),
+            ),
+            (
+                "Deployable Component Hashes",
+                not bool(self.components_without_sha512_hashes),
+            ),
+            (
+                "Source Code URIs (Warning)",
+                not bool(self.components_without_source_code_uris),
+            ),
+            (
+                "Deployable Form URIs (Warning)",
+                not bool(self.components_without_deployable_uris),
+            ),
+            (
+                "Other Unique Identifiers (Warning)",
+                not bool(self.components_without_unique_identifiers),
+            ),
+            (
+                "Original Licenses (Warning)",
+                not bool(self.components_without_original_licenses),
+            ),
+            (
+                "Effective Licenses (Optional)",
+                not bool(self.components_without_effective_licenses),
+            ),
+            (
+                "Source Code Hashes (Optional)",
+                not bool(self.components_without_source_code_hashes),
+            ),
+            (
+                "Security.txt URLs (Optional)",
+                not bool(self.components_without_security_txt),
+            ),
+            (
+                "BOM References (Optional)",
+                not bool(self.components_without_bom_references),
+            ),
+        ]
+
+    def check_compliance(self) -> bool:
+        """Check overall compliance with BSI minimum elements."""
+        # Execute Document-Level Checks
+        self.doc_creator = self.check_doc_creator()
+        self.doc_uri = self.check_sbom_uri()
+        self.doc_timestamp = self.check_timestamp()
+
+        # Execute Component-Level Checks
+        self.dependency_completeness = self.check_dependency_completeness()
+        self.components_without_names = self.get_components_without_names()
+        self.components_without_versions = self.get_components_without_versions()
+
+        # Run BSI-specific overrides and new methods
+        self.components_without_concluded_licenses = (
+            self.get_components_without_concluded_licenses()
+        )
+        self.components_without_creators = self.get_components_without_creators()
+        self.components_without_filenames = self.get_components_without_filenames()
+        self.components_without_executable_prop = self.get_components_without_executable_prop()
+        self.components_without_archive_prop = self.get_components_without_archive_prop()
+        self.components_without_structured_prop = self.get_components_without_structured_prop()
+        self.components_without_sha512_hashes = self.get_components_without_sha512_hashes()
+
+        # Run Additional/Optional checks
+        self.components_without_source_code_uris = self.get_components_without_source_code_uris()
+        self.components_without_deployable_uris = self.get_components_without_deployable_uris()
+        self.components_without_unique_identifiers = (
+            self.get_components_without_unique_identifiers()
+        )
+        self.components_without_original_licenses = self.get_components_without_original_licenses()
+        self.components_without_effective_licenses = (
+            self.get_components_without_effective_licenses()
+        )
+        self.components_without_source_code_hashes = (
+            self.get_components_without_source_code_hashes()
+        )
+        self.components_without_security_txt = self.get_components_without_security_txt()
+        self.components_without_bom_references = self.get_components_without_bom_references()
+
+        # Refresh the aggregated tracking list used by the base class reporter
+        self.all_components_without_info = self._get_all_components_without_info()
+
+        return all(
+            [
+                self.doc_creator,
+                self.doc_timestamp,
+                self.doc_uri,
+                self.dependency_completeness,
+                not bool(self.all_components_without_info),
+            ]
+        )
+
+
+    @staticmethod
+    def _is_valid_creator(
+        creator: Any, doc: spdx3.SHACLObjectSet, url_id_types: tuple[str, ...]
+    ) -> bool:
+        """Validate if a creator object has a valid email or URL identifier."""
+        creator_obj = creator if not isinstance(creator, str) else doc.find_by_id(creator)
+        if not isinstance(creator_obj, (spdx3.Person, spdx3.Organization)):
+            return False
+
+        for ext_id in getattr(creator_obj, "externalIdentifier", []):
+            id_type = str(getattr(ext_id, "externalIdentifierType", "")).lower()
+            id_val = getattr(ext_id, "identifier", "")
+            if not id_val:
+                continue
+
+            if "email" in id_type and "@" in id_val:
+                return True
+            if any(t in id_type for t in url_id_types) and id_val.startswith(
+                ("http://", "https://")
+            ):
+                return True
+
+        return False
+
+
+    def check_doc_creator(self) -> bool:
+        """
+        Check if the document creator has a valid email or URL.
+        """
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return False
+
+        spdx3_doc = getattr(self, "_BaseChecker__spdx3_doc", None)
+        if not spdx3_doc:
+            return False
+
+        creation_info = getattr(spdx3_doc, "creationInfo", None)
+        if not creation_info:
+            return False
+
+        creators = getattr(creation_info, "createdBy", [])
+        if not creators:
+            return False
+
+        return any(
+            self._is_valid_creator(c, self.doc, ("urlscheme", "other")) for c in creators
+        )
+
+    def check_sbom_uri(self) -> bool:
+        """
+        Check if the SBOM-URI exists.
+        """
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return False
+
+        spdx3_doc = getattr(self, "_BaseChecker__spdx3_doc", None)
+        if not spdx3_doc:
+            return False
+
+        root_elements = getattr(spdx3_doc, "rootElement", [])
+
+        for root in root_elements:
+            root_obj = root if not isinstance(root, str) else self.doc.find_by_id(root)
+
+            # The rootElement (software_Sbom or software_Package) MUST have a valid spdxId.
+            if isinstance(root_obj, (spdx3.software_Sbom, spdx3.software_Package)):
+                spdx_id = getattr(root_obj, "spdxId", None)
+                if spdx_id and isinstance(spdx_id, str) and spdx_id.strip():
+                    return True
+
+        return False
+
+    def get_components_without_creators(self) -> list[tuple[str, str]]:
+        """
+        Check if each component creator has a valid email or URL.
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        # Iterate through all packages in the reachable graph
+        for name, spdx_id, originated_by_list in iter_objects_with_property(
+            self.doc,
+            spdx3.software_Package,
+            "originatedBy",
+            self.reachable_component_ids,
+        ):
+            creators = originated_by_list or []
+            has_valid = any(
+                self._is_valid_creator(c, self.doc, ("other", "urlscheme"))
+                for c in creators
+            )
+            if not has_valid:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_filenames(self) -> list[tuple[str, str]]:
+        """
+        Check if each package has a linked software_File with a valid name.
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        artifacts_map = get_distribution_artifacts_map(self.doc)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            has_filename = False
+            linked_files = artifacts_map.get(spdx_id, [])
+
+            for file_obj in linked_files:
+                file_name = getattr(file_obj, "name", "")
+                if file_name and isinstance(file_name, str) and file_name.strip():
+                    has_filename = True
+                    break
+
+            if not has_filename:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def check_dependency_completeness(self) -> bool:
+        """
+        Check if dependency enumerations clearly indicate their completeness.
+        """
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return False
+
+        completeness_map = get_dependency_relationships_completeness(self.doc)
+
+        for _, completeness_list in completeness_map.items():
+            for completeness_val in completeness_list:
+                if completeness_val not in ("complete", "incomplete", "noAssertion"):
+                    return False
+
+        return True
+
+    def get_components_without_concluded_licenses(self) -> list[tuple[str, str]]:
+        """
+        Overrides BaseChecker to enforce BSI document Table 9 and Section 6.1 rules:
+        1. Target MUST be simplelicensing_LicenseExpression.
+        2. Must use valid SPDX license expressions, Scancode, or custom LicenseRefs.
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        valid_license_ids = set()
+        for from_id, to_ids in iter_relationships_by_type(self.doc, "hasConcludedLicense"):
+            has_valid_expression = False
+            for target_id in to_ids:
+                obj = self.doc.find_by_id(target_id)
+                if obj and isinstance(obj, spdx3.simplelicensing_LicenseExpression):
+                    expr = getattr(obj, "simplelicensing_licenseExpression", "")
+                    if expr and isinstance(expr, str) and expr.strip() != "NoAssertionLicense":
+                        has_valid_expression = True
+                        break
+
+            if has_valid_expression:
+                valid_license_ids.add(from_id)
+
+        # Check packages against the valid license list
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            if spdx_id not in valid_license_ids:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_sha512_hashes(self) -> list[tuple[str, str]]:
+        """
+        Check if the deployable component has a SHA-512 hash.
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        artifacts_map = get_distribution_artifacts_map(self.doc)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            linked_files = artifacts_map.get(spdx_id, [])
+
+            # If no file is linked, skip file level checks.
+            if not linked_files:
+                continue
+
+            has_hash = False
+            for file_obj in linked_files:
+                if has_sha512_hash(file_obj):
+                    has_hash = True
+                    break
+
+            if not has_hash:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_executable_prop(self) -> list[tuple[str, str]]:
+        """
+        BSI Requirement: Omit 'executable' if non-executable.
+        Since omission represents 'False', a static checker cannot fail a component
+        for missing this tag. Always compliant.
+        """
+        return []
+
+    def get_components_without_archive_prop(self) -> list[tuple[str, str]]:
+        """
+        BSI Requirement: Omit 'archive' if non-archive.
+        Since omission represents 'False', a static checker cannot fail a component
+        for missing this tag. Always compliant.
+        """
+        return []
+
+    def get_components_without_structured_prop(self) -> list[tuple[str, str]]:
+        """
+        Check if the component declares a structured property.
+        BSI Requirement: MUST indicate 'container' (structured) or 'firmware' (unstructured).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        artifacts_map = get_distribution_artifacts_map(self.doc)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            linked_files = artifacts_map.get(spdx_id, [])
+
+            # If no file is linked, skip file level checks.
+            if not linked_files:
+                continue
+
+            has_structured_prop = False
+            for file_obj in linked_files:
+                purposes = getattr(file_obj, "software_additionalPurpose", [])
+                # Convert IRIs/Enums to strings and check for BSI keywords
+                purposes_str = [str(p).lower() for p in purposes]
+
+                if any("container" in p or "firmware" in p for p in purposes_str):
+                    has_structured_prop = True
+                    break
+
+            if not has_structured_prop:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_source_code_uris(self) -> list[tuple[str, str]]:
+        """
+        Check if the component has a Source code URI.
+        BSI Requirement: MUST be included IF it exists (Additional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        valid_package_ids = set()
+
+        for from_id, to_ids in iter_relationships_by_type(self.doc, "generates"):
+            is_valid_source = False
+
+            obj = self.doc.find_by_id(from_id)
+            if obj and isinstance(
+                obj,
+                (
+                    spdx3.software_SoftwareArtifact,
+                    spdx3.software_File,
+                    spdx3.software_Package,
+                ),
+            ):
+                raw_purpose = getattr(obj, "software_primaryPurpose", None) or getattr(
+                    obj, "primaryPurpose", None
+                )
+                purposes = raw_purpose if isinstance(raw_purpose, list) else [raw_purpose]
+                purposes_str = [str(p).lower() for p in purposes]
+
+                if any("source" in p for p in purposes_str):
+                    if getattr(obj, "externalRef", []):
+                        is_valid_source = True
+
+            if is_valid_source:
+                for target_id in to_ids:
+                    valid_package_ids.add(target_id)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            if spdx_id not in valid_package_ids:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_deployable_uris(self) -> list[tuple[str, str]]:
+        """
+        Check if the component has a URI of the deployable form.
+        BSI Requirement: MUST be included IF it exists (Additional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        artifacts_map = get_distribution_artifacts_map(self.doc)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            linked_files = artifacts_map.get(spdx_id, [])
+            if not linked_files:
+                continue
+
+            has_deployable_uri = False
+            for file_obj in linked_files:
+                for ext_ref in getattr(file_obj, "externalRef", []):
+                    ref_type = str(getattr(ext_ref, "externalRefType", "")).lower()
+                    if "binaryartifact" in ref_type:
+                        has_deployable_uri = True
+                        break
+                if has_deployable_uri:
+                    break
+
+            if not has_deployable_uri:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_unique_identifiers(self) -> list[tuple[str, str]]:
+        """
+        Check if the component has additional unique identifiers (CPE, SWID, PURL).
+        BSI Requirement: MUST be included IF they exist (Additional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        # Valid BSI external identifier types
+        valid_types = {"cpe22", "cpe23", "swid", "packageurl"}
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            has_valid_id = False
+
+            obj = self.doc.find_by_id(spdx_id)
+            if obj:
+                ext_ids = getattr(obj, "externalIdentifier", [])
+                for ext_id in ext_ids:
+                    id_type = str(getattr(ext_id, "externalIdentifierType", "")).lower()
+                    # Extract the base type name from the IRI/Enum
+                    id_type_clean = id_type.rsplit('/', maxsplit=1)[-1]
+
+                    if id_type_clean in valid_types:
+                        has_valid_id = True
+                        break
+
+            if not has_valid_id:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_original_licenses(self) -> list[tuple[str, str]]:
+        """
+        Check if original licences are included.
+        BSI Requirement: MUST be included IF they exist (Additional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        valid_license_ids = set()
+
+        for from_id, to_ids in iter_relationships_by_type(self.doc, "hasDeclaredLicense"):
+            has_valid_expression = False
+            for target_id in to_ids:
+                obj = self.doc.find_by_id(target_id)
+                if obj and isinstance(obj, spdx3.simplelicensing_LicenseExpression):
+                    expr = getattr(obj, "simplelicensing_licenseExpression", "")
+                    if expr and isinstance(expr, str) and expr.strip() != "NoAssertionLicense":
+                        has_valid_expression = True
+                        break
+
+            if has_valid_expression:
+                valid_license_ids.add(from_id)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            if spdx_id not in valid_license_ids:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_effective_licenses(self) -> list[tuple[str, str]]:
+        """
+        Check if the effective licence is included.
+        BSI Requirement: MAY be included (Optional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        valid_license_ids = set()
+
+        for rel in self.doc.foreach_type(spdx3.Relationship):
+            rel_type = getattr(rel, "relationshipType", "")
+
+            if rel_type and str(rel_type).rsplit('/', maxsplit=1)[-1].lower() == "other":
+                comment = getattr(rel, "comment", "")
+
+                if comment and "hasEffectiveLicense" in str(comment):
+                    from_obj = getattr(rel, "from_", None)
+                    from_id = (
+                        from_obj if isinstance(from_obj, str) else getattr(from_obj, "spdxId", "")
+                    )
+
+                    if from_id:
+                        valid_license_ids.add(from_id)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            if spdx_id not in valid_license_ids:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_source_code_hashes(self) -> list[tuple[str, str]]:
+        """
+        Check if the source code of the component has a SHA-512 hash.
+        BSI Requirement: MAY be included (Optional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        valid_package_ids = set()
+
+        for from_id, to_ids in iter_relationships_by_type(self.doc, "generates"):
+            has_hash = False
+            obj = self.doc.find_by_id(from_id)
+            if obj and isinstance(
+                obj,
+                (
+                    spdx3.software_SoftwareArtifact,
+                    spdx3.software_File,
+                    spdx3.software_Package,
+                ),
+            ):
+                raw_purpose = getattr(obj, "software_primaryPurpose", None) or getattr(
+                    obj, "primaryPurpose", None
+                )
+                purposes = raw_purpose if isinstance(raw_purpose, list) else [raw_purpose]
+                purposes_str = [str(p).lower() for p in purposes]
+
+                if any("source" in p for p in purposes_str):
+                    if has_sha512_hash(obj):
+                        has_hash = True
+
+            if has_hash:
+                valid_package_ids.update(to_ids)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            if spdx_id not in valid_package_ids:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_security_txt(self) -> list[tuple[str, str]]:
+        """
+        Check if the component contains a URL to security.txt.
+        BSI Requirement: MAY be included (Optional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            has_security = False
+            obj = self.doc.find_by_id(spdx_id)
+            if obj:
+                for ext_ref in getattr(obj, "externalRef", []):
+                    ref_type = str(getattr(ext_ref, "externalRefType", "")).lower()
+                    if "securityother" in ref_type:
+                        has_security = True
+                        break
+
+            if not has_security:
+                missing.append((name, spdx_id))
+
+        return missing
+
+    def get_components_without_bom_references(self) -> list[tuple[str, str]]:
+        """
+        Check if the component references another BOM.
+        BSI Requirement: MAY be included (Optional Data Field).
+        """
+        missing: list[tuple[str, str]] = []
+        if not isinstance(self.doc, spdx3.SHACLObjectSet):
+            return missing
+
+        valid_package_ids = set()
+
+        for from_id, to_ids in iter_relationships_by_type(self.doc, "describes"):
+            has_bom_ref = False
+            obj = self.doc.find_by_id(from_id)
+            if obj and isinstance(obj, spdx3.software_Sbom):
+                for ext_ref in getattr(obj, "externalRef", []):
+                    ref_type = str(getattr(ext_ref, "externalRefType", "")).lower()
+                    if "buildmeta" in ref_type:
+                        has_bom_ref = True
+                        break
+
+            if has_bom_ref:
+                valid_package_ids.update(to_ids)
+
+        for name, spdx_id, _ in iter_objects_with_property(
+            self.doc, spdx3.software_Package, "spdxId", self.reachable_component_ids
+        ):
+            if spdx_id not in valid_package_ids:
+                missing.append((name, spdx_id))
+
+        return missing

--- a/ntia_conformance_checker/bsi_checker.py
+++ b/ntia_conformance_checker/bsi_checker.py
@@ -52,12 +52,12 @@ class BSIChecker(BaseChecker):
             "Components missing a distribution filename",
         ),
         "distribution_licenses": (
-                    "components_without_concluded_licenses",
-                    "Components missing distribution licenses",
+            "components_without_concluded_licenses",
+            "Components missing distribution licenses",
         ),
         "sha512_hash": (
-                    "components_without_sha512_hashes",
-                    "Components missing SHA-512 hash",
+            "components_without_sha512_hashes",
+            "Components missing SHA-512 hash",
         ),
         "executable_property": (
             "components_without_executable_prop",
@@ -95,10 +95,10 @@ class BSIChecker(BaseChecker):
 
         self.components_without_creators: list[tuple[str, str]] = []
         self.components_without_filenames: list[tuple[str, str]] = []
+        self.components_without_sha512_hashes: list[tuple[str, str]] = []
         self.components_without_executable_prop: list[tuple[str, str]] = []
         self.components_without_archive_prop: list[tuple[str, str]] = []
         self.components_without_structured_prop: list[tuple[str, str]] = []
-        self.components_without_sha512_hashes: list[tuple[str, str]] = []
 
         # Initialize Additional/Optional lists (Warnings)
         self.components_without_source_code_uris: list[tuple[str, str]] = []
@@ -532,7 +532,10 @@ class BSIChecker(BaseChecker):
                 (
                     spdx3.software_SoftwareArtifact,
                     spdx3.software_File,
+                    spdx3.software_Snippet,
                     spdx3.software_Package,
+                    spdx3.ai_AIPackage,
+                    spdx3.dataset_DatasetPackage,
                 ),
             ):
                 raw_purpose = getattr(obj, "software_primaryPurpose", None) or getattr(
@@ -579,6 +582,8 @@ class BSIChecker(BaseChecker):
 
             has_deployable_uri = False
             for file_obj in linked_files:
+                # Note: BSI TR-03183-2 example shows 'binaryArtifact' as a direct property,
+                # but SPDX 3.0.1 defines it strictly as an ExternalRefType.
                 for ext_ref in getattr(file_obj, "externalRef", []):
                     ref_type = str(getattr(ext_ref, "externalRefType", "")).lower()
                     if "binaryartifact" in ref_type:
@@ -722,7 +727,10 @@ class BSIChecker(BaseChecker):
                 (
                     spdx3.software_SoftwareArtifact,
                     spdx3.software_File,
+                    spdx3.software_Snippet,
                     spdx3.software_Package,
+                    spdx3.ai_AIPackage,
+                    spdx3.dataset_DatasetPackage,
                 ),
             ):
                 raw_purpose = getattr(obj, "software_primaryPurpose", None) or getattr(

--- a/ntia_conformance_checker/bsi_checker.py
+++ b/ntia_conformance_checker/bsi_checker.py
@@ -51,6 +51,14 @@ class BSIChecker(BaseChecker):
             "components_without_filenames",
             "Components missing a distribution filename",
         ),
+        "distribution_licenses": (
+                    "components_without_concluded_licenses",
+                    "Components missing distribution licenses",
+        ),
+        "sha512_hash": (
+                    "components_without_sha512_hashes",
+                    "Components missing SHA-512 hash",
+        ),
         "executable_property": (
             "components_without_executable_prop",
             "Components missing executable property",
@@ -62,14 +70,6 @@ class BSIChecker(BaseChecker):
         "structured_property": (
             "components_without_structured_prop",
             "Components missing structured property",
-        ),
-        "distribution_licenses": (
-            "components_without_concluded_licenses",
-            "Components missing distribution licenses",
-        ),
-        "sha512_hash": (
-            "components_without_sha512_hashes",
-            "Components missing SHA-512 hash",
         ),
     }
 

--- a/ntia_conformance_checker/constants.py
+++ b/ntia_conformance_checker/constants.py
@@ -36,6 +36,7 @@ VALID_SPDX3_COMPOSITION_RELATIONSHIPS = {
 SUPPORTED_COMPLIANCE_STANDARDS_DESC = {
     # "cisasbom2025": "2025 CISA SBOM Minimum Elements",
     # https://www.cisa.gov/resources-tools/resources/2025-minimum-elements-software-bill-materials-sbom
+    "bsi": "BSI TR-03183-2 v2.1.0 Cyber Resilience Requirements for Manufacturers and Products",
     "fsct3-min": "2024 CISA Framing Software Component Transparency (minimum expectation)",
     "ntia": "2021 NTIA SBOM Minimum Elements",
 }

--- a/ntia_conformance_checker/sbom_checker.py
+++ b/ntia_conformance_checker/sbom_checker.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, final
 
+from ntia_conformance_checker.bsi_checker import BSIChecker
+
 from .base_checker import BaseChecker
 from .constants import SUPPORTED_SBOM_SPECS
 
@@ -71,6 +73,9 @@ class SbomChecker(BaseChecker):
             from .fsct_checker import FSCT3Checker
 
             return FSCT3Checker(file, validate, sbom_spec=sbom_spec)
+
+        if compliance == "bsi":
+            return BSIChecker(file, validate, sbom_spec=sbom_spec)
 
         raise ValueError(f"Unknown compliance standard: {compliance}")
 

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -277,3 +277,76 @@ def has_package_dependency_relationship(object_set: spdx3.SHACLObjectSet) -> boo
                 return True
 
     return False
+
+
+def get_distribution_artifacts_map(
+    object_set: spdx3.SHACLObjectSet,
+) -> dict[str, list[spdx3.software_File]]:
+    """
+    Create a mapping of package spdxId to their linked software_File distribution artifacts.
+    
+    Returns:
+        dict[str, list[spdx3.software_File]]: A dictionary mapping package spdxId to a list of linked software_File objects.
+    """ 
+    artifact_map: dict[str, list[spdx3.software_File]] = {}
+
+    file_map: dict[str, spdx3.software_File] = {}
+    for file_obj in object_set.foreach_type(spdx3.software_File):
+        file_id = getattr(file_obj, "spdxId", "")
+        if file_id:
+            file_map[file_id] = file_obj
+
+    for from_id, to_ids in iter_relationships_by_type(object_set, "hasDistributionArtifact"):
+        files = [file_map[to_id] for to_id in to_ids if to_id in file_map]
+        if files:
+            artifact_map.setdefault(from_id, []).extend(files)
+
+    return artifact_map
+
+
+def has_sha512_hash(file_obj: spdx3.software_File) -> bool:
+    """
+    Check if a software_File has a SHA-512 hash declared in its verifiedUsing property.
+    """
+    verified_using = getattr(file_obj, "verifiedUsing", [])
+    for verification in verified_using:
+        if isinstance(verification, spdx3.Hash):
+            algorithm = getattr(verification, "algorithm", "")
+            hash_value = getattr(verification, "hashValue", "")
+
+            if algorithm and "sha512" in str(algorithm).lower() and hash_value:
+                return True
+
+    return False
+
+
+def get_dependency_relationships_completeness(
+    object_set: spdx3.SHACLObjectSet,
+) -> dict[str, list[str]]:
+    """
+    Extract the completeness attribute for all dependency relationships ('contains', 'dependsOn') in the SPDX 3 document.
+    
+    Returns:
+        dict[str, list[str]]: A dictionary mapping all relationship's from_id to a list of all completeness attributes.
+    """
+    completeness_map: dict[str, list[str]] = {}
+
+    for obj in object_set.foreach_type(spdx3.Relationship):
+        rel_type = getattr(obj, "relationshipType", "")
+        if not rel_type:
+            continue
+
+        # Remove the IRI prefix of entry name before compare
+        rel_type_name = str(rel_type).split("/")[-1]
+        if rel_type_name in ("contains", "dependsOn"):
+            from_ = getattr(obj, "from_", None)
+            from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", "")
+
+            if from_id:
+                completeness_iri = getattr(obj, "completeness", None)
+                completeness_val = str(completeness_iri).split("/")[-1] if completeness_iri else "noAssertion"
+                if completeness_val:
+                    completeness_map.setdefault(from_id, []).append(str(completeness_val))
+
+    return completeness_map
+

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -52,7 +52,9 @@ def validate_spdx3_data(
     doc: spdx3.SpdxDocument | None = None
     validation_messages: list[ValidationMessage] = []
 
-    spdx_documents: list[spdx3.SpdxDocument] = list(object_set.foreach_type(spdx3.SpdxDocument))
+    spdx_documents: list[spdx3.SpdxDocument] = list(
+        object_set.foreach_type(spdx3.SpdxDocument)
+    )
 
     # == SPDX 3 JSON serialization constraint =====
 
@@ -219,7 +221,9 @@ def iter_relationships_by_type(
         from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", "")
         to_ids = []
         for to_item in to_elements:
-            to_id = to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
+            to_id = (
+                to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
+            )
             if to_id:
                 to_ids.append(to_id)
 
@@ -229,7 +233,9 @@ def iter_relationships_by_type(
 
 def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Package]:
     """Retrieve all /Software/Package objects from an SHACLObjectSet."""
-    packages: set[spdx3.software_Package] = set(object_set.foreach_type(spdx3.software_Package))
+    packages: set[spdx3.software_Package] = set(
+        object_set.foreach_type(spdx3.software_Package)
+    )
     return packages
 
 
@@ -280,7 +286,7 @@ def get_distribution_artifacts_map(
     Create a mapping of package spdxId to their linked software_File distribution artifacts.
 
     Returns:
-        dict[str, list[spdx3.software_File]]: A dictionary mapping package spdxId to a list of 
+        dict[str, list[spdx3.software_File]]: A dictionary mapping package spdxId to a list of
         linked software_File objects.
     """
     artifact_map: dict[str, list[spdx3.software_File]] = {}
@@ -291,7 +297,9 @@ def get_distribution_artifacts_map(
         if file_id:
             file_map[file_id] = file_obj
 
-    for from_id, to_ids in iter_relationships_by_type(object_set, "hasDistributionArtifact"):
+    for from_id, to_ids in iter_relationships_by_type(
+        object_set, "hasDistributionArtifact"
+    ):
         files = [file_map[to_id] for to_id in to_ids if to_id in file_map]
         if files:
             artifact_map.setdefault(from_id, []).extend(files)
@@ -319,11 +327,11 @@ def get_dependency_relationships_completeness(
     object_set: spdx3.SHACLObjectSet,
 ) -> dict[str, list[str]]:
     """
-    Extract the completeness attribute for all dependency 
+    Extract the completeness attribute for all dependency
     relationships ('contains', 'dependsOn') in the SPDX 3 document.
 
     Returns:
-        dict[str, list[str]]: A dictionary mapping all relationship's 
+        dict[str, list[str]]: A dictionary mapping all relationship's
         from_id to a list of all completeness attributes.
     """
     completeness_map: dict[str, list[str]] = {}
@@ -343,9 +351,12 @@ def get_dependency_relationships_completeness(
                 completeness_iri = getattr(obj, "completeness", None)
                 completeness_val = (
                     str(completeness_iri).rsplit("/", maxsplit=1)[-1]
-                    if completeness_iri else "noAssertion"
+                    if completeness_iri
+                    else "noAssertion"
                 )
                 if completeness_val:
-                    completeness_map.setdefault(from_id, []).append(str(completeness_val))
+                    completeness_map.setdefault(from_id, []).append(
+                        str(completeness_val)
+                    )
 
     return completeness_map

--- a/ntia_conformance_checker/spdx3_utils.py
+++ b/ntia_conformance_checker/spdx3_utils.py
@@ -52,9 +52,7 @@ def validate_spdx3_data(
     doc: spdx3.SpdxDocument | None = None
     validation_messages: list[ValidationMessage] = []
 
-    spdx_documents: list[spdx3.SpdxDocument] = list(
-        object_set.foreach_type(spdx3.SpdxDocument)
-    )
+    spdx_documents: list[spdx3.SpdxDocument] = list(object_set.foreach_type(spdx3.SpdxDocument))
 
     # == SPDX 3 JSON serialization constraint =====
 
@@ -221,9 +219,7 @@ def iter_relationships_by_type(
         from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", "")
         to_ids = []
         for to_item in to_elements:
-            to_id = (
-                to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
-            )
+            to_id = to_item if isinstance(to_item, str) else getattr(to_item, "spdxId", "")
             if to_id:
                 to_ids.append(to_id)
 
@@ -233,9 +229,7 @@ def iter_relationships_by_type(
 
 def get_all_packages(object_set: spdx3.SHACLObjectSet) -> set[spdx3.software_Package]:
     """Retrieve all /Software/Package objects from an SHACLObjectSet."""
-    packages: set[spdx3.software_Package] = set(
-        object_set.foreach_type(spdx3.software_Package)
-    )
+    packages: set[spdx3.software_Package] = set(object_set.foreach_type(spdx3.software_Package))
     return packages
 
 
@@ -284,10 +278,11 @@ def get_distribution_artifacts_map(
 ) -> dict[str, list[spdx3.software_File]]:
     """
     Create a mapping of package spdxId to their linked software_File distribution artifacts.
-    
+
     Returns:
-        dict[str, list[spdx3.software_File]]: A dictionary mapping package spdxId to a list of linked software_File objects.
-    """ 
+        dict[str, list[spdx3.software_File]]: A dictionary mapping package spdxId to a list of 
+        linked software_File objects.
+    """
     artifact_map: dict[str, list[spdx3.software_File]] = {}
 
     file_map: dict[str, spdx3.software_File] = {}
@@ -304,7 +299,7 @@ def get_distribution_artifacts_map(
     return artifact_map
 
 
-def has_sha512_hash(file_obj: spdx3.software_File) -> bool:
+def has_sha512_hash(file_obj: spdx3.SHACLObject) -> bool:
     """
     Check if a software_File has a SHA-512 hash declared in its verifiedUsing property.
     """
@@ -324,10 +319,12 @@ def get_dependency_relationships_completeness(
     object_set: spdx3.SHACLObjectSet,
 ) -> dict[str, list[str]]:
     """
-    Extract the completeness attribute for all dependency relationships ('contains', 'dependsOn') in the SPDX 3 document.
-    
+    Extract the completeness attribute for all dependency 
+    relationships ('contains', 'dependsOn') in the SPDX 3 document.
+
     Returns:
-        dict[str, list[str]]: A dictionary mapping all relationship's from_id to a list of all completeness attributes.
+        dict[str, list[str]]: A dictionary mapping all relationship's 
+        from_id to a list of all completeness attributes.
     """
     completeness_map: dict[str, list[str]] = {}
 
@@ -337,16 +334,18 @@ def get_dependency_relationships_completeness(
             continue
 
         # Remove the IRI prefix of entry name before compare
-        rel_type_name = str(rel_type).split("/")[-1]
+        rel_type_name = str(rel_type).rsplit("/", maxsplit=1)[-1]
         if rel_type_name in ("contains", "dependsOn"):
             from_ = getattr(obj, "from_", None)
             from_id = from_ if isinstance(from_, str) else getattr(from_, "spdxId", "")
 
             if from_id:
                 completeness_iri = getattr(obj, "completeness", None)
-                completeness_val = str(completeness_iri).split("/")[-1] if completeness_iri else "noAssertion"
+                completeness_val = (
+                    str(completeness_iri).rsplit("/", maxsplit=1)[-1]
+                    if completeness_iri else "noAssertion"
+                )
                 if completeness_val:
                     completeness_map.setdefault(from_id, []).append(str(completeness_val))
 
     return completeness_map
-

--- a/tests/data/bsi/compliant_bsi_spdx3.json
+++ b/tests/data/bsi/compliant_bsi_spdx3.json
@@ -19,12 +19,12 @@
       "type": "Person",
       "spdxId": "https://example.com/spdx/person-01",
       "creationInfo": "_:creationinfo",
-      "name": "SBOM Author",
+      "name": "Induwara",
       "externalIdentifier": [
         {
           "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
-          "identifier": "author@example.com"
+          "identifier": "induwaras@example.com"
         }
       ]
     },

--- a/tests/data/bsi/compliant_bsi_spdx3.json
+++ b/tests/data/bsi/compliant_bsi_spdx3.json
@@ -1,0 +1,176 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "BSI Compliant Document",
+      "rootElement": ["https://example.com/spdx/sbom-01"]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "SBOM Author",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "author@example.com"
+        }
+      ]
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "https://example.com/spdx/sbom-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Primary SBOM",
+      "rootElement": ["https://example.com/spdx/package-01"],
+      "externalRef": [
+        {
+          "type": "ExternalRef",
+          "externalRefType": "buildMeta",
+          "locator": "https://example.com/external-sbom.json"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"],
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "packageUrl",
+          "identifier": "pkg:generic/example-component@1.0.0"
+        }
+      ],
+      "externalRef": [
+        {
+          "type": "ExternalRef",
+          "externalRefType": "securityOther",
+          "locator": "https://example.com/.well-known/security.txt"
+        }
+      ]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/file-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component.tar.gz",
+      "software_additionalPurpose": ["executable", "archive", "container"],
+      "externalRef": [
+        {
+          "type": "ExternalRef",
+          "externalRefType": "binaryArtifact",
+          "locator": "https://example.com/downloads/example-component.tar.gz"
+        }
+      ],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha512",
+          "hashValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/source-01",
+      "creationInfo": "_:creationinfo",
+      "software_primaryPurpose": "source",
+      "externalRef": [
+        {
+          "type": "ExternalRef",
+          "externalRefType": "sourceArtifact",
+          "locator": "https://github.com/example/repo"
+        }
+      ],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha512",
+          "hashValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-01",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "Apache-2.0"
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-02",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "MIT"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-01",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDistributionArtifact",
+      "to": ["https://example.com/spdx/file-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-02",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasConcludedLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-03",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDeclaredLicense",
+      "to": ["https://example.com/spdx/license-02"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-04",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/source-01",
+      "relationshipType": "generates",
+      "to": ["https://example.com/spdx/package-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-05",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "other",
+      "comment": "hasEffectiveLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-06",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/sbom-01",
+      "relationshipType": "describes",
+      "to": ["https://example.com/spdx/package-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/data/bsi/missing_bsi_creator.json
+++ b/tests/data/bsi/missing_bsi_creator.json
@@ -1,0 +1,86 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Missing Creator Doc",
+      "rootElement": ["https://example.com/spdx/package-01"],
+      "element": [
+        "https://example.com/spdx/person-01",
+        "https://example.com/spdx/package-01",
+        "https://example.com/spdx/file-01",
+        "https://example.com/spdx/license-01",
+        "https://example.com/spdx/rel-01",
+        "https://example.com/spdx/rel-02"
+      ]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Invalid Creator",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "other",
+          "identifier": "just-a-plain-name-no-email-or-url"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/file-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component.tar.gz",
+      "software_additionalPurpose": ["container"],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha512",
+          "hashValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-01",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "Apache-2.0"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-01",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDistributionArtifact",
+      "to": ["https://example.com/spdx/file-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-02",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasConcludedLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/data/bsi/missing_concluded_license.json
+++ b/tests/data/bsi/missing_concluded_license.json
@@ -25,12 +25,12 @@
       "type": "Person",
       "spdxId": "https://example.com/spdx/person-01",
       "creationInfo": "_:creationinfo",
-      "name": "Author",
+      "name": "Induwara",
       "externalIdentifier": [
         {
           "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
-          "identifier": "author@example.com"
+          "identifier": "induwara@example.com"
         }
       ]
     },

--- a/tests/data/bsi/missing_concluded_license.json
+++ b/tests/data/bsi/missing_concluded_license.json
@@ -1,0 +1,69 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Missing Concluded License Doc",
+      "rootElement": ["https://example.com/spdx/package-01"],
+      "element": [
+        "https://example.com/spdx/person-01",
+        "https://example.com/spdx/package-01",
+        "https://example.com/spdx/file-01",
+        "https://example.com/spdx/rel-01"
+      ]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Author",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "author@example.com"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/file-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component.tar.gz",
+      "software_additionalPurpose": ["container"],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha512",
+          "hashValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-01",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDistributionArtifact",
+      "to": ["https://example.com/spdx/file-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/data/bsi/missing_distribution_filename.json
+++ b/tests/data/bsi/missing_distribution_filename.json
@@ -1,0 +1,61 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Missing Filename Doc",
+      "rootElement": ["https://example.com/spdx/package-01"],
+      "element": [
+        "https://example.com/spdx/person-01",
+        "https://example.com/spdx/package-01",
+        "https://example.com/spdx/license-01",
+        "https://example.com/spdx/rel-02"
+      ]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Author",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "author@example.com"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-01",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "Apache-2.0"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-02",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasConcludedLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/data/bsi/missing_distribution_filename.json
+++ b/tests/data/bsi/missing_distribution_filename.json
@@ -25,12 +25,12 @@
       "type": "Person",
       "spdxId": "https://example.com/spdx/person-01",
       "creationInfo": "_:creationinfo",
-      "name": "Author",
+      "name": "Induwara",
       "externalIdentifier": [
         {
           "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
-          "identifier": "author@example.com"
+          "identifier": "induwara@example.com"
         }
       ]
     },

--- a/tests/data/bsi/missing_optional_warnings.json
+++ b/tests/data/bsi/missing_optional_warnings.json
@@ -1,0 +1,86 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Compliant Minimal Doc",
+      "rootElement": ["https://example.com/spdx/package-01"],
+      "element": [
+        "https://example.com/spdx/person-01",
+        "https://example.com/spdx/package-01",
+        "https://example.com/spdx/file-01",
+        "https://example.com/spdx/license-01",
+        "https://example.com/spdx/rel-01",
+        "https://example.com/spdx/rel-02"
+      ]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Author",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "author@example.com"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/file-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component.tar.gz",
+      "software_additionalPurpose": ["container"],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha512",
+          "hashValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-01",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "Apache-2.0"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-01",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDistributionArtifact",
+      "to": ["https://example.com/spdx/file-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-02",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasConcludedLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/data/bsi/missing_optional_warnings.json
+++ b/tests/data/bsi/missing_optional_warnings.json
@@ -27,12 +27,12 @@
       "type": "Person",
       "spdxId": "https://example.com/spdx/person-01",
       "creationInfo": "_:creationinfo",
-      "name": "Author",
+      "name": "Induwara",
       "externalIdentifier": [
         {
           "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
-          "identifier": "author@example.com"
+          "identifier": "induwara@example.com"
         }
       ]
     },

--- a/tests/data/bsi/missing_sbom_uri.json
+++ b/tests/data/bsi/missing_sbom_uri.json
@@ -27,12 +27,12 @@
       "type": "Person",
       "spdxId": "https://example.com/spdx/person-01",
       "creationInfo": "_:creationinfo",
-      "name": "Author",
+      "name": "Induwara",
       "externalIdentifier": [
         {
           "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
-          "identifier": "author@example.com"
+          "identifier": "induwara@example.com"
         }
       ]
     },

--- a/tests/data/bsi/missing_sbom_uri.json
+++ b/tests/data/bsi/missing_sbom_uri.json
@@ -1,0 +1,86 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Missing SBOM URI Doc",
+      "rootElement": [],
+      "element": [
+        "https://example.com/spdx/person-01",
+        "https://example.com/spdx/package-01",
+        "https://example.com/spdx/file-01",
+        "https://example.com/spdx/license-01",
+        "https://example.com/spdx/rel-01",
+        "https://example.com/spdx/rel-02"
+      ]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Author",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "author@example.com"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/file-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component.tar.gz",
+      "software_additionalPurpose": ["container"],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha512",
+          "hashValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-01",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "Apache-2.0"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-01",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDistributionArtifact",
+      "to": ["https://example.com/spdx/file-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-02",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasConcludedLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/data/bsi/missing_sha512_hash.json
+++ b/tests/data/bsi/missing_sha512_hash.json
@@ -1,0 +1,86 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Missing SHA512 Doc",
+      "rootElement": ["https://example.com/spdx/package-01"],
+      "element": [
+        "https://example.com/spdx/person-01",
+        "https://example.com/spdx/package-01",
+        "https://example.com/spdx/file-01",
+        "https://example.com/spdx/license-01",
+        "https://example.com/spdx/rel-01",
+        "https://example.com/spdx/rel-02"
+      ]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Author",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "author@example.com"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/file-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component.tar.gz",
+      "software_additionalPurpose": ["container"],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-01",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "Apache-2.0"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-01",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDistributionArtifact",
+      "to": ["https://example.com/spdx/file-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-02",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasConcludedLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/data/bsi/missing_sha512_hash.json
+++ b/tests/data/bsi/missing_sha512_hash.json
@@ -27,12 +27,12 @@
       "type": "Person",
       "spdxId": "https://example.com/spdx/person-01",
       "creationInfo": "_:creationinfo",
-      "name": "Author",
+      "name": "Induwara",
       "externalIdentifier": [
         {
           "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
-          "identifier": "author@example.com"
+          "identifier": "induwara@example.com"
         }
       ]
     },

--- a/tests/data/bsi/missing_structured_property.json
+++ b/tests/data/bsi/missing_structured_property.json
@@ -27,12 +27,12 @@
       "type": "Person",
       "spdxId": "https://example.com/spdx/person-01",
       "creationInfo": "_:creationinfo",
-      "name": "Author",
+      "name": "Induwara",
       "externalIdentifier": [
         {
           "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
-          "identifier": "author@example.com"
+          "identifier": "induwara@example.com"
         }
       ]
     },

--- a/tests/data/bsi/missing_structured_property.json
+++ b/tests/data/bsi/missing_structured_property.json
@@ -1,0 +1,86 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "CreationInfo",
+      "@id": "_:creationinfo",
+      "specVersion": "3.0.1",
+      "createdBy": ["https://example.com/spdx/person-01"],
+      "created": "2026-08-16T04:00:00Z"
+    },
+    {
+      "type": "SpdxDocument",
+      "spdxId": "https://example.com/spdx/doc-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Missing Structured Prop Doc",
+      "rootElement": ["https://example.com/spdx/package-01"],
+      "element": [
+        "https://example.com/spdx/person-01",
+        "https://example.com/spdx/package-01",
+        "https://example.com/spdx/file-01",
+        "https://example.com/spdx/license-01",
+        "https://example.com/spdx/rel-01",
+        "https://example.com/spdx/rel-02"
+      ]
+    },
+    {
+      "type": "Person",
+      "spdxId": "https://example.com/spdx/person-01",
+      "creationInfo": "_:creationinfo",
+      "name": "Author",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "author@example.com"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "https://example.com/spdx/package-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component",
+      "software_packageVersion": "1.0.0",
+      "originatedBy": ["https://example.com/spdx/person-01"]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "https://example.com/spdx/file-01",
+      "creationInfo": "_:creationinfo",
+      "name": "example-component.tar.gz",
+      "software_additionalPurpose": ["executable"],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha512",
+          "hashValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "https://example.com/spdx/license-01",
+      "creationInfo": "_:creationinfo",
+      "simplelicensing_licenseExpression": "Apache-2.0"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-01",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasDistributionArtifact",
+      "to": ["https://example.com/spdx/file-01"],
+      "completeness": "complete"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "https://example.com/spdx/rel-02",
+      "creationInfo": "_:creationinfo",
+      "from": "https://example.com/spdx/package-01",
+      "relationshipType": "hasConcludedLicense",
+      "to": ["https://example.com/spdx/license-01"],
+      "completeness": "complete"
+    }
+  ]
+}

--- a/tests/test_bsi_checker.py
+++ b/tests/test_bsi_checker.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2026 SPDX contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the BSI TR-03183-2 conformance checker."""
+
+import os
+from unittest import TestCase
+
+import pytest
+
+from ntia_conformance_checker import BSIChecker
+
+
+def _component_names(tuples_list: list[tuple[str, str]]) -> list[str]:
+    """
+    Extract first element from list of tuples,
+    or second if first is None or empty.
+    """
+    return [t[0] if t and t[0] not in (None, "") else (t[1] if t else "") for t in tuples_list]
+
+
+BSI_DATA_DIR = os.path.join(os.path.dirname(__file__), "data", "bsi")
+
+
+def test_bsichecker_compliant_spdx3() -> None:
+    """
+    Test that a perfectly formatted BSI SPDX 3 document passes compliance and 
+    triggers no warnings.
+    """
+    test_file = os.path.join(BSI_DATA_DIR, "compliant_bsi_spdx3.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    # Overall Compliance
+    assert sbom.compliant
+
+    # Document Level (Required)
+    assert sbom.doc_creator
+    assert sbom.doc_timestamp
+    assert sbom.doc_uri
+    assert sbom.dependency_completeness
+
+    # Component Level (Required) - should be empty lists
+    assert not sbom.components_without_names
+    assert not sbom.components_without_versions
+    assert not sbom.components_without_creators
+    assert not sbom.components_without_filenames
+    assert not sbom.components_without_concluded_licenses
+    assert not sbom.components_without_sha512_hashes
+    assert not sbom.components_without_executable_prop
+    assert not sbom.components_without_archive_prop
+    assert not sbom.components_without_structured_prop
+
+    # Additional/Optional Level (Warnings)
+    assert not sbom.components_without_source_code_uris
+    assert not sbom.components_without_deployable_uris
+    assert not sbom.components_without_unique_identifiers
+    assert not sbom.components_without_original_licenses
+    assert not sbom.components_without_effective_licenses
+    assert not sbom.components_without_source_code_hashes
+    assert not sbom.components_without_security_txt
+    assert not sbom.components_without_bom_references
+
+
+def test_bsichecker_missing_creator() -> None:
+    """Test that missing a valid BSI Creator (email/URL) fails compliance."""
+    test_file = os.path.join(BSI_DATA_DIR, "missing_bsi_creator.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    assert not sbom.compliant
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_creators), ["example-component"]
+    )
+
+
+def test_bsichecker_missing_sha512_hash() -> None:
+    """Test that a component using SHA-256 instead of SHA-512 fails compliance."""
+    test_file = os.path.join(BSI_DATA_DIR, "missing_sha512_hash.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    assert not sbom.compliant
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_sha512_hashes), ["example-component"]
+    )
+
+
+def test_bsichecker_missing_structured_property() -> None:
+    """Test that a component missing both 'container' and 'firmware' fails compliance."""
+    test_file = os.path.join(BSI_DATA_DIR, "missing_structured_property.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    assert not sbom.compliant
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_structured_prop), ["example-component"]
+    )
+
+
+def test_bsichecker_missing_distribution_filename() -> None:
+    """Test that a component missing a distribution filename fails compliance."""
+    test_file = os.path.join(BSI_DATA_DIR, "missing_distribution_filename.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    assert not sbom.compliant
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_filenames), ["example-component"]
+    )
+
+
+def test_bsichecker_missing_concluded_license() -> None:
+    """Test that a component missing a concluded license expression fails compliance."""
+    test_file = os.path.join(BSI_DATA_DIR, "missing_concluded_license.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    assert not sbom.compliant
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_concluded_licenses),
+        ["example-component"],
+    )
+
+
+def test_bsichecker_missing_sbom_uri() -> None:
+    """Test that a document without a valid SBOM URI fails compliance."""
+    test_file = os.path.join(BSI_DATA_DIR, "missing_sbom_uri.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    assert not sbom.doc_uri
+    assert not sbom.compliant
+
+
+def test_bsichecker_missing_optional_warnings() -> None:
+    """
+    Test that missing Additional/Optional fields correctly populates warning lists
+    but DOES NOT fail the overall compliance of the document.
+    """
+    test_file = os.path.join(BSI_DATA_DIR, "missing_optional_warnings.json")
+    if not os.path.exists(test_file):
+        pytest.skip(f"Test file {test_file} not found.")
+
+    sbom = BSIChecker(test_file, compliance="bsi", sbom_spec="spdx3")
+
+    # The document MUST still be compliant
+    assert sbom.compliant
+
+    # However, all warning lists should have exactly 1 missing package
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_source_code_uris),
+        ["example-component"],
+    )
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_deployable_uris), ["example-component"]
+    )
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_unique_identifiers),
+        ["example-component"],
+    )
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_original_licenses),
+        ["example-component"],
+    )
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_effective_licenses),
+        ["example-component"],
+    )
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_source_code_hashes),
+        ["example-component"],
+    )
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_security_txt), ["example-component"]
+    )
+    TestCase().assertCountEqual(
+        _component_names(sbom.components_without_bom_references), ["example-component"]
+    )

--- a/tests/test_bsi_checker.py
+++ b/tests/test_bsi_checker.py
@@ -17,7 +17,10 @@ def _component_names(tuples_list: list[tuple[str, str]]) -> list[str]:
     Extract first element from list of tuples,
     or second if first is None or empty.
     """
-    return [t[0] if t and t[0] not in (None, "") else (t[1] if t else "") for t in tuples_list]
+    return [
+        t[0] if t and t[0] not in (None, "") else (t[1] if t else "")
+        for t in tuples_list
+    ]
 
 
 BSI_DATA_DIR = os.path.join(os.path.dirname(__file__), "data", "bsi")
@@ -25,7 +28,7 @@ BSI_DATA_DIR = os.path.join(os.path.dirname(__file__), "data", "bsi")
 
 def test_bsichecker_compliant_spdx3() -> None:
     """
-    Test that a perfectly formatted BSI SPDX 3 document passes compliance and 
+    Test that a perfectly formatted BSI SPDX 3 document passes compliance and
     triggers no warnings.
     """
     test_file = os.path.join(BSI_DATA_DIR, "compliant_bsi_spdx3.json")


### PR DESCRIPTION
This PR implements the BSI Minimum Elements check ([TR-03183-2 v2.1.0](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2_v2_1_0.html)) for SPDX 3 SBOMs.

It adds the new **BSIChecker** class, extends helper utilities, and adds comprehensive test coverage without duplicating existing validation logic.

### Summary of Changes

- spdx3_utils.py:

    - Added `get_distribution_artifacts_map` to map packages to linked distribution files.
    - Added `has_sha512_hash` to verify SHA-512 hashes in verifiedUsing.
    - Added `get_dependency_relationships_completeness` to read relationship completeness attributes.  
    
    All thses are helper functions for implement the BSI checker.

- bsi_checker.py:

    - Inherited from `BaseChecker` and reused shared element checks (`name`, `version`, `timestamp`, `dependency_completeness`).
    - Implemented BSI-specific **mandatory checks** (Email/URL creator validation, distribution files, SHA-512 hashes, container/firmware structured properties, and strict concluded license expressions).    
    - Implemented warning checks for **optional/additional fields** (source code URIs, deployable URIs, external identifiers, original licenses, effective licenses, security.txt, and BOM references) without causing false compliance failures.

- `__init__.py`, `sbom_checker.py` and `constats.py`:
    - Register the BSI standard in `SUPPORTED_COMPLIANCE_STANDARDS_DESC`.
    - Include `BSIChecker` at the package root alongside with other checkers.
    - Support the `compliance` argument(compliance="bsi") to instantiate this new checker in factory method.

- Tests:

    - Created `test_bsi_checker.py` covering positive, negative, and warning cases.
    - Added some SPDX 3 JSON testing files inside `tests/data/bsi/`.
    
 *Note* : The data mapping can be found in this shared [Google doc](https://docs.google.com/document/d/1faoLriEnLy5wlubmho-TZGrtlgPBHOWm1H20P8moKxk/edit?usp=sharing).